### PR TITLE
Hotfix

### DIFF
--- a/pypeit/core/flat.py
+++ b/pypeit/core/flat.py
@@ -715,7 +715,7 @@ def sn_frame(slf, sciframe, idx):
 '''
 
 
-def flatfield(sciframe, flatframe, bpix, slitprofile, snframe=None, varframe=None):
+def flatfield(sciframe, flatframe, bpix, slitprofile=None, snframe=None, varframe=None):
     """ Flat field the input image
 
     .. todo::
@@ -744,7 +744,8 @@ def flatfield(sciframe, flatframe, bpix, slitprofile, snframe=None, varframe=Non
         msgs.error("Cannot set both varframe and snframe")
 
     # Fold in the slit profile
-    flatframe *= slitprofile
+    if slitprofile is not None:
+        flatframe *= slitprofile
 
     # New image
     retframe = np.zeros_like(sciframe)

--- a/pypeit/core/fsort.py
+++ b/pypeit/core/fsort.py
@@ -54,6 +54,7 @@ def ftype_indices(fitstbl, ftype, sci_ID):
     idx = np.where(fitstbl[ftype] & (fitstbl['sci_ID'] & sci_ID > 0))[0]
     return idx
 
+
 def list_of_files(fitstbl, ftype, sci_ID):
     """
     Generate a list of filenames with path for a given frametype and sci_ID

--- a/pypeit/core/load.py
+++ b/pypeit/core/load.py
@@ -261,10 +261,10 @@ def load_specobj(fname):
         # New and wrong
         try:
             specobj = specobjs.SpecObj(shape, [float(objp[1][1:])/10000.]*2,
-                                   np.mean([int(objp[-1][1:]), int(objp[-2][1:])]),
-                                   config='dummy_config',
-                                   slitid=1, det=det,
-                                   spat_pixpos=100)  # DUMMY
+                                       np.mean([int(objp[-1][1:]), int(objp[-2][1:])]),
+                                       config='dummy_config',
+                                       slitid=1, det=det,
+                                       spat_pixpos=100)  # DUMMY
         except:
             debugger.set_trace()
         # Add trace

--- a/pypeit/core/load.py
+++ b/pypeit/core/load.py
@@ -95,12 +95,12 @@ def load_headers(datlines, spectrograph, strict=True):
         # Now get the rest of the keywords
 
         for head_idx in head_keys.keys():
-            for kw,hkey in head_keys[head_idx].items():
+            for kw, hkey in head_keys[head_idx].items():
                 try:
                     value = headarr[head_idx][hkey]
                 except KeyError: # Keyword not found in header
                     msgs.warn("{:s} keyword not in header. Setting to None".format(hkey))
-                    value=str('None')
+                    value = str('None')
 #                except IndexError:
 #                    debugger.set_trace()
                 # Convert the input time into hours -- Should we really do this here??

--- a/pypeit/core/pypsetup.py
+++ b/pypeit/core/pypsetup.py
@@ -632,7 +632,7 @@ def load_sorted(sorted_file):
     """
     all_setups, all_setuplines, all_setupfiles = [], [], []
     try:
-        with open(sorted_file,'r') as ff:
+        with open(sorted_file, 'r') as ff:
             # Should begin with ####
             fline = ff.readline()
             if fline[0:4] != '####':

--- a/pypeit/processimages.py
+++ b/pypeit/processimages.py
@@ -399,7 +399,7 @@ class ProcessImages(object):
             msgs.error('No bpm for {0}'.format(self.spectrograph.spectrograph))
 
         # Flat-field the data and return the result
-        self.stack = flat.flatfield(self.stack, self.pixel_flat, self.bpm, self.slitprof)
+        self.stack = flat.flatfield(self.stack, self.pixel_flat, self.bpm, slitprofile=self.slitprof)
         return self.stack
 
     def process(self, bias_subtract=None, apply_gain=False, trim=True, overwrite=False,

--- a/pypeit/pypeitsetup.py
+++ b/pypeit/pypeitsetup.py
@@ -195,8 +195,7 @@ class PypeItSetup(object):
         #
         all_sci_idx = np.where(self.fitstbl['science'])[0]
         all_sci_ID = self.fitstbl['sci_ID'][self.fitstbl['science']]
-        self.group_dict = pypsetup.build_group_dict(self.fitstbl, self.setupIDs, all_sci_idx,
-                                                   all_sci_ID)
+        self.group_dict = pypsetup.build_group_dict(self.fitstbl, self.setupIDs, all_sci_idx, all_sci_ID)
 
         # TODO: Move this to a method that writes the sorted file
         # Write .sorted file

--- a/pypeit/scripts/setup.py
+++ b/pypeit/scripts/setup.py
@@ -14,13 +14,11 @@ from __future__ import (print_function, absolute_import, division,
 import argparse
 
 def parser(options=None):
-    parser = argparse.ArgumentParser(description="Script to setup a PYPIT run [v2]")
+    parser = argparse.ArgumentParser(description="Script to setup a PypeIt run [v2]")
     parser.add_argument("files_root", type=str, help="File path+root, e.g. /data/Kast/b ")
     parser.add_argument("spectrograph", type=str, help="Name of spectrograph")
     parser.add_argument("-v", "--verbosity", type=int, default=2,
                         help="(2) Level of verbosity (0-2)")
-    parser.add_argument("-d", "--develop", default=False, action='store_true',
-                        help="Turn develop debugging on")
     parser.add_argument("--extension", default='.fits',
                         help='File extension; compression indicators (e.g. .gz) not required.')
     parser.add_argument("--pypeit_file", default=False, action='store_true',
@@ -55,7 +53,7 @@ def main(args):
     # Check that input spectrograph is supported
     instruments_served = valid_spectrographs()
     if args.spectrograph not in instruments_served:
-        raise ValueError('Instrument \'{0}\' unknown to PYPIT.\n'.format(args.spectrograph)
+        raise ValueError('Instrument \'{0}\' unknown to PypeIt.\n'.format(args.spectrograph)
                          + '\tAvailable options are: {0}\n'.format(', '.join(instruments_served))
                          + '\tSelect an available instrument or consult the documentation '
                          + 'on how to add a new instrument.')
@@ -85,8 +83,6 @@ def main(args):
     pinp = [pypeit_file, '-p', '-s {0}'.format(root) ]
     if args.overwrite:
         pinp += ['-o']
-    if args.develop:
-        pinp += ['-d']
     pargs = run_pypeit.parser(pinp)
     sorted_file = pypeit_file.replace('.pypeit', '.sorted')
 

--- a/pypeit/specobjs.py
+++ b/pypeit/specobjs.py
@@ -57,8 +57,8 @@ class SpecObj(object):
     # Init
 
     # TODO
-    def __init__(self, shape, slit_spat_pos, slit_spec_pos, det = 1, setup = None,
-                 slitid = 999, scidx = 1, objtype='unknown', spat_pixpos=None):
+    def __init__(self, shape, slit_spat_pos, slit_spec_pos, det=1, setup=None,
+                 slitid=999, scidx=1, objtype='unknown', spat_pixpos=None):
 
         #Assign from init parameters
         self.shape = shape
@@ -145,8 +145,8 @@ class SpecObj(object):
             return False
 
     def copy(self):
-        slf = SpecObj(self.shape, self.slit_spat_pos, self.slit_spec_pos, det= self.det,
-                      setup=self.setup, slitid = self.slitid, scidx = self.scidx,
+        slf = SpecObj(self.shape, self.slit_spat_pos, self.slit_spec_pos, det=self.det,
+                      setup=self.setup, slitid = self.slitid, scidx=self.scidx,
                       objtype=self.objtype, spat_pixpos=self.spat_pixpos)
         slf.boxcar = self.boxcar.copy()
         slf.optimal = self.optimal.copy()

--- a/pypeit/spectrographs/keck_lris.py
+++ b/pypeit/spectrographs/keck_lris.py
@@ -311,6 +311,7 @@ class KeckLRISRSpectrograph(KeckLRISSpectrograph):
                             suffix          ='_02red'
                             )
             ]
+        self.numhead = 5
         # Uses default timeunit
         # Uses default primary_hdrext
         # self.sky_file ?

--- a/pypeit/spectrographs/keck_lris.py
+++ b/pypeit/spectrographs/keck_lris.py
@@ -17,6 +17,7 @@ from pypeit.core import fsort
 
 from pypeit import debugger
 
+
 class KeckLRISSpectrograph(spectrograph.Spectrograph):
     """
     Child to handle Keck/LRIS specific code
@@ -141,6 +142,7 @@ class KeckLRISSpectrograph(spectrograph.Spectrograph):
         # Return
         return match_criteria
 
+
 class KeckLRISBSpectrograph(KeckLRISSpectrograph):
     """
     Child to handle Keck/LRISb specific code
@@ -262,8 +264,6 @@ class KeckLRISBSpectrograph(KeckLRISSpectrograph):
             arcparam['disp'] = 1.43
         else:
             msgs.error('Not ready for this disperser {:s}!'.format(disperser))
-
-
 
 
 class KeckLRISRSpectrograph(KeckLRISSpectrograph):

--- a/pypeit/tests/test_setups.py
+++ b/pypeit/tests/test_setups.py
@@ -45,7 +45,7 @@ def test_run_setup():
     assert '01' in setup_dict['A'].keys()
     assert setup_dict['A']['--']['disperser']['name'] == '600/4310'
     # Failures
-    pargs2 = setup.parser([droot, 'shane_kast_blu', '-d', '-c',
+    pargs2 = setup.parser([droot, 'shane_kast_blu', '-c',
                               '--extension=fits.gz', '--redux_path={:s}'.format(data_path(''))])
     with pytest.raises(ValueError):
         setup.main(pargs2)


### PR DESCRIPTION
Removed a few lingering debug/develop options in the setup files, and set `numhead=5` for LRISr.

I've also now set `slit_profile=None` as the keyword argument. At this stage, the `slit_profile` is not actually folded in when performing the flatfielding (i.e. `slit_profile=None`), and I couldn't immediately figure out where it was missing as a keyword argument. I suspect this is an easy fix, but after the code rearrangement I became rather lost...

With the addition of [PR#45](https://github.com/pypeit/PypeIt-development-suite/pull/45) of the dev suite, the dev suite now passes: ISIS, kastb, kastr, lrisb x2

The dev suite fails for LRISr, and I'm now baffled about how the file sorting is being done. Perhaps the file sorting for LRISr is not implemented yet?