### PR TITLE
set method for SpecObjs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -152,7 +152,6 @@ install:
     - git clone git://github.com/astropy/ci-helpers.git
     - source ci-helpers/travis/setup_conda_$TRAVIS_OS_NAME.sh
     - if [[ $SETUP_CMD != egg_info ]]; then $PIP_INSTALL git+https://github.com/linetools/linetools.git; fi
-    - if [[ $SETUP_CMD != egg_info ]]; then $PIP_INSTALL git+https://github.com/PYPIT/arclines.git; fi
     - if [[ $SETUP_CMD != egg_info ]]; then $PIP_INSTALL git+https://github.com/profxj/ginga.git; fi
     - conda install numpy
     - conda install configobj

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@
 - Turn off 2.7 Travis testing
 - Integrated arclines into PypeIt
 - Modified debug/developer modes
+- Update SpecObjs class; ndarray instead of list;  set() method
 
 
 0.8.1

--- a/doc/nb/SpecObjs.ipynb
+++ b/doc/nb/SpecObjs.ipynb
@@ -4,21 +4,21 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Developing SpecObjs [v1]"
+    "# Developing SpecObjs [v2]\n",
+    "    v2 -- Converting specobjs to be a numpy array instead of a list"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# imports\n",
+    "import numpy as np\n",
     "from importlib import reload\n",
     "\n",
