### PR TITLE
Fix flatfield bug

### DIFF
--- a/pypeit/core/flat.py
+++ b/pypeit/core/flat.py
@@ -715,7 +715,7 @@ def sn_frame(slf, sciframe, idx):
 '''
 
 
-def flatfield(sciframe, flatframe, bpix, snframe=None, varframe=None, slitprofile=None):
+def flatfield(sciframe, flatframe, bpix, slitprofile, snframe=None, varframe=None):
     """ Flat field the input image
 
     .. todo::
@@ -725,13 +725,13 @@ def flatfield(sciframe, flatframe, bpix, snframe=None, varframe=None, slitprofil
     ----------
     sciframe : 2d image
     flatframe : 2d image
+    slitprofile : ndarray
+      slit profile image
     snframe : 2d image, optional
     det : int
       Detector index
     varframe : ndarray
       variance image
-    slitprofile : ndarray
-      slit profile image
 
     Returns
     -------
@@ -742,8 +742,10 @@ def flatfield(sciframe, flatframe, bpix, snframe=None, varframe=None, slitprofil
     """
     if (varframe is not None) & (snframe is not None):
         msgs.error("Cannot set both varframe and snframe")
-    if slitprofile is not None:
-        flatframe *= slitprofile
+
+    # Fold in the slit profile
+    flatframe *= slitprofile
+
     # New image
     retframe = np.zeros_like(sciframe)
     w = np.where(flatframe > 0.0)

--- a/pypeit/flatfield.py
+++ b/pypeit/flatfield.py
@@ -261,10 +261,10 @@ class FlatField(processimages.ProcessImages, masterframe.MasterFrame):
                 # Leave slit_profiles as ones if the slitprofile is not
                 # being determined, otherwise, set the model.
                 self.slit_profiles[word] = modvals/nrmvals
-            self.mspixelflatnrm[word] /= nrmvals
+            self.mspixelflatnrm[word] /= modvals
             # Fill
-            self.msblaze[:,slit] = msblaze_slit
-            self.blazeext[:,slit] = blazeext_slit
+            self.msblaze[:, slit] = msblaze_slit
+            self.blazeext[:, slit] = blazeext_slit
 
         # If some slit profiles/blaze functions need to be extrapolated, do that now
         if armed:

--- a/pypeit/processimages.py
+++ b/pypeit/processimages.py
@@ -399,8 +399,7 @@ class ProcessImages(object):
             msgs.error('No bpm for {0}'.format(self.spectrograph.spectrograph))
 
         # Flat-field the data and return the result
-        self.stack = flat.flatfield(self.stack, self.pixel_flat, self.bpm,
-                                    slitprofile=self.slitprof)
+        self.stack = flat.flatfield(self.stack, self.pixel_flat, self.bpm, self.slitprof)
         return self.stack
 
     def process(self, bias_subtract=None, apply_gain=False, trim=True, overwrite=False,

--- a/pypeit/processimages.py
+++ b/pypeit/processimages.py
@@ -400,9 +400,8 @@ class ProcessImages(object):
 
         # Flat-field the data and return the result
         self.stack = flat.flatfield(self.stack, self.pixel_flat, self.bpm,
-                                      slitprofile=self.slitprof)
+                                    slitprofile=self.slitprof)
         return self.stack
-
 
     def process(self, bias_subtract=None, apply_gain=False, trim=True, overwrite=False,
                 pixel_flat=None, bpm=None, slitprof=None):
@@ -417,6 +416,9 @@ class ProcessImages(object):
           Apply gain to the various amplifier regions
         trim : bool, optional
         overwrite :
+        pixel_flat : ndarray or None
+          This is the normalized pixel flat (i.e. no blaze, no slit illumination profile).
+          The values of this array should have a scatter about 1.0
 
         Returns
         -------


### PR DESCRIPTION
Addresses Issue #418.

In the previous version of the code, the normalized pixel flat contained the slit illumination (spatial) profile. When processing science frames, this normalized pixelflat was then multiplied by the slit profile (So the slit profile was accounted for twice). The fix forces the normalized pixel flat to be truly normalized (with deviations about 1) - it is the flat field frame with both the blaze and the slit illumination profile taken out.