### PR TITLE
Parsing with spaces

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,7 +18,7 @@
 - Hot fix for bspline + requirements update
 - Fixed issue with biases being written to disk as untrimmed. 
 - Completely reworked flat fielding algorithm. 
-
+- Fixed some parsing issues with the .pypeit file for cases where there is a whitepsace in the path. 
 
 0.8.1
 -----

--- a/pypeit/par/util.py
+++ b/pypeit/par/util.py
@@ -300,22 +300,30 @@ def _read_data_file_names(lines, file_check=True):
     read_inp = []
     for l in lines:
         _l = l.split(' ')
-        if len(_l) > 2:
-            msgs.error('There can be no more than two strings per line in a data block:'
-                       + msgs.newline() + l)
+         # JFH I don't see why we need to throw an error here. You can just ignore the extra strings?
+#        if len(_l) > 2:
+#            msgs.error('There can be no more than two strings per line in a data block:'
+#                       + msgs.newline() + l)
 
         if _l[0] == 'skip':
-            skip_inp += _parse_data_file_name(_l[1], current_path)
+            # skip_inp += _parse_data_file_name(_l[1], current_path)
+            space_ind = l.index(" ")
+            path = l[space_ind + 1:]
+            skip_inp += _parse_data_file_name(path, current_path)
             continue
 
         if _l[0] == 'path':
-            current_path = _l[1]
+            space_ind = l.index(" ")
+            current_path = l[space_ind + 1:]
+            #current_path = _l[1]
             continue
 
-        if len(_l) > 1:
-            msgs.error('There must be no spaces when specifying the datafile:'+msgs.newline()+l)
+#       JFH I don't see why we need to throw an error here. Python and fits.io can handle spaces in path just fine.
+#        if len(_l) > 1:
+#            msgs.error('There must be no spaces when specifying the datafile:'+msgs.newline()+l)
 
-        read_inp += _parse_data_file_name(_l[0], current_path)
+        #read_inp += _parse_data_file_name(_l[0], current_path)
+        read_inp += _parse_data_file_name(l, current_path)
 
     # Remove any repeated lines
     if len(skip_inp) > 0 and len(skip_inp) != len(set(skip_inp)):
@@ -377,7 +385,8 @@ def _determine_data_format(lines):
 
 def _read_data_file_table(lines, file_check=True):
     """Read the file table format."""
-    path = lines[0].split(' ')[1]
+    space_ind = lines[0].index(" ")
+    path = lines[0][space_ind+1:]
     header = np.array([ l.strip() for l in lines[1].split('|') ])
 
     file_col = np.where(header == 'filename')[0]


### PR DESCRIPTION
This very small PR address an issue with the parsing of the .pypeit file which was breaking for the case where the path to the data files has a space in it. In particular: 

/Volumes/GoogleDrive/Team\ Drives/PHYS-GP-Hennawi/PypeIt/PypeIt-development-suite/

Unfortunately Google File Stream defaults to putting Team Drives in a directory with a whitespace. This fix was thus necessary to get the dev suite to work with the new Google Drive dev suite RAW_DATA directory. 

Anyway, I don't see a reason why the pipeline has to crash for paths with a whitespace in them, and my changes to the util.py parser fix this. 