-    "from pypit import specobjs"
+    "from pypeit import specobjs"
    ]
   },
   {
@@ -95,7 +95,11 @@
     {
      "data": {
       "text/plain": [
-       "<SpecObj: Setup = None, Slit = 999 at spec = 1240.00 & spat = ( 800.00, 810.00) on det=01, scidx=1, objid = None and objtype=unknown>"
+       "<Table length=1>\n",
+       " shape [2]   slit_spat_pos [2] slit_spec_pos ... boxcar optimal\n",
+       "   int64          float64         float64    ... object  object\n",
+       "------------ ----------------- ------------- ... ------ -------\n",
+       "1024 .. 2048    800.0 .. 810.0        1240.0 ...     {}      {}"
       ]
      },
      "execution_count": 5,
@@ -116,7 +120,11 @@
     {
      "data": {
       "text/plain": [
-       "<SpecObj: Setup = None, Slit = 999 at spec = 1240.00 & spat = ( 400.00, 430.00) on det=01, scidx=1, objid = None and objtype=unknown>"
+       "<Table length=1>\n",
+       " shape [2]   slit_spat_pos [2] slit_spec_pos ... boxcar optimal\n",
+       "   int64          float64         float64    ... object  object\n",
+       "------------ ----------------- ------------- ... ------ -------\n",
+       "1024 .. 2048    400.0 .. 430.0        1240.0 ...     {}      {}"
       ]
      },
      "execution_count": 6,
@@ -137,21 +145,24 @@
     {
      "data": {
       "text/plain": [
-       "{'HAND_DET': None,\n",
-       " 'HAND_FLAG': False,\n",
-       " 'HAND_FWHM': None,\n",
-       " 'HAND_SPAT': None,\n",
-       " 'HAND_SPEC': None,\n",
+       "{'HAND_EXTRACT_DET': None,\n",
+       " 'HAND_EXTRACT_FLAG': False,\n",
+       " 'HAND_EXTRACT_FWHM': None,\n",
+       " 'HAND_EXTRACT_SPAT': None,\n",
+       " 'HAND_EXTRACT_SPEC': None,\n",
        " 'boxcar': {},\n",
        " 'config': None,\n",
        " 'det': 1,\n",
        " 'fwhm': None,\n",
-       " 'idx': None,\n",
+       " 'idx': 'O-----S999-D01-I0001',\n",
        " 'maskwidth': None,\n",
+       " 'maxcol': None,\n",
+       " 'mincol': None,\n",
        " 'objid': None,\n",
        " 'objtype': 'unknown',\n",
        " 'optimal': {},\n",
        " 'scidx': 1,\n",
+       " 'setup': None,\n",
        " 'shape': (1024, 2048),\n",
        " 'slit_spat_pos': (800.0, 810.0),\n",
        " 'slit_spec_pos': 1240.0,\n",
@@ -187,7 +198,7 @@
    },
    "outputs": [],
    "source": [
-    "sobjs.specobjs = [sobj1, sobj2]\n",
+    "sobjs.specobjs = np.array([sobj1, sobj2])\n",
     "sobjs.build_summary()"
    ]
   },
@@ -200,11 +211,11 @@
      "data": {
       "text/plain": [
        "<Table length=2>\n",
-       " shape [2]   slit_spat_pos [2] slit_spec_pos config ... HAND_FLAG boxcar optimal\n",
-       "   int64          float64         float64    object ...    bool   object  object\n",
-       "------------ ----------------- ------------- ------ ... --------- ------ -------\n",
-       "1024 .. 2048    800.0 .. 810.0        1240.0   None ...     False     {}      {}\n",
-       "1024 .. 2048    400.0 .. 430.0        1240.0   None ...     False     {}      {}"
+       " shape [2]   slit_spat_pos [2] slit_spec_pos ... boxcar optimal\n",
+       "   int64          float64         float64    ... object  object\n",
+       "------------ ----------------- ------------- ... ------ -------\n",
+       "1024 .. 2048    800.0 .. 810.0        1240.0 ...     {}      {}\n",
+       "1024 .. 2048    400.0 .. 430.0        1240.0 ...     {}      {}"
       ]
      },
      "execution_count": 9,
@@ -281,7 +292,11 @@
     {
      "data": {
       "text/plain": [
-       "<SpecObj: Setup = None, Slit = 999 at spec = 1240.00 & spat = ( 200.00, 220.00) on det=01, scidx=1, objid = None and objtype=unknown>"
+       "<Table length=1>\n",
+       " shape [2]   slit_spat_pos [2] slit_spec_pos ... boxcar optimal\n",
+       "   int64          float64         float64    ... object  object\n",
+       "------------ ----------------- ------------- ... ------ -------\n",
+       "1024 .. 2048    200.0 .. 220.0        1240.0 ...     {}      {}"
       ]
      },
      "execution_count": 12,
@@ -297,9 +312,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "sobjs.add_sobj(sobj3)"
@@ -314,12 +327,12 @@
      "data": {
       "text/plain": [
        "<Table length=3>\n",
-       " shape [2]   slit_spat_pos [2] slit_spec_pos config ... HAND_FLAG boxcar optimal\n",
-       "   int64          float64         float64    object ...    bool   object  object\n",
-       "------------ ----------------- ------------- ------ ... --------- ------ -------\n",
-       "1024 .. 2048    800.0 .. 810.0        1240.0   None ...     False     {}      {}\n",
-       "1024 .. 2048    400.0 .. 430.0        1240.0   None ...     False     {}      {}\n",
-       "1024 .. 2048    200.0 .. 220.0        1240.0   None ...     False     {}      {}"
+       " shape [2]   slit_spat_pos [2] slit_spec_pos ... boxcar optimal\n",
+       "   int64          float64         float64    ... object  object\n",
+       "------------ ----------------- ------------- ... ------ -------\n",
+       "1024 .. 2048    800.0 .. 810.0        1240.0 ...     {}      {}\n",
+       "1024 .. 2048    400.0 .. 430.0        1240.0 ...     {}      {}\n",
+       "1024 .. 2048    200.0 .. 220.0        1240.0 ...     {}      {}"
       ]
      },
      "execution_count": 14,
@@ -341,7 +354,9 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "sobjs.remove_sobj(2)"
@@ -356,11 +371,11 @@
      "data": {
       "text/plain": [
        "<Table length=2>\n",
-       " shape [2]   slit_spat_pos [2] slit_spec_pos config ... HAND_FLAG boxcar optimal\n",
-       "   int64          float64         float64    object ...    bool   object  object\n",
-       "------------ ----------------- ------------- ------ ... --------- ------ -------\n",
-       "1024 .. 2048    800.0 .. 810.0        1240.0   None ...     False     {}      {}\n",
-       "1024 .. 2048    400.0 .. 430.0        1240.0   None ...     False     {}      {}"
+       " shape [2]   slit_spat_pos [2] slit_spec_pos ... boxcar optimal\n",
+       "   int64          float64         float64    ... object  object\n",
+       "------------ ----------------- ------------- ... ------ -------\n",
+       "1024 .. 2048    800.0 .. 810.0        1240.0 ...     {}      {}\n",
+       "1024 .. 2048    400.0 .. 430.0        1240.0 ...     {}      {}"
       ]
      },
      "execution_count": 16,
@@ -370,6 +385,54 @@
    ],
    "source": [
     "sobjs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Set"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "sobjs.set(0, 'det', 3)\n",
+    "sobjs.set(slice(1,2), 'det', 2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([3, 2])"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sobjs.det"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "----"
    ]
   },
   {

--- a/pypeit/specobjs.py
+++ b/pypeit/specobjs.py
@@ -10,6 +10,7 @@ import numpy as np
 from astropy import units
 from astropy.table import Table
 from astropy.units import Quantity
+from astropy.utils import isiterable
 
 from pypeit import msgs
 from pypeit.core import parse
@@ -185,7 +186,9 @@ class SpecObjs(object):
     Object to hold a set of SpecObj objects
 
     Parameters:
-        specobjs : list
+        specobjs : ndarray or list, optional
+
+    Internals:
         summary : Table
     """
 
@@ -193,13 +196,13 @@ class SpecObjs(object):
         """
 
         Args:
-            specobjs: list, optional
+            specobjs: ndarray, optional
         """
-
-        # ToDo Should we just be using numpy object arrays here instead of lists? Seems like that would be easier
         if specobjs is None:
-            self.specobjs = []
+            self.specobjs = np.array([])
         else:
+            if isinstance(specobjs, list):
+                specobjs = np.array(specobjs)
             self.specobjs = specobjs
 
         # Internal summary Table
@@ -212,16 +215,16 @@ class SpecObjs(object):
         The summary table is rebuilt
 
         Args:
-            sobj: SpecObj or list
+            sobj: SpecObj or list or ndarray
 
         Returns:
 
 
         """
         if isinstance(sobj, SpecObj):
-            self.specobjs += [sobj]
-        elif isinstance(sobj, list):
-            self.specobjs += sobj
+            self.specobjs = np.append(self.specobjs, [sobj])
+        elif isinstance(sobj, (np.ndarray,list)):
+            self.specobjs = np.append(self.specobjs, sobj)
         # Rebuild summary table
         self.build_summary()
 
@@ -255,7 +258,11 @@ class SpecObjs(object):
         Returns:
 
         """
-        self.specobjs.pop(index)
+        msk = np.ones(self.specobjs.size, dtype=bool)
+        msk[index] = False
+        # Do it
+        self.specobjs = self.specobjs[msk]
+        # Update
         self.build_summary()
 
     def __getitem__(self, item):
@@ -281,8 +288,34 @@ class SpecObjs(object):
             # here for the many ways to give a slice; a tuple of ndarray
             # is produced by np.where, as in t[np.where(t['a'] > 2)]
             # For all, a new table is constructed with slice of all columns
-            sobjs_new = np.array(self.specobjs,dtype=object)
-            return SpecObjs(specobjs=sobjs_new[item])
+            #sobjs_new = np.array(self.specobjs,dtype=object)
+            return SpecObjs(specobjs=self.specobjs[item])
+
+    def set(self, islice, attr, value):
+        """
+        Set the attribute for a slice of the specobjs
+
+        Args:
+            islice: int, ndarray of bool, slice
+            attr: str
+            value: anything
+
+        Returns:
+
+        """
+        sub_sobjs = self.specobjs[islice]
+        if isiterable(value):
+            if sub_sobjs.size == len(value):  # Assume you want each paired up
+                for kk,sobj in enumerate(sub_sobjs):
+                    setattr(sobj, attr, value[kk])
+                    return
+        # Assuming scalar assignment
+        if isinstance(sub_sobjs, SpecObj):
+            setattr(sub_sobjs, attr, value)
+        else:
+            for sobj in sub_sobjs:
+                setattr(sobj, attr, value)
+        return
 
 
     def __getattr__(self, k):

--- a/pypeit/tests/test_specobjs.py
+++ b/pypeit/tests/test_specobjs.py
@@ -47,3 +47,10 @@ def test_add_rm():
     sobjs.remove_sobj(2)
     assert len(sobjs.specobjs) == 2
     assert len(sobjs.summary) == 2
+
+def test_set():
+    sobjs = specobjs.SpecObjs([sobj1,sobj2,sobj3])
+    sobjs.set(0, 'det', 3)
+    sobjs.set(slice(1,2), 'det', 2)
+    # Test
+    assert np.all(sobjs[:].det == np.array([3,2,1]))

--- a/pypeit/tests/test_specobjs.py
+++ b/pypeit/tests/test_specobjs.py
@@ -55,9 +55,12 @@ def test_set():
     assert np.all(sobjs[:].det == np.array([3,3,3]))
     # Slice
     sobjs[1:2]['det'] = 2
-    sobjs.det[1] = 2
+    assert sobjs.det[1] == 2
     # Under the hood
     sobjs.set(0, 'det', 3)
     sobjs.set(slice(1,2), 'det', 2)
     # Test
     assert np.all(sobjs[:].det == np.array([3,2,3]))
+    # Hennawi test
+    idx = sobjs.det == 3
+    sobjs[idx]['det'] = 1


### PR DESCRIPTION
Responding to #451 

The syntax that @jhennawi requested in that Issue is not
achievable given the way we are over-loading ```__getitem___```.
So I have constructed a ```set()``` method instead.  Only klunky
part is that one has to insert a ```slice``` object if you want to slice, e.g.

sobjs.set(slice(1,2), 'det', 2)

Includes new tests and updated Notebook.