### PR TITLE
Removed develop option

### DIFF
--- a/pypeit/armed.py
+++ b/pypeit/armed.py
@@ -119,7 +119,7 @@ def ARMED(fitsdict, reuseMaster=False, reloadMaster=True):
             ###############
             # Determine the edges of the spectrum (spatial)
             if ('trace'+settings.argflag['reduce']['masters']['setup'] not in settings.argflag['reduce']['masters']['loaded']):
-                if True:#not msgs._debug['develop']:
+                if True:
                     msgs.info("Tracing slit edges with a {0:s} frame".format(settings.argflag['trace']['useframe']))
                     if settings.argflag['trace']['useframe'] == 'pinhole':
                         ###############

--- a/pypeit/artrace.py
+++ b/pypeit/artrace.py
@@ -196,7 +196,7 @@ def trace_objects_in_slits(slf, det, sciframe, varframe, crmask, doqa=False, **k
         tracelist += tlist
 
     # QA?
-    if doqa: # and (not msgs._debug['no_qa']):
+    if doqa:
         obj_trace_qa(slf, sciframe, det, tracelist, root="object_trace", normalize=False)
 
     # Return
@@ -465,13 +465,12 @@ def trace_objects_in_slit(det, slitn, tslits_dict, sciframe, skyframe, varframe,
                                                 [objl, objr], [bckl, bckr],
                                                 triml=triml, trimr=trimr)
     # Check object traces in ginga
-    '''
-    if msgs._debug['trace_obj']:
+    if debug:
         viewer, ch = ginga.show_image(skysub)
         for ii in range(nobj):
             ginga.show_trace(viewer, ch, traces[:, ii], '{:d}'.format(ii), clear=(ii == 0))
         debugger.set_trace()
-    '''
+
     # Trace dict
     tracelist = trace_object_dict(nobj, traces, object=rec_obj_img, background=rec_bg_img,
                                   params=tracepar)

--- a/pypeit/core/arc.py
+++ b/pypeit/core/arc.py
@@ -458,7 +458,7 @@ def simple_calib(msarc, aparm, censpec, nfitpix=5, get_poly=False,
     ions = all_idsion[ifit][mask==0]
     #
     '''
-    if False:
+    if debug:
         wave = utils.func_val(fit, np.arange(msarc.shape[0])/float(msarc.shape[0]),
             'legendre', minv=fmin, maxv=fmax)
         debugger.set_trace()

--- a/pypeit/core/arc.py
+++ b/pypeit/core/arc.py
@@ -274,7 +274,7 @@ def fit_arcspec(xarray, yarray, pixt, fitp):
 
 
 def simple_calib(msarc, aparm, censpec, nfitpix=5, get_poly=False,
-                 IDpixels=None, IDwaves=None):
+                 IDpixels=None, IDwaves=None, debug=False):
     """Simple calibration algorithm for longslit wavelengths
 
     Uses slf._arcparam to guide the analysis
@@ -388,7 +388,7 @@ def simple_calib(msarc, aparm, censpec, nfitpix=5, get_poly=False,
         gd_str = np.where( np.abs(disp_str-aparm['disp'])/aparm['disp'] < aparm['disp_toler'])[0]
         msgs.info('Found {:d} lines within the dispersion threshold'.format(len(gd_str)))
         if len(gd_str) < 5:
-            if msgs._debug['arc']:
+            if debug:
                 msgs.warn('You should probably try your best to ID lines now.')
                 debugger.set_trace()
                 debugger.plot1d(yprep)
@@ -423,7 +423,7 @@ def simple_calib(msarc, aparm, censpec, nfitpix=5, get_poly=False,
             mn = np.min(np.abs(iwave-llist['wave']))
             if mn/aparm['disp'] < aparm['match_toler']:
                 imn = np.argmin(np.abs(iwave-llist['wave']))
-                #if msgs._debug['arc']:
+                #if debug:
                 #    print('Adding {:g} at {:g}'.format(llist['wave'][imn],tcent[ss]))
                 # Update and append
                 all_ids[ss] = llist['wave'][imn]
@@ -431,7 +431,7 @@ def simple_calib(msarc, aparm, censpec, nfitpix=5, get_poly=False,
                 ifit.append(ss)
         # Keep unique ones
         ifit = np.unique(np.array(ifit,dtype=int))
-        #if msgs._debug['arc']:
+        #if debug:
         #    debugger.set_trace()
         # Increment order
         if n_order < aparm['n_final']:
@@ -443,7 +443,7 @@ def simple_calib(msarc, aparm, censpec, nfitpix=5, get_poly=False,
     # Final fit (originals can now be rejected)
     fmin, fmax = 0., 1.
     xfit, yfit = tcent[ifit]/(msarc.shape[0]-1), all_ids[ifit]
-    mask, fit = utils.robust_polyfit(xfit, yfit, n_order, function=aparm['func'], sigma=aparm['nsig_rej_final'], minv=fmin, maxv=fmax)#, debug=True)
+    mask, fit = utils.robust_polyfit(xfit, yfit, n_order, function=aparm['func'], sigma=aparm['nsig_rej_final'], minv=fmin, maxv=fmax)
     irej = np.where(mask==1)[0]
     if len(irej) > 0:
         xrej = xfit[irej]
@@ -458,7 +458,7 @@ def simple_calib(msarc, aparm, censpec, nfitpix=5, get_poly=False,
     ions = all_idsion[ifit][mask==0]
     #
     '''
-    if msgs._debug['arc']:
+    if False:
         wave = utils.func_val(fit, np.arange(msarc.shape[0])/float(msarc.shape[0]),
             'legendre', minv=fmin, maxv=fmax)
         debugger.set_trace()

--- a/pypeit/core/coadd.py
+++ b/pypeit/core/coadd.py
@@ -445,7 +445,7 @@ def scale_spectra(spectra, smask, sn2, iref=0, scale_method='auto', hand_scale=N
     return scales, omethod
 
 
-def bspline_cr(spectra, n_grow_mask=1, cr_nsig=5.):
+def bspline_cr(spectra, n_grow_mask=1, cr_nsig=5., debug=False):
     """ Experimental and not so successful..
 
     Parameters
@@ -477,7 +477,6 @@ def bspline_cr(spectra, n_grow_mask=1, cr_nsig=5.):
                                         function='bspline', sigma=cr_nsig, everyn=2*spectra.nspec,
                                         weights=1./np.sqrt(all_s[srt][goodp]), maxone=False)
     # Plot?
-    debug = True
     if debug:
         from matplotlib import pyplot as plt
         plt.clf()

--- a/pypeit/core/extract.py
+++ b/pypeit/core/extract.py
@@ -1814,7 +1814,7 @@ def obj_profiles(det, specobjs, sciframe, varframe, crmask,
                 fdict['flux_val'] = flux_val
                 scitrace[sl]['opt_profile'].append(copy.deepcopy(fdict))
                 specobjs[sl][o].optimal['fwhm'] = fdict['param'][1]  # Pixels
-                if False: #msgs._debug['obj_profile']:
+                if False:
                     gdp = mask == 0
                     mn = np.min(slit_val[gdp])
                     mx = np.max(slit_val[gdp])
@@ -1841,7 +1841,7 @@ def obj_profiles(det, specobjs, sciframe, varframe, crmask,
                 scitrace[sl]['opt_profile'].append({})
                 continue
     # QA
-    if doqa: #not msgs._debug['no_qa'] and doqa:
+    if doqa:
         msgs.info("Preparing QA for spatial object profiles")
 #        qa.obj_profile_qa(slf, specobjs, scitrace, det)
         debugger.set_trace()  # Need to avoid slf
@@ -2014,11 +2014,6 @@ def optimal_extract(specobjs, sciframe, varframe,
             # Update object model
             counts_image = np.outer(opt_flux, np.ones(prof_img.shape[1]))
             obj_model += prof_img * counts_image
-            '''
-            if 'OPTIMAL' in msgs._debug:
-                debugger.set_trace()
-                debugger.xplot(opt_wave, opt_flux, np.sqrt(opt_var))
-            '''
 
     # KBW: Using variance_frame here produces a circular import.  I've
     # changed this function to return the object model, then this last

--- a/pypeit/core/flat.py
+++ b/pypeit/core/flat.py
@@ -333,7 +333,7 @@ def norm_slits(mstrace, datasec_img, lordloc, rordloc, pixwid,
 
 
 def slit_profile_pca(mstrace, tilts, msblaze, extrap_slit, slit_profiles,
-                     lordloc, rordloc, pixwid, slitpix, setup):
+                     lordloc, rordloc, pixwid, slitpix, setup, debug=False):
     """ Perform a PCA analysis on the spatial slit profile and blaze function.
 
     Parameters
@@ -461,7 +461,7 @@ def slit_profile_pca(mstrace, tilts, msblaze, extrap_slit, slit_profiles,
         xcen = xv[:, np.newaxis].repeat(nslits, axis=1)
         fitted, outpar = pca.basis(xcen, blzval, fitcoeff, lnpc, ofit, x0in=ordsnd, mask=maskord, skipx0=False,
                                      function=fitfunc)
-        if not msgs._debug['no_qa']:
+        if not debug:
 #            arqa.pca_plot(slf, outpar, ofit, "Blaze_Profile", pcadesc="PCA of blaze function fits")
             pca.pca_plot(slf.setup, outpar, ofit, "Blaze_Profile",
                            pcadesc="PCA of blaze function fits")
@@ -532,7 +532,7 @@ def slit_profile_pca(mstrace, tilts, msblaze, extrap_slit, slit_profiles,
         xcen = spatfit[:, np.newaxis].repeat(nslits, axis=1)
         fitted, outpar = pca.basis(xcen, sltval, fitcoeff, lnpc, sofit, x0in=ordsnd, mask=maskord, skipx0=False,
                                      function=fitfunc)
-        if not msgs._debug['no_qa']:
+        if not debug:
 #            arqa.pca_plot(slf, outpar, sofit, "Slit_Profile", pcadesc="PCA of slit profile fits")
             pca.pca_plot(setup, outpar, sofit, "Slit_Profile", pcadesc="PCA of slit profile fits")
         # Extrapolate the remaining orders requested

--- a/pypeit/core/skysub.py
+++ b/pypeit/core/skysub.py
@@ -653,7 +653,7 @@ def orig_bg_subtraction_slit(tslits_dict, pixlocn,
                         settings,
                         tracemask=None,
                         rejsigma=3.0, maskval=-999999.9,
-                        method='bspline'):
+                        method='bspline', debug=False):
     """ Extract a science target and background flux
     :param slf:
     :param sciframe:
@@ -778,7 +778,7 @@ def orig_bg_subtraction_slit(tslits_dict, pixlocn,
         bgf_flat = utils.func_val(bspl, tilts[in_slit].flatten(), 'bspline')
         #bgframe = bgf_flat.reshape(tilts.shape)
         bgframe[in_slit] = bgf_flat
-        if msgs._debug['sky_sub']:
+        if debug:
             plt_bspline_sky(tilts, scifrcp, bgf_flat, in_slit, gdp)
             debugger.set_trace()
     else:

--- a/pypeit/core/trace_slits.py
+++ b/pypeit/core/trace_slits.py
@@ -224,7 +224,7 @@ def assign_slits(binarr, edgearr, ednum=100000, lor=-1, function='legendre', pol
                 break
             if wpk.size != 1:
                 try:
-                    wpkmsk = prune_peaks(smedgehist, wpk, np.where(wpk+2 == offs)[0][0])#, debug=debug)
+                    wpkmsk = prune_peaks(smedgehist, wpk, np.where(wpk+2 == offs)[0][0])
                 except:
                     debugger.set_trace()
                 wpk = wpk[np.where(wpkmsk == 1)]
@@ -237,12 +237,7 @@ def assign_slits(binarr, edgearr, ednum=100000, lor=-1, function='legendre', pol
             if np.all(pedges[:, 1]-pedges[:, 0] == 0):
                 # Remaining peaks have no width
                 break
-#            if msgs._debug['trace']:
-#                plt.clf()
-#                plt.plot(arrcen, 'k-', drawstyle='steps')
-#                plt.plot(wpk, np.zeros(wpk.size), 'ro')
-#                plt.show()
-#                debugger.set_trace()
+
             # Label all edge ids (in the original edgearr) that are located in each peak with the same number
             for ii in range(pks.size):
                 shbad = np.zeros(edgearr.shape)
@@ -275,7 +270,7 @@ def assign_slits(binarr, edgearr, ednum=100000, lor=-1, function='legendre', pol
                 # Find the peaks of this distribution
                 wspk = np.where((smallhist[1:-1] >= smallhist[2:]) & (smallhist[1:-1] > smallhist[:-2]))[0]
                 wspk += 1  # Add one here to account for peak finding
-#                if msgs._debug['trace'] and False:
+#                if False:
 #                    plt.clf()
 #                    plt.plot(smallhist, 'k-', drawstyle='steps')
 #                    plt.show()
@@ -1979,7 +1974,7 @@ def pca_order_slit_edges(binarr, edgearr, lcent, rcent, gord, lcoeff, rcoeff, pl
     xcen = xv[:, np.newaxis].repeat(ordsnd.size, axis=1)
     fitted, outpar = pca.basis(xcen, slitcen, coeffs, lnpc, ofit, x0in=ordsnd, mask=maskord,
                                  skipx0=False, function=function)
-#    if not msgs._debug['no_qa']:
+#    if False:
 #        debugger.set_trace()  # NEED TO REMOVE slf
 #        # pca.pca_plot(slf, outpar, ofit, "Slit_Trace", pcadesc=pcadesc)
 
@@ -2093,7 +2088,7 @@ def pca_pixel_slit_edges(binarr, edgearr, lcoeff, rcoeff, ldiffarr, rdiffarr,
         xcen = xv[:, np.newaxis].repeat(binarr.shape[1], axis=1)
         fitted, outpar = pca.basis(xcen, trcval, tcoeff, lnpc, ofit, weights=pxwght,
                                      x0in=ordsnd, mask=maskrw, skipx0=False, function=function)
-#        if not msgs._debug['no_qa']:
+#        if False:
 #            # JXP -- NEED TO REMOVE SLF FROM THE NEXT BIT
 #            msgs.warn("NEED TO REMOVE SLF FROM THE NEXT BIT")
 #            # pca.pca_plot(slf, outpar, ofit, "Slit_Trace", pcadesc=pcadesc, addOne=False)
@@ -2413,8 +2408,6 @@ def synchronize_edges(binarr, edgearr, plxbin, lmin, lmax, lcoeff, rmin, rcoeff,
     else: # There's an order overlap
         rsub = edgbtwn[1]-(lval)
     """
-#    if msgs._debug['trace']:
-#        debugger.set_trace()
     if mnvalp > mnvalm:
         lvp = (utils.func_val(lcoeff[:, lval + 1 - lmin], xv, function, minv=minvf, maxv=maxvf) \
                + 0.5).astype(np.int)

--- a/pypeit/core/trace_slits.py
+++ b/pypeit/core/trace_slits.py
@@ -1911,7 +1911,7 @@ def find_peak_limits(hist, pks):
 
 def pca_order_slit_edges(binarr, edgearr, lcent, rcent, gord, lcoeff, rcoeff, plxbin, slitcen,
                          pixlocn, function='lengendre', polyorder=3, diffpolyorder=2,
-                         ofit=[3,2,1,0,0,0], extrapolate=[0,0]):
+                         ofit=[3,2,1,0,0,0], extrapolate=[0,0], doqa=True):
     """ Perform a PCA analyis on the order edges
     Primarily for extrapolation
 
@@ -1974,7 +1974,7 @@ def pca_order_slit_edges(binarr, edgearr, lcent, rcent, gord, lcoeff, rcoeff, pl
     xcen = xv[:, np.newaxis].repeat(ordsnd.size, axis=1)
     fitted, outpar = pca.basis(xcen, slitcen, coeffs, lnpc, ofit, x0in=ordsnd, mask=maskord,
                                  skipx0=False, function=function)
-#    if False:
+#    if doqa:
 #        debugger.set_trace()  # NEED TO REMOVE slf
 #        # pca.pca_plot(slf, outpar, ofit, "Slit_Trace", pcadesc=pcadesc)
 
@@ -2011,7 +2011,7 @@ def pca_order_slit_edges(binarr, edgearr, lcent, rcent, gord, lcoeff, rcoeff, pl
 
 def pca_pixel_slit_edges(binarr, edgearr, lcoeff, rcoeff, ldiffarr, rdiffarr,
                          lnmbrarr, rnmbrarr, lwghtarr, rwghtarr, lcent, rcent, plxbin,
-                         function='lengendre', polyorder=3, ofit=[3,2,1,0,0,0]):
+                         function='lengendre', polyorder=3, ofit=[3,2,1,0,0,0], doqa=True):
     """ PCA analysis for slit edges
 
     Parameters
@@ -2088,7 +2088,7 @@ def pca_pixel_slit_edges(binarr, edgearr, lcoeff, rcoeff, ldiffarr, rdiffarr,
         xcen = xv[:, np.newaxis].repeat(binarr.shape[1], axis=1)
         fitted, outpar = pca.basis(xcen, trcval, tcoeff, lnpc, ofit, weights=pxwght,
                                      x0in=ordsnd, mask=maskrw, skipx0=False, function=function)
-#        if False:
+#        if doqa:
 #            # JXP -- NEED TO REMOVE SLF FROM THE NEXT BIT
 #            msgs.warn("NEED TO REMOVE SLF FROM THE NEXT BIT")
 #            # pca.pca_plot(slf, outpar, ofit, "Slit_Trace", pcadesc=pcadesc, addOne=False)

--- a/pypeit/core/tracewave.py
+++ b/pypeit/core/tracewave.py
@@ -624,7 +624,7 @@ def echelle_tilt(slf, msarc, det, settings_argflag, settings_spect, pcadesc="PCA
         xcen = xv[:, np.newaxis].repeat(norders, axis=1)
         fitted, outpar = pca.basis(xcen, tiltval, tcoeff, lnpc, ofit, x0in=ordsnd, mask=maskord, skipx0=False,
                                      function=settings_argflag['trace']['slits']['function'])
-        if not msgs._debug['no_qa']:
+        if False:
             #pcadesc = "Spectral Tilt PCA"
 #            qa.pca_plot(slf, outpar, ofit, 'Arc', pcadesc=pcadesc, addOne=False)
             pca.pca_plot(slf, outpar, ofit, 'Arc', pcadesc=pcadesc, addOne=False)
@@ -723,7 +723,7 @@ def multislit_tilt(msarc, lordloc, rordloc, pixlocn, pixcen, slitpix, det,
         if trcdict is None:
             # No arc lines were available to determine the spectral tilt
             continue
-        if msgs._debug['tilts']:
+        if False:
             debugger.chk_arc_tilts(msarc, trcdict, sedges=(lordloc[:,slit], rordloc[:,slit]))
             debugger.set_trace()
 
@@ -925,7 +925,7 @@ def tilts_spline(all_tilts, arcdet, aduse, polytilts, msarc, use_mtilt=False, ma
     #tmp3 = tiltspl(xsbs, zsbs, grid=True)
     print(tmp, tmp2)
     '''
-    if msgs._debug['tilts']:
+    if False:
         tiltqa = tiltspl(xsbs, zsbs, grid=False)
         plt.clf()
         # plt.imshow((zsbs-tiltqa)/zsbs, origin='lower')

--- a/pypeit/core/tracewave.py
+++ b/pypeit/core/tracewave.py
@@ -519,7 +519,8 @@ def trace_fweight_deprecated(fimage, xinit, ltrace=None, rtraceinvvar=None, radi
     return xnew, xerr
 
 
-def echelle_tilt(slf, msarc, det, settings_argflag, settings_spect, pcadesc="PCA trace of the spectral tilts", maskval=-999999.9):
+def echelle_tilt(slf, msarc, det, settings_argflag, settings_spect,
+                 pcadesc="PCA trace of the spectral tilts", maskval=-999999.9, doqa=True):
     """ Determine the spectral tilts in each echelle order
 
     Parameters
@@ -624,7 +625,7 @@ def echelle_tilt(slf, msarc, det, settings_argflag, settings_spect, pcadesc="PCA
         xcen = xv[:, np.newaxis].repeat(norders, axis=1)
         fitted, outpar = pca.basis(xcen, tiltval, tcoeff, lnpc, ofit, x0in=ordsnd, mask=maskord, skipx0=False,
                                      function=settings_argflag['trace']['slits']['function'])
-        if False:
+        if doqa:
             #pcadesc = "Spectral Tilt PCA"
 #            qa.pca_plot(slf, outpar, ofit, 'Arc', pcadesc=pcadesc, addOne=False)
             pca.pca_plot(slf, outpar, ofit, 'Arc', pcadesc=pcadesc, addOne=False)
@@ -723,7 +724,7 @@ def multislit_tilt(msarc, lordloc, rordloc, pixlocn, pixcen, slitpix, det,
         if trcdict is None:
             # No arc lines were available to determine the spectral tilt
             continue
-        if False:
+        if doqa:
             debugger.chk_arc_tilts(msarc, trcdict, sedges=(lordloc[:,slit], rordloc[:,slit]))
             debugger.set_trace()
 
@@ -886,7 +887,7 @@ def tilts_interp(ordcen, slit, all_tilts, polytilts, arcdet, aduse, msarc):
     return tilts
 
 
-def tilts_spline(all_tilts, arcdet, aduse, polytilts, msarc, use_mtilt=False, maskval=-999999.9):
+def tilts_spline(all_tilts, arcdet, aduse, polytilts, msarc, use_mtilt=False, maskval=-999999.9, doqa=False):
     msgs.info("Performing a spline fit to the tilts")
     # Unpack
     xtilt, ytilt, ztilt, mtilt, wtilt = all_tilts
@@ -925,7 +926,7 @@ def tilts_spline(all_tilts, arcdet, aduse, polytilts, msarc, use_mtilt=False, ma
     #tmp3 = tiltspl(xsbs, zsbs, grid=True)
     print(tmp, tmp2)
     '''
-    if False:
+    if doqa:
         tiltqa = tiltspl(xsbs, zsbs, grid=False)
         plt.clf()
         # plt.imshow((zsbs-tiltqa)/zsbs, origin='lower')

--- a/pypeit/core/wave.py
+++ b/pypeit/core/wave.py
@@ -172,11 +172,6 @@ def flex_shift(obj_skyspec, arx_skyspec, mxshft=None):
     msgs.info("Flexure correction of {:g} pixels".format(shift))
     #model = (fit[2]*(subpix_grid**2.))+(fit[1]*subpix_grid)+fit[0]
 
-    #if msgs._debug['flexure']:
-    #    debugger.plot1d(arx_skyspec.wavelength, arx_sky_flux, xtwo=np.roll(obj_skyspec.wavelength,int(-1*shift)), ytwo=obj_sky_flux)
-    #    #debugger.xplot(arx_sky.wavelength, arx_sky.flux, xtwo=np.roll(obj_sky.wavelength.value,9), ytwo=obj_sky.flux*100)
-    #    debugger.set_trace()
-
     flex_dict = dict(polyfit=fit, shift=shift, subpix=subpix_grid,
                      corr=corr[subpix_grid.astype(np.int)],
                      sky_spec=obj_skyspec,

--- a/pypeit/debugger.py
+++ b/pypeit/debugger.py
@@ -16,27 +16,6 @@ else:
 # Moved to the top and changed to only import set_trace
 from pdb import set_trace
 
-def init():
-    """
-    Returns
-    -------
-    debug : dict
-        default debug dict
-    """
-    debug = dict(develop=False,
-                 arc=False,
-                 obj_profile=False,
-                 slit_profile=False,
-                 sky_sub=False,
-                 trace=False,
-                 wave=False,
-                 tilts=False,
-                 flexure=False,
-                 no_qa=False,
-                 trace_obj=False,
-                 )
-    return debug
-
 # ADD-ONs from xastropy
 def plot1d(*args, **kwargs):
     """ Plot 1d arrays

--- a/pypeit/deprecated/arproc.py
+++ b/pypeit/deprecated/arproc.py
@@ -29,7 +29,7 @@ try:
 except NameError:
     basestring = str
 
-def background_subtraction(slf, sciframe, varframe, slitn, det, refine=0.0):
+def background_subtraction(slf, sciframe, varframe, slitn, det, refine=0.0, debug=False):
     """ Generate a frame containing the background sky spectrum
 
     Parameters
@@ -129,7 +129,7 @@ def background_subtraction(slf, sciframe, varframe, slitn, det, refine=0.0):
                                             maxone=False, **settings.argflag['reduce']['skysub']['bspline'])
         bgf_flat = arutils.func_val(bspl, tilts.flatten(), 'bspline')
         bgframe = bgf_flat.reshape(tilts.shape)
-        if msgs._debug['sky_sub']:
+        if debug:
             plt_bspline_sky(tilts, sciframe, bgf_flat, gdp)
             debugger.set_trace()
     else:
@@ -326,7 +326,7 @@ def reduce_prepare(slf, sciframe, bpix, datasec_img, scidx, fitsdict, det,
 
 def reduce_echelle(slf, sciframe, scidx, fitsdict, det,
                    standard=False, triml=1, trimr=1,
-                   mspixelflatnrm=None):
+                   mspixelflatnrm=None, debug=False):
     """ Run standard extraction steps on an echelle frame
 
     Parameters
@@ -428,7 +428,7 @@ def reduce_echelle(slf, sciframe, scidx, fitsdict, det,
         if np.sum(1.0 - extrap_slit) > ofit[0] + 1:
             fitted, outpar = arpca.basis(xcen, trccen, trccoeff, lnpc, ofit, skipx0=False, mask=maskord,
                                          function=settings.argflag['trace']['object']['function'])
-            if not msgs._debug['no_qa']:
+            if not debug:
 #                arqa.pca_plot(slf, outpar, ofit, "Object_Trace", pcadesc="PCA of object trace")
                 arpca.pca_plot(slf.setup, outpar, ofit, "Object_Trace", pcadesc="PCA of object trace")
             # Extrapolate the remaining orders requested
@@ -492,7 +492,7 @@ def reduce_echelle(slf, sciframe, scidx, fitsdict, det,
                                              tracelist=scitrace)
 
     # Save the quality control
-    if not msgs._debug['no_qa']:
+    if not debug:
         artrace.obj_trace_qa(slf, sciframe, trobjl, trobjr, None, det,
                              root="object_trace", normalize=False)
 
@@ -513,8 +513,8 @@ def reduce_echelle(slf, sciframe, scidx, fitsdict, det,
                         scitrace=scitrace, standard=standard)
 
 
-def reduce_multislit(slf, tilts, sciframe, bpix, datasec_img, scidx, fitsdict, det,
-                     mswave, mspixelflatnrm=None, standard=False, slitprof=None):
+def reduce_multislit(slf, tilts, sciframe, bpix, datasec_img, scidx, fitsdict, det, mswave,
+                     mspixelflatnrm=None, standard=False, slitprof=None, debug=False):
     """ Run standard extraction steps on an echelle frame
 
     Parameters
@@ -546,7 +546,7 @@ def reduce_multislit(slf, tilts, sciframe, bpix, datasec_img, scidx, fitsdict, d
     # Estimate Sky Background
     if settings.argflag['reduce']['skysub']['perform']:
         # Perform an iterative background/science extraction
-        if msgs._debug['obj_profile'] and False:
+        if debug:
             debugger.set_trace()  # JXP says THIS MAY NOT WORK AS EXPECTED
             msgs.warn("Reading background from 2D image on disk")
             datfil = settings.argflag['run']['directory']['science']+'/spec2d_{:s}.fits'.format(slf._basename.replace(":","_"))
@@ -609,8 +609,6 @@ def reduce_multislit(slf, tilts, sciframe, bpix, datasec_img, scidx, fitsdict, d
     # Flexure down the slit? -- Not currently recommended
     if settings.argflag['reduce']['flexure']['method'] == 'slitcen':
         flex_dict = arwave.flexure_slit(slf, det)
-        #if not msgs._debug['no_qa']:
-#        arqa.flexure(slf, det, flex_dict, slit_cen=True)
         arwave.flexure_qa(slf, det, flex_dict, slit_cen=True)
 
     # Perform an optimal extraction
@@ -715,7 +713,6 @@ def reduce_frame(slf, sciframe, rawvarframe, modelvarframe, bpix, datasec_img,
     if settings.argflag['reduce']['flexure']['perform'] and (not standard):
         if settings.argflag['reduce']['flexure']['method'] is not None:
             flex_list = arwave.flexure_obj(slf, det)
-            #if not msgs._debug['no_qa']:
             arwave.flexure_qa(slf, det, flex_list)
 
     # Correct Earth's motion

--- a/pypeit/deprecated/arproc.py
+++ b/pypeit/deprecated/arproc.py
@@ -29,7 +29,7 @@ try:
 except NameError:
     basestring = str
 
-def background_subtraction(slf, sciframe, varframe, slitn, det, refine=0.0, debug=False):
+def background_subtraction(slf, sciframe, varframe, slitn, det, refine=0.0, doqa=True):
     """ Generate a frame containing the background sky spectrum
 
     Parameters
@@ -129,7 +129,7 @@ def background_subtraction(slf, sciframe, varframe, slitn, det, refine=0.0, debu
                                             maxone=False, **settings.argflag['reduce']['skysub']['bspline'])
         bgf_flat = arutils.func_val(bspl, tilts.flatten(), 'bspline')
         bgframe = bgf_flat.reshape(tilts.shape)
-        if debug:
+        if doqa:
             plt_bspline_sky(tilts, sciframe, bgf_flat, gdp)
             debugger.set_trace()
     else:
@@ -326,7 +326,7 @@ def reduce_prepare(slf, sciframe, bpix, datasec_img, scidx, fitsdict, det,
 
 def reduce_echelle(slf, sciframe, scidx, fitsdict, det,
                    standard=False, triml=1, trimr=1,
-                   mspixelflatnrm=None, debug=False):
+                   mspixelflatnrm=None, doqa=True):
     """ Run standard extraction steps on an echelle frame
 
     Parameters
@@ -428,7 +428,7 @@ def reduce_echelle(slf, sciframe, scidx, fitsdict, det,
         if np.sum(1.0 - extrap_slit) > ofit[0] + 1:
             fitted, outpar = arpca.basis(xcen, trccen, trccoeff, lnpc, ofit, skipx0=False, mask=maskord,
                                          function=settings.argflag['trace']['object']['function'])
-            if not debug:
+            if doqa:
 #                arqa.pca_plot(slf, outpar, ofit, "Object_Trace", pcadesc="PCA of object trace")
                 arpca.pca_plot(slf.setup, outpar, ofit, "Object_Trace", pcadesc="PCA of object trace")
             # Extrapolate the remaining orders requested
@@ -492,7 +492,7 @@ def reduce_echelle(slf, sciframe, scidx, fitsdict, det,
                                              tracelist=scitrace)
 
     # Save the quality control
-    if not debug:
+    if doqa:
         artrace.obj_trace_qa(slf, sciframe, trobjl, trobjr, None, det,
                              root="object_trace", normalize=False)
 

--- a/pypeit/pypeit.py
+++ b/pypeit/pypeit.py
@@ -17,7 +17,7 @@ from pypeit import pypeitsetup
 from pypeit import debugger
 
 def PypeIt(pypeit_file, setup_only=False, calibration_check=False, use_header_frametype=False,
-          sort_dir=None, debug=None, quick=False, ncpus=1, overwrite=True, verbosity=2,
+          sort_dir=None, quick=False, ncpus=1, overwrite=True, verbosity=2,
           use_masters=False, logname=None):
     """
     Execute PYPIT.
@@ -50,8 +50,6 @@ def PypeIt(pypeit_file, setup_only=False, calibration_check=False, use_header_fr
             headers using the instrument specific keywords.
         sort_dir (str):
             The directory to put the '.sorted' file.
-        debug (:obj:`dict`, optional):
-            Debugging dictionary.  TODO: More description.
         quick (:obj:`bool`, optional):
             Perform a quick version of the reduction.  NOT IMPLEMENTED.
         ncpus (:obj:`int`, optional):
@@ -80,7 +78,7 @@ def PypeIt(pypeit_file, setup_only=False, calibration_check=False, use_header_fr
         raise NotImplementedError('Quick version of pypeit is not yet implemented.')
 
     # Reset the global logger
-    msgs.reset(log=logname, debug=None, verbosity=verbosity)
+    msgs.reset(log=logname, verbosity=verbosity)
     msgs.pypeit_file = pypeit_file
 
     # Record the starting time

--- a/pypeit/pypmsgs.py
+++ b/pypeit/pypmsgs.py
@@ -26,8 +26,10 @@ from pypeit.core.qa import close_qa
 
 #pypeit_logger = None
 
+
 class PypeItError(Exception):
     pass
+
 
 class Messages:
     """
@@ -40,9 +42,6 @@ class Messages:
     ----------
     log : str or None
       Name of saved log file (no log will be saved if log=="")
-    debug : dict
-      dict used for debugging.
-      'LOAD', 'BIAS', 'ARC', 'TRACE'
     verbosity : int (0,1,2)
       Level of verbosity:
         0 = No output
@@ -52,11 +51,9 @@ class Messages:
       If true, the screen output will have colors, otherwise
       normal screen output will be displayed
     """
-    def __init__(self, log=None, debug=None, verbosity=None, colors=True):
+    def __init__(self, log=None, verbosity=None, colors=True):
 
         # Initialize other variables
-        # TODO: debug could just be develop=True or False
-        self._debug = debug
         self._verbosity = 2 if verbosity is None else verbosity
 #        self._last_updated = __last_updated__
         self._version = __version__
@@ -100,21 +97,21 @@ class Messages:
             msg = msg.replace(i, '')
         return msg
 
-    def _debugmessage(self):
-        if self._debug is not None and self._debug['develop']:
+    def _devmsg(self):
+        if self._verbosity == 2:
             info = inspect.getouterframes(inspect.currentframe())[3]
-            dbgmsg = self._start + self._blue_CL + info[1].split('/')[-1] + ' ' + str(info[2]) \
+            devmsg = self._start + self._blue_CL + info[1].split('/')[-1] + ' ' + str(info[2]) \
                         + ' ' + info[3] + '()' + self._end + ' - '
         else:
-            dbgmsg = ''
-        return dbgmsg
+            devmsg = ''
+        return devmsg
 
-    def _print(self, premsg, msg, last=True, debug=True):
+    def _print(self, premsg, msg, last=True):
         """
         Print to standard error and the log file
         """
-        dbgmsg = self._debugmessage() if debug else ''
-        _msg = premsg+dbgmsg+msg
+        devmsg = self._devmsg()
+        _msg = premsg+devmsg+msg
         print(_msg, file=sys.stderr)
         if self._log:
             clean_msg = self._cleancolors(_msg)
@@ -139,7 +136,7 @@ class Messages:
         self._log.write("You are using astropy version={:s}\n\n".format(astropy.__version__))
         self._log.write("------------------------------------------------------\n\n")
 
-    def reset(self, log=None, debug=None, verbosity=None, colors=True):
+    def reset(self, log=None, verbosity=None, colors=True):
         """
         Reinitialize the object.
 
@@ -147,8 +144,7 @@ class Messages:
         but also a dynamically defined log file.
         """
         # Initialize other variables
-        self._debug = debug
-        self._verbosity = 1 if verbosity is None else verbosity
+        self._verbosity = 2 if verbosity is None else verbosity
         self.reset_log_file(log)
         self.disablecolors()
         if colors:
@@ -177,10 +173,10 @@ class Messages:
 
     def pypeitheader(self, prognm):
         """
-        Get the info header for PYPIT
+        Get the info header for PypeIt
         """
         header = '##  '
-        header += self._start + self._white_GR + 'PYPIT : '
+        header += self._start + self._white_GR + 'PypeIt : '
         header += 'The Python Spectroscopic Data Reduction Pipeline v{0:s}'.format(
                         self._version) + self._end + '\n'
         header += '##  '
@@ -305,7 +301,7 @@ class Messages:
         """
         Print a work in progress message
         """
-        if self._debug is not None and self._debug['develop']:
+        if self._verbosity == 2:
             premsgp = self._start + self._black_CL + '[WORK IN ]::' + self._end + '\n'
             premsgs = self._start + self._yellow_CL + '[PROGRESS]::' + self._end + ' '
             self._print(premsgp+premsgs, msg)
@@ -315,7 +311,7 @@ class Messages:
         Print an indent
         """
         premsg = '             '
-        self._print(premsg, msg, debug=False)
+        self._print(premsg, msg)
 
     def input(self):
         """
@@ -386,26 +382,3 @@ class Messages:
         self._white_BL = ''
         self._black_YL = ''
         self._yellow_BK = ''
-
-
-#def get_logger(init=None):
-#    """ Logger
-#    Parameters
-#    ----------
-#    init : tuple
-#      For instantiation
-#      (log, debug, verbosity)
-#
-#    Returns
-#    -------
-#    msgs : Messages
-#    """
-#    global pypeit_logger
-#
-#    # Instantiate??
-#    if init is not None:
-#        pypeit_logger = Messages(init[0], init[1], init[2])
-#
-#    return pypeit_logger
-
-

--- a/pypeit/pypmsgs.py
+++ b/pypeit/pypmsgs.py
@@ -12,6 +12,7 @@ from __future__ import unicode_literals
 
 import sys
 import os
+import getpass
 import glob
 import textwrap
 import inspect
@@ -25,6 +26,8 @@ from pypeit import __version__ #, __last_updated__
 from pypeit.core.qa import close_qa
 
 #pypeit_logger = None
+
+developers = ['rcooke']
 
 
 class PypeItError(Exception):
@@ -54,7 +57,10 @@ class Messages:
     def __init__(self, log=None, verbosity=None, colors=True):
 
         # Initialize other variables
-        self._verbosity = 2 if verbosity is None else verbosity
+        self._defverb = 1
+        if getpass.getuser() in developers:
+            self._defverb = 2
+        self._verbosity = self._defverb if verbosity is None else verbosity
 #        self._last_updated = __last_updated__
         self._version = __version__
 
@@ -145,7 +151,7 @@ class Messages:
         but also a dynamically defined log file.
         """
         # Initialize other variables
-        self._verbosity = 2 if verbosity is None else verbosity
+        self._verbosity = self._defverb if verbosity is None else verbosity
         self.reset_log_file(log)
         self.disablecolors()
         if colors:

--- a/pypeit/pypmsgs.py
+++ b/pypeit/pypmsgs.py
@@ -27,7 +27,8 @@ from pypeit.core.qa import close_qa
 
 #pypeit_logger = None
 
-developers = ['rcooke']
+# Alphabetical list of developers
+developers = ['ema', 'milvang', 'rcooke', 'xavier']
 
 
 class PypeItError(Exception):

--- a/pypeit/pypmsgs.py
+++ b/pypeit/pypmsgs.py
@@ -112,7 +112,8 @@ class Messages:
         """
         devmsg = self._devmsg()
         _msg = premsg+devmsg+msg
-        print(_msg, file=sys.stderr)
+        if self._verbosity != 0:
+            print(_msg, file=sys.stderr)
         if self._log:
             clean_msg = self._cleancolors(_msg)
             self._log.write(clean_msg+'\n' if last else clean_msg)

--- a/pypeit/pypmsgs.py
+++ b/pypeit/pypmsgs.py
@@ -28,7 +28,7 @@ from pypeit.core.qa import close_qa
 #pypeit_logger = None
 
 # Alphabetical list of developers
-developers = ['ema', 'milvang', 'rcooke', 'thsyu', 'westfall', 'xavier']
+developers = ['ema', 'joe', 'milvang', 'rcooke', 'thsyu', 'westfall', 'xavier']
 
 
 class PypeItError(Exception):

--- a/pypeit/scripts/run_pypeit.py
+++ b/pypeit/scripts/run_pypeit.py
@@ -4,7 +4,7 @@
 #
 # -*- coding: utf-8 -*-
 """
-This script runs PYPIT
+This script runs PypeIt
 """
 from __future__ import print_function
 from __future__ import absolute_import
@@ -30,10 +30,10 @@ from pypeit import msgs
 
 def parser(options=None):
 
-    parser = argparse.ArgumentParser(description=msgs.usage('PYPIT'),
+    parser = argparse.ArgumentParser(description=msgs.usage('PypeIt'),
                                      formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument('pypeit_file', type=str,
-                        help='PYPIT reduction file (must have .pypeit extension)')
+                        help='PypeIt reduction file (must have .pypeit extension)')
     parser.add_argument('-v', '--verbosity', type=int, default=2,
                         help='Verbosity level between 0 [none] and 2 [all]')
     parser.add_argument('-t', '--hdrframetype', default=False, action='store_true',
@@ -44,8 +44,6 @@ def parser(options=None):
                              'writing these files.')
     parser.add_argument('-m', '--use_masters', default=False, action='store_true',
                         help='Load previously generated MasterFrames')
-    parser.add_argument('-d', '--develop', default=False, action='store_true',
-                        help='Turn develop debugging on')
 #    parser.add_argument('--devtest', default=False, action='store_true',
 #                        help='Running development tests')
     parser.add_argument('--debug_arc', default=False, action='store_true',
@@ -89,16 +87,14 @@ def main(args):
     #vrb = 2
 
     # Load options from command line
-    debug = None
     splitnm = os.path.splitext(args.pypeit_file)
     if splitnm[1] != '.pypeit':
         msgs.error("Bad extension for PYPIT reduction file."+msgs.newline()+".pypeit is required")
     logname = splitnm[0] + ".log"
 
     pypeit.PypeIt(args.pypeit_file, setup_only=args.prep_setup, calibration_check=args.calcheck,
-                use_header_frametype=args.hdrframetype, sort_dir=args.sort_dir, debug=debug,
-                overwrite=args.overwrite, verbosity=args.verbosity, use_masters=args.use_masters,
-                logname=logname)
+                  use_header_frametype=args.hdrframetype, sort_dir=args.sort_dir, overwrite=args.overwrite,
+                  verbosity=args.verbosity, use_masters=args.use_masters, logname=logname)
 
     return 0
 

--- a/pypeit/scripts/run_pypeit.py
+++ b/pypeit/scripts/run_pypeit.py
@@ -15,18 +15,6 @@ import argparse
 
 from pypeit import msgs
 
-# Globals
-#debug = ardebug.init()
-#debug['develop'] = True
-#debug['arc'] = True
-#debug['sky_sub'] = True
-#debug['trace'] = True
-#debug['obj_profile'] = True
-#debug['trace_obj'] = True
-#debug['tilts'] = True
-#debug['flexure'] = True
-#debug['no_qa'] = True
-
 
 def parser(options=None):
 
@@ -102,12 +90,12 @@ def main(args):
 #    if debug['develop']:
 #        pypeit.PYPIT(args.pypeit_file, progname=pypeit.__file__, quick=qck, ncpus=cpu,
 #                    verbosity=args.verbosity, use_masters=args.use_masters, devtest=args.devtest,
-#                    logname=logname, debug=debug)
+#                    logname=logname)
 #    else:
 #        try:
 #            pypeit.PYPIT(args.pypeit_file, progname=pypeit.__file__, quick=qck, ncpus=cpu,
 #                        verbosity=args.verbosity, use_masters=args.use_masters,
-#                        devtest=args.devtest, logname=logname, debug=debug)
+#                        devtest=args.devtest, logname=logname)
 #        except:
 #            # There is a bug in the code, print the file and line number of the error.
 #            et, ev, tb = sys.exc_info()

--- a/pypeit/scripts/run_pypeit.py
+++ b/pypeit/scripts/run_pypeit.py
@@ -89,7 +89,7 @@ def main(args):
     # Load options from command line
     splitnm = os.path.splitext(args.pypeit_file)
     if splitnm[1] != '.pypeit':
-        msgs.error("Bad extension for PYPIT reduction file."+msgs.newline()+".pypeit is required")
+        msgs.error("Bad extension for PypeIt reduction file."+msgs.newline()+".pypeit is required")
     logname = splitnm[0] + ".log"
 
     pypeit.PypeIt(args.pypeit_file, setup_only=args.prep_setup, calibration_check=args.calcheck,

--- a/pypeit/tests/test_flexure.py
+++ b/pypeit/tests/test_flexure.py
@@ -31,7 +31,6 @@ def test_flex_shift():
     arx_file = pypeit.__path__[0]+'/data/sky_spec/sky_LRISb_600.fits'
     arx_spec = readspec(arx_file)
     # Call
-    #msgs._debug['flexure'] = True
     flex_dict = wave.flex_shift(obj_spec, arx_spec)
     assert np.abs(flex_dict['shift'] - 15.7) < 0.1
 

--- a/pypeit/tests/test_msgs.py
+++ b/pypeit/tests/test_msgs.py
@@ -9,12 +9,11 @@ import numpy as np
 import pytest
 
 from pypeit import pypmsgs
-debug = None
 
 def test_log_write():
 
     outfil = 'tst.log'
-    msgs = pypmsgs.Messages(outfil, debug, 1)
+    msgs = pypmsgs.Messages(outfil, verbosity=1)
     msgs.close()
     # Insure scipy, numpy, astropy are being version
     with open(outfil, 'r') as f:
@@ -30,7 +29,7 @@ def test_log_write():
 
 
 def test_msgs():
-    msgs = pypmsgs.Messages(None, debug, 1)
+    msgs = pypmsgs.Messages(None, verbosity=1)
     msgs.info("test 123")
     msgs.warn("test 123")
     msgs.bug("test 123")


### PR DESCRIPTION
Addresses Issue #405.

The new default is verbosity=2. Here is what each verbosity does:

```
verbosity =
0: print nothing
1: print every message (but do not print "work" and "test" messages)
2: print every message, and include the blue "develop" text
```

Both "develop" and "debug" have now disappeared.

NOTE: I haven't checked that the code runs, because my python 3 is broken, so don't merge until I (or someone else) checks that PypeIt still runs!