### PR TITLE
added in PyYAML in requirements, and fixed arcycomb to compile on OSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The Python Spectroscopic Data Reduction Pipeline
 * astropy
 * matplotlib
 * GNU Scientific Library
+* PyYAML
 
 # License
 This program is free software: you can redistribute it and/or modify

--- a/src/arcycomb_setup.py
+++ b/src/arcycomb_setup.py
@@ -5,6 +5,6 @@ import numpy
 
 setup(
     cmdclass = {'build_ext': build_ext},
-    ext_modules = [Extension("arcycomb", ["arcycomb.pyx"], )],
-    include_dirs = [numpy.get_include(),],
+    ext_modules = [Extension("arcycomb", ["arcycomb.pyx"],
+                             include_dirs=[numpy.get_include()])]
 )


### PR DESCRIPTION
Just some issues I noticed while installing.  I needed to install PyYAML, so I added that to the README.  There was an issue with compiling the arcycomb setup routine on OSX Yosemite (10.10.5).  I think it's related to the problem here:
https://github.com/hmmlearn/hmmlearn/issues/43
All the other setup scripts seemed okay, as they were passing include_dirs through Extension rather than through 'setup' directly.
