### PR TITLE
New global and interactive plotting

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,9 @@
 - Fixed issue with biases being written to disk as untrimmed. 
 - Completely reworked flat fielding algorithm. 
 - Fixed some parsing issues with the .pypeit file for cases where there is a whitepsace in the path.
+- Implemented interactive plots with the -s option which allow the reduction to continue running.
+- Modified global sky subtraction significantly to now do a polynomial fit. This greatly improves results for large slits.
+- Updated loading of spectra and pypeit_show_1dspec script to work with new output data model. 
 
 0.8.1
 -----

--- a/pypeit/calibrations.py
+++ b/pypeit/calibrations.py
@@ -62,7 +62,7 @@ class Calibrations(object):
     # TODO: master_root is a bit of a kludge.  It could be defined
     # earlier and/or in par.
     def __init__(self, fitstbl, spectrograph=None, par=None, redux_path=None,
-                 save_masters=True, write_qa=True):
+                 save_masters=True, write_qa=True, show = False):
 
         # Check the type of the provided fits table
         if not isinstance(fitstbl, Table):
@@ -72,6 +72,7 @@ class Calibrations(object):
         self.fitstbl = fitstbl
         self.save_masters = save_masters
         self.write_qa = write_qa
+        self.show = show
 
         # Spectrometer class
         if spectrograph is None:
@@ -385,7 +386,7 @@ class Calibrations(object):
             #            and (traceSlits.mstrace is not None):
             #    flatField.mspixelflat = traceSlits.mstrace.copy()
             # Run
-            self.mspixflatnrm, self.msillumflat = self.flatField.run(show=show)
+            self.mspixflatnrm, self.msillumflat = self.flatField.run(show=self.show)
             # Save to Masters
             if self.save_masters:
                 self.flatField.save_master(self.mspixflatnrm, raw_files=pixflat_image_files,
@@ -827,7 +828,7 @@ class Calibrations(object):
             #            and (traceSlits.mstrace is not None):
             #    flatField.mspixelflat = traceSlits.mstrace.copy()
             # Run
-            self.mspixflatnrm, self.slitprof = self.flatField.run(armed=False)
+            self.mspixflatnrm, self.slitprof = self.flatField.run()
             # Save to Masters
             if self.save_masters:
                 self.flatField.save_master(self.mspixflatnrm, raw_files=pixflat_image_files,
@@ -851,10 +852,10 @@ class MultiSlitCalibrations(Calibrations):
     calibrations.
     """
     def __init__(self, fitstbl, spectrograph=None, par=None, redux_path=None, save_masters=True,
-                 write_qa=True, steps=None):
+                 write_qa=True, show = False, steps=None):
         Calibrations.__init__(self, fitstbl, spectrograph=spectrograph, par=par,
                               redux_path=redux_path, save_masters=save_masters,
-                              write_qa=write_qa)
+                              write_qa=write_qa, show = show)
         self.steps = MultiSlitCalibrations.default_steps() if steps is None else steps
 
     @staticmethod

--- a/pypeit/core/extract.py
+++ b/pypeit/core/extract.py
@@ -484,11 +484,6 @@ def findfwhm(model, sig_x):
 def qa_fit_profile(x_tot,y_tot, model_tot, l_limit = None, r_limit = None, ind = None,
                    title =' ', xtrunc = 1e6, xlim = None, ylim = None, qafile = None):
 
-    from importlib import reload
-    import matplotlib
-    reload(matplotlib)
-    plt = matplotlib.pyplot
-
     # Plotting pre-amble
     plt.close("all")
     #plt.clf()
@@ -611,7 +606,7 @@ def return_gaussian(sigma_x, norm_obj, fwhm, med_sn2, obj_string, show_profile,
         p_show_profile.daemon = True
         p_show_profile.start()
 
-    return (profile_model, p_show_profile)
+    return profile_model, p_show_profile
 
 
 def fit_profile(image, ivar, waveimg, trace_in, wave, flux, fluxivar,
@@ -1727,6 +1722,6 @@ def objfind(image, thismask, slit_left, slit_righ, inmask = None, FWHM = 3.0,
 #        p_show_gauss_wt.terminate()
 
 
-    return (sobjs, skymask[thismask], objmask[thismask], proc_list)
+    return sobjs, skymask[thismask], objmask[thismask], proc_list
 
 

--- a/pypeit/core/extract.py
+++ b/pypeit/core/extract.py
@@ -1480,7 +1480,7 @@ def objfind(image, thismask, slit_left, slit_righ, inmask = None, FWHM = 3.0,
     skymask = np.copy(thismask)
     if (len(sobjs) == 0) & (hand_extract_dict == None):
         msgs.info('No objects found')
-        return (None, skymask[thismask], objmask[thismask])
+        return (None, skymask[thismask], objmask[thismask], proc_list)
 
 
     msgs.info('Fitting the object traces')

--- a/pypeit/core/flat.py
+++ b/pypeit/core/flat.py
@@ -1088,6 +1088,7 @@ def flatfield(sciframe, flatframe, bpix, illum_flat=None, snframe=None, varframe
 
     # Fold in the slit profile
     if illum_flat is not None:
+        msgs.info('Dividing by illumination flat')
         flatframe *= illum_flat
 
     # New image

--- a/pypeit/core/load.py
+++ b/pypeit/core/load.py
@@ -335,8 +335,8 @@ def load_1dspec(fname, exten=None, extract='OPT', objname=None, flux=False):
     rsp_kwargs = {}
     rsp_kwargs['wave_tag'] = '{:s}_WAVE'.format(extract)
     if flux:
-        rsp_kwargs['flux_tag'] = '{:s}_flam'.format(extract)
-        rsp_kwargs['ivar_tag'] = '{:s}_flam_ivar'.format(extract)
+        rsp_kwargs['flux_tag'] = '{:s}_FLAM'.format(extract)
+        rsp_kwargs['ivar_tag'] = '{:s}_FLAM_IVAR'.format(extract)
     else:
         rsp_kwargs['flux_tag'] = '{:s}_COUNTS'.format(extract)
         rsp_kwargs['ivar_tag'] = '{:s}_COUNTS_IVAR'.format(extract)

--- a/pypeit/core/load.py
+++ b/pypeit/core/load.py
@@ -336,10 +336,11 @@ def load_1dspec(fname, exten=None, extract='OPT', objname=None, flux=False):
     rsp_kwargs['wave_tag'] = '{:s}_WAVE'.format(extract)
     if flux:
         rsp_kwargs['flux_tag'] = '{:s}_flam'.format(extract)
-        rsp_kwargs['var_tag'] = '{:s}_flam_var'.format(extract)
+        rsp_kwargs['ivar_tag'] = '{:s}_flam_ivar'.format(extract)
     else:
         rsp_kwargs['flux_tag'] = '{:s}_COUNTS'.format(extract)
-        rsp_kwargs['var_tag'] = '{:s}_VAR'.format(extract)
+        rsp_kwargs['ivar_tag'] = '{:s}_COUNTS_IVAR'.format(extract)
+
     # Identify extension from objname?
     if objname is not None:
         hdulist = fits.open(fname)
@@ -347,6 +348,7 @@ def load_1dspec(fname, exten=None, extract='OPT', objname=None, flux=False):
         exten = hdu_names.index(objname)
         if exten < 0:
             msgs.error("Bad input object name: {:s}".format(objname))
+
     # Load
     spec = XSpectrum1D.from_file(fname, exten=exten, **rsp_kwargs)
     # Return

--- a/pypeit/core/masters.py
+++ b/pypeit/core/masters.py
@@ -205,7 +205,7 @@ def _load(name, exten=0, frametype='<None>', force=False):
     elif frametype == 'trace':
         msgs.error('Load from the class not this method')
     else:
-        msgs.info("Loading a pre-existing master calibration frame")
+        msgs.info("Loading a pre-existing master calibration frame of type: {:}".format(frametype) + " from filename: {:}".format(name))
         hdu = fits.open(name)
         #msgs.info("Master {0:s} frame loaded successfully:".format(hdu[0].header['FRAMETYP'])+msgs.newline()+name)
         head0 = hdu[0].header

--- a/pypeit/core/pydl.py
+++ b/pypeit/core/pydl.py
@@ -672,12 +672,14 @@ class bspline(object):
         goodbkpt = np.where(self.mask)[0]
         nbkpt = len(goodbkpt)
         if nbkpt <= 2*self.nord:
+            msgs.warn('Fewer good break points than order of b-spline. Returning...')
             return -2
         # Find the unique ones for the polynomial
         hmm = err[uniq(err//self.npoly)]//self.npoly
 
         n = nbkpt - self.nord
         if np.any(hmm >= n):
+            msgs.warn('Note enough unique points in cholesky_band decomposition of b-spline matrix. Returning...')
             return -2
         test = np.zeros(nbkpt, dtype='bool')
         for jj in range(-int(np.ceil(self.nord/2)), int(self.nord/2.)):
@@ -730,6 +732,7 @@ class bspline(object):
         goodbk = self.mask[self.nord:]
         nn = goodbk.sum()
         if nn < self.nord:
+            msgs.warn('Fewer good break points than order of b-spline. Returning...')
             yfit = np.zeros(ydata.shape, dtype='f')
             return (-2, yfit)
         nfull = nn * self.npoly

--- a/pypeit/core/skysub.py
+++ b/pypeit/core/skysub.py
@@ -131,9 +131,15 @@ def global_skysub(image, ivar, tilts, thismask, slit_left, slit_righ, inmask = N
         npercol = np.fmax(np.floor(np.sum(thismask) / nspec), 1.0)
         # Demand at least 10 pixels per row (on average) per degree of the polynomial
         if npoly is None:
-            npoly_in = 7
-            npoly = np.fmax(np.fmin(npoly_in, (np.ceil(npercol / 10.)).astype(int)), 1)
-        poly_basis = pydl.fpoly(2.0*ximg_fit - 1.0, npoly).T
+            #npoly_in = 7
+            #npoly = np.fmax(np.fmin(npoly_in, (np.ceil(npercol / 10.)).astype(int)), 1)
+            if npercol > 100:
+                npoly = 3
+            elif npercol > 40:
+                npoly = 2
+            else:
+                npoly = 1
+        poly_basis = pydl.flegendre(2.0*ximg_fit - 1.0, npoly).T
 
     # Full fit now
     #full_bspline = pydl.bspline(wsky, nord=4, bkspace=bsp, npoly = npoly)

--- a/pypeit/core/skysub.py
+++ b/pypeit/core/skysub.py
@@ -14,130 +14,10 @@ from pypeit import utils
 from pypeit import debugger
 from pypeit.core import pixels
 from pypeit.core import extract
+from matplotlib import pyplot as plt
 
 from scipy.special import ndtr
 
-
-
-# ToDO Fix masking logic. This code should also take an ivar for consistency with rest of extraction
-def bg_subtraction_slit(slit, slitpix, edge_mask, sciframe, varframe, tilts,
-                        bpm=None, crmask=None, tracemask=None, bsp=0.6, sigrej=3., POS_MASK=True,
-                        PLOT_FIT=False):
-    """
-    Perform sky subtraction on an input slit
-
-    Parameters
-    ----------
-    slit : int
-      Slit number; indexed 1, 2,
-    slitpix : ndarray
-      Specifies pixels in the slits
-    edgemask : ndarray
-      Mask edges of the slit
-    sciframe : ndarray
-      science frame
-    varframe : ndarray
-      Variance array
-    tilts : ndarray
-      Tilts of the wavelengths
-    bpm : ndarray, optional
-      Bad pixel mask
-    crmask : ndarray
-      Cosmic ray mask
-    tracemask : ndarray
-      Object mask
-    bsp : float
-      Break point spacing
-    sigrej : float
-      rejection
-
-    Returns
-    -------
-    bgframe : ndarray
-      Sky background image
-
-    """
-
-    # Init
-    bgframe = np.zeros_like(sciframe)
-    ivar = utils.calc_ivar(varframe)
-    ny = sciframe.shape[0]
-    piximg = tilts * (ny-1)
-
-    #
-    ordpix = slitpix.copy()
-    # Masks
-    if bpm is not None:
-        ordpix *= 1-bpm.astype(np.int)
-    if crmask is not None:
-        ordpix *= 1-crmask.astype(np.int)
-    if tracemask is not None:
-        ordpix *= (1-tracemask.astype(np.int))
-
-    # Sky pixels for fitting
-    fit_sky = (ordpix == slit) & (ivar > 0.) & (~edge_mask)
-    isrt = np.argsort(piximg[fit_sky])
-    wsky = piximg[fit_sky][isrt]
-    sky = sciframe[fit_sky][isrt]
-    sky_ivar = ivar[fit_sky][isrt]
-
-    # All for evaluation
-    all_slit = (slitpix == slit) & (~edge_mask)
-
-    # Restrict fit to positive pixels only and mask out large outliers via a pre-fit to the log
-    if (POS_MASK==True):
-        pos_sky = (sky > 1.0) & (sky_ivar > 0.)
-        if np.sum(pos_sky) > ny:
-            lsky = np.log(sky[pos_sky])
-            lsky_ivar = lsky * 0. + 0.1
-
-            # Init bspline to get the sky breakpoints (kludgy)
-            tmp = pydl.bspline(wsky[pos_sky], nord=4, bkspace=bsp)
-
-            #skybkpt = bspline_bkpts(wsky[pos_sky], nord=4, bkspace=bsp $
-            #, / silent)
-            if False:
-                plt.clf()
-                ax = plt.gca()
-                ax.scatter(wsky[pos_sky], lsky)
-                #ax.scatter(wsky[~full_out], sky[~full_out], color='red')
-                #ax.plot(wsky, yfit, color='green')
-                plt.show()
-                #debugger.set_trace()
-            lskyset, outmask, lsky_fit, red_chi = utils.bspline_profile(
-                wsky[pos_sky], lsky, lsky_ivar, np.ones_like(lsky),
-                fullbkpt = tmp.breakpoints, upper=sigrej, lower=sigrej,
-                kwargs_reject={'groupbadpix':True})
-            res = (sky[pos_sky] - np.exp(lsky_fit)) * np.sqrt(sky_ivar[pos_sky])
-            lmask = (res < 5.0) & (res > -4.0)
-            sky_ivar[pos_sky] = sky_ivar[pos_sky] * lmask
-
-    # Full fit now
-    full_bspline = pydl.bspline(wsky, nord=4, bkspace=bsp)
-    skyset, full_out, yfit, _ = utils.bspline_profile(
-        wsky, sky, sky_ivar, np.ones_like(sky),
-        fullbkpt=full_bspline.breakpoints,
-        upper=sigrej, lower=sigrej, kwargs_reject={'groupbadpix':True, 'maxrej': 10})
-    # Evaluate and save
-    bgframe[all_slit] = skyset.value(piximg[all_slit])[0] #, skyset)
-
-    # Debugging/checking
-    if PLOT_FIT:
-        goodbk = skyset.mask
-        yfit_bkpt = np.interp(skyset.breakpoints[goodbk], wsky,yfit)
-        plt.clf()
-        ax = plt.gca()
-        was_fit = (sky_ivar > 0.0)
-        was_fit_and_masked = (was_fit == True) & (full_out == False)
-        ax.plot(wsky[was_fit], sky[was_fit], color='k', marker='o', markersize=0.4, mfc='k', fillstyle='full', linestyle='None')
-        ax.plot(wsky[was_fit_and_masked], sky[was_fit_and_masked], color='red', marker='+', markersize=1.5, mfc='red', fillstyle='full', linestyle='None')
-        ax.plot(wsky, yfit, color='cornflowerblue')
-        ax.plot(skyset.breakpoints[goodbk], yfit_bkpt, color='lawngreen', marker='o', markersize=2.0, mfc='lawngreen', fillstyle='full', linestyle='None')
-        ax.set_ylim((0.99*yfit.min(),1.01*yfit.max()))
-        plt.show()
-
-    # Return
-    return bgframe
 
 
 def global_skysub(image, ivar, tilts, thismask, slit_left, slit_righ, inmask = None, bsp=0.6, sigrej=3., trim_edg = (3,3),
@@ -450,19 +330,18 @@ def local_skysub_extract(sciimg, sciivar, tilts, waveimg, global_sky, rn2_img, t
             npoly = 1
         obj_profiles = np.zeros((nspec, nspat, objwork), dtype=float)
         sigrej_eff = sigrej
-        for iiter in range(1, niter):
-            msgs.info("Iteration # " + "{:2d}".format(iiter) + " of " + "{:2d}".format(niter))
+        proc_list = [] # List of processes for interactive plotting, these are terminated at the end of each iteration sequence
+        for iiter in range(1, niter + 1):
             img_minsky = sciimg - skyimage
             for ii in range(objwork):
                 iobj = group[ii]
                 if iiter == 1:
                     # If this is the first iteration, print status message. Initiate profile fitting with a simple
                     # boxcar extraction.
-                    msgs.info("-------------------REDUCING-------------------")
-                    msgs.info("Fitting profile for obj #: " + "{:}".format(sobjs[iobj].objid) + " of {:}".format(nobj))
-                    msgs.info(
-                        "At x = {:5.2f}".format(sobjs[iobj].spat_pixpos) + " on slit # {:}".format(sobjs[iobj].slitid))
-                    msgs.info("----------------------------------------------")
+                    msgs.info('--------------------------REDUCING: Iteration # ' + '{:2d}'.format(iiter) + ' of ' + '{:2d}'.format(niter) + '---------------------------------------------------')
+                    msgs.info("Fitting profile for obj # " + "{:}".format(sobjs[iobj].objid) + " of {:}".format(nobj))
+                    msgs.info("At x = {:5.2f}".format(sobjs[iobj].spat_pixpos) + " on slit # {:}".format(sobjs[iobj].slitid))
+                    msgs.info("------------------------------------------------------------------------------------------------------------")
                     flux = extract.extract_boxcar(img_minsky * outmask, sobjs[iobj].trace_spat, box_rad,
                                           ycen=sobjs[iobj].trace_spec)
                     mvarimg = 1.0 / (modelivar + (modelivar == 0))
@@ -478,6 +357,7 @@ def local_skysub_extract(sciimg, sciivar, tilts, waveimg, global_sky, rn2_img, t
                                 box_denom + (box_denom == 0.0))
                     fluxivar = mask_box / (mvar_box + (mvar_box == 0.0))
                 else:
+                    msgs.info('--------------------------REDUCING: Iteration # ' + '{:2d}'.format(iiter) + ' of ' + '{:2d}'.format(niter) + '---------------------------------------------------')
                     # For later iterations, profile fitting is based on an optimal extraction
                     last_profile = obj_profiles[:, :, ii]
                     trace = np.outer(sobjs[iobj].trace_spat, np.ones(nspat))
@@ -490,15 +370,19 @@ def local_skysub_extract(sciimg, sciivar, tilts, waveimg, global_sky, rn2_img, t
                         fluxivar = sobjs[iobj].optimal['COUNTS_IVAR']
                         wave = sobjs[iobj].optimal['WAVE']
 
+                obj_string = 'obj # {:}'.format(sobjs[iobj].objid) + ' on slit # {:}'.format(sobjs[iobj].slitid) + ', iter # {:}'.format(iiter) + ':'
                 if wave.any():
-                    (profile_model, xnew, fwhmfit, med_sn2) = extract.fit_profile(img_minsky[ipix], (modelivar * outmask)[ipix],
+                    (profile_model, xnew, fwhmfit, med_sn2, show_proc) = extract.fit_profile(img_minsky[ipix], (modelivar * outmask)[ipix],
                                                                           waveimg[ipix],
                                                                           sobjs[iobj].trace_spat - mincol,
                                                                           wave, flux, fluxivar,
                                                                           thisfwhm=sobjs[iobj].fwhm,
                                                                           hwidth=sobjs[iobj].maskwidth,
                                                                           prof_nsigma=sobjs[iobj].prof_nsigma,
-                                                                          sn_gauss=sn_gauss, show_profile=show_profile)
+                                                                          sn_gauss=sn_gauss, obj_string = obj_string,
+                                                                          show_profile=show_profile)
+                    proc_list.append(show_proc)
+
                     # Update the object profile and the fwhm and mask parameters
                     obj_profiles[ipix[0], ipix[1], ii] = profile_model
                     sobjs[iobj].trace_spat = xnew + mincol
@@ -600,6 +484,12 @@ def local_skysub_extract(sciimg, sciivar, tilts, waveimg, global_sky, rn2_img, t
                 msgs.warn('       Moving on......')
                 obj_profiles = np.zeros_like(obj_profiles)
 
+        # Now that iterations are complete, clear the windows if show_profile was set
+        if show_profile:
+            for proc in proc_list:
+                proc.terminate()
+                proc.join()
+
         # Now that the iterations of profile fitting and sky subtraction are completed,
         # loop over the objwork objects in this grouping and perform the final extractions.
         for ii in range(objwork):
@@ -667,189 +557,14 @@ def local_skysub_extract(sciimg, sciivar, tilts, waveimg, global_sky, rn2_img, t
         canvas_list = points_mask + points_omask + text_mask + text_omask
         canvas.add('constructedcanvas', canvas_list)
 
+    # Clean up any profile plots
+#    if show_profile:
+#        try:
+#            show_proc.terminate()
+#            show_proc.join()
+#        except:
+#            pass
 
     return (skyimage[thismask], objimage[thismask], modelivar[thismask], outmask[thismask])
-
-def order_pixels(pixlocn, lord, rord):
-    """
-    Based on physical pixel locations, determine which pixels are within the orders
-    """
-
-    sz_x, sz_y, _ = pixlocn.shape
-    sz_o = lord.shape[1]
-
-    outfr = np.zeros((sz_x, sz_y), dtype=int)
-
-    for y in range(sz_y):
-        for o in range(sz_o):
-            indx = (lord[:,o] < rord[:,o]) & (pixlocn[:,y,1] > lord[:,o]) \
-                   & (pixlocn[:,y,1] < rord[:,o])
-            indx |= ( (lord[:,o] > rord[:,o]) & (pixlocn[:,y,1] < lord[:,o])
-                      & (pixlocn[:,y,1] > rord[:,o]) )
-            if np.any(indx):
-                # Only assign a single order to a given pixel
-                outfr[indx,y] = o+1
-                break
-
-    return outfr
-
-
-# This code is deprecated and replaced by bg_subtraction_slit
-def orig_bg_subtraction_slit(tslits_dict, pixlocn,
-                        slit, tilts, sciframe, varframe, bpix, crpix,
-                        settings,
-                        tracemask=None,
-                        rejsigma=3.0, maskval=-999999.9,
-                        method='bspline', debug=False):
-    """ Extract a science target and background flux
-    :param slf:
-    :param sciframe:
-    :param varframe:
-    :return:
-    """
-    # Unpack tslits
-    lordloc = tslits_dict['lcen']
-    rordloc = tslits_dict['rcen']
-    slitpix = tslits_dict['slitpix']
-    # Init
-    bgframe = np.zeros_like(sciframe)
-
-    # Begin the algorithm
-    # Find which pixels are within the order edges
-    msgs.info("Identifying pixels within each order")
-    ordpix = order_pixels(pixlocn, lordloc*0.95+rordloc*0.05, lordloc*0.05+rordloc*0.95)
-
-    msgs.info("Applying bad pixel mask")
-    ordpix *= (1-bpix.astype(np.int)) * (1-crpix.astype(np.int))
-    if tracemask is not None: ordpix *= (1-tracemask.astype(np.int))
-
-    # Construct an array of pixels to be fit with a spline
-    whord = np.where(ordpix == slit+1)
-    xvpix  = tilts[whord]
-    scipix = sciframe[whord]
-    xargsrt = np.argsort(xvpix, kind='mergesort')
-    sxvpix  = xvpix[xargsrt]
-    sscipix = scipix[xargsrt]
-
-    # Reject deviant pixels -- step through every 1.0/sciframe.shape[0] in sxvpix and reject significantly deviant pixels
-    edges = np.linspace(min(0.0,np.min(sxvpix)),max(1.0,np.max(sxvpix)),sciframe.shape[0])
-    fitcls = np.zeros(sciframe.shape[0])
-
-    # Identify science target
-    maskpix = np.zeros(sxvpix.size)
-    msgs.info("Identifying pixels containing the science target")
-    msgs.work("Speed up this step with multi-processing")
-    for i in range(sciframe.shape[0]-1):
-        wpix = np.where((sxvpix>=edges[i]) & (sxvpix<=edges[i+1]))
-        if (wpix[0].size>5):
-            txpix = sxvpix[wpix]
-            typix = sscipix[wpix]
-            msk, cf = utils.robust_polyfit(txpix, typix, 0, sigma=rejsigma)
-            maskpix[wpix] = msk
-            #fitcls[i] = cf[0]
-            wgd=np.where(msk == 0)
-            szt = np.size(wgd[0])
-            if szt > 8:
-                fitcls[i] = np.mean(typix[wgd][szt//2-3:szt//2+4]) # Average the 7 middle pixels
-                #fitcls[i] = np.mean(np.random.shuffle(typix[wgd])[:5]) # Average the 5 random pixels
-            else:
-                fitcls[i] = cf[0]
-    '''
-    else:
-        debugger.set_trace()
-        msgs.work("Speed up this step in cython")
-        for i in range(sciframe.shape[0]-1):
-            wpix = np.where((sxvpix >= edges[i]) & (sxvpix <= edges[i+1]))
-            typix = sscipix[wpix]
-            szt = typix.size
-            if szt > 8:
-                fitcls[i] = np.mean(typix[szt//2-3:szt//2+4])  # Average the 7 middle pixels
-            elif szt != 0:
-                fitcls[i] = np.mean(typix)
-            else:
-                fitcls[i] = 0.0
-        # Trace the sky lines to get a better estimate of the tilts
-        scicopy = sciframe.copy()
-        scicopy[np.where(ordpix == slit)] = maskval
-        scitilts, _ = artrace.model_tilt(det, scicopy, guesstilts=tilts.copy(),
-                                         censpec=fitcls, maskval=maskval, plotQA=True)
-        xvpix  = scitilts[whord]
-        scipix = sciframe[whord]
-        varpix = varframe[whord]
-        mskpix = tracemask[whord]
-        xargsrt = np.argsort(xvpix, kind='mergesort')
-        sxvpix  = xvpix[xargsrt]
-        sscipix = scipix[xargsrt]
-        svarpix = varpix[xargsrt]
-        maskpix = mskpix[xargsrt]
-    '''
-
-    # Check the mask is reasonable
-    scimask = sciframe.copy()
-    rxargsrt = np.argsort(xargsrt, kind='mergesort')
-    scimask[whord] *= (1.0-maskpix)[rxargsrt]
-
-    # Now trace the sky lines to get a better estimate of the spectral tilt during the observations
-    scifrcp = scimask.copy()
-    scifrcp[whord] += (maskval*maskpix)[rxargsrt]
-    scifrcp[np.where(ordpix != slit+1)] = maskval
-
-    # Check tilts? -- Can also be error in flat fielding or slit illumination
-    if False:
-        idx = 1893
-        plt.clf()
-        ax = plt.gca()
-        ax.scatter(tilts[idx-2,:], scifrcp[idx-2,:], color='green')
-        ax.scatter(tilts[idx-1,:], scifrcp[idx-1,:], color='blue')
-        ax.scatter(tilts[idx,:], scifrcp[idx,:], color='red')
-        ax.scatter(tilts[idx+1,:], scifrcp[idx+1,:], color='orange')
-        ax.set_ylim(0., 3000)
-        plt.show()
-        debugger.set_trace()
-    #
-    msgs.info("Fitting sky background spectrum")
-    if method == 'bspline':
-        msgs.info("Using bspline sky subtraction")
-        gdp = (scifrcp != maskval) & (ordpix == slit+1) & (varframe > 0.)
-        srt = np.argsort(tilts[gdp])
-        #bspl = utils.func_fit(tilts[gdp][srt], scifrcp[gdp][srt], 'bspline', 3,
-        #                        **settings.argflag['reduce']['skysub']['bspline'])
-        ivar = utils.calc_ivar(varframe)
-        mask, bspl = utils.robust_polyfit(tilts[gdp][srt], scifrcp[gdp][srt], 3,
-                                            function='bspline',
-                                            weights=np.sqrt(ivar)[gdp][srt],
-                                            sigma=5., maxone=False,
-                                            bspline_par=settings['skysub']['bspline'])
-        # Just those in the slit
-        in_slit = np.where(slitpix == slit+1)
-        bgf_flat = utils.func_val(bspl, tilts[in_slit].flatten(), 'bspline')
-        #bgframe = bgf_flat.reshape(tilts.shape)
-        bgframe[in_slit] = bgf_flat
-        if debug:
-            plt_bspline_sky(tilts, scifrcp, bgf_flat, in_slit, gdp)
-            debugger.set_trace()
-    else:
-        msgs.error('Not ready for this method for skysub {:s}'.format(method))
-
-    if np.sum(np.isnan(bgframe)) > 0:
-        msgs.warn("NAN in bgframe.  Replacing with 0")
-        bad = np.isnan(bgframe)
-        bgframe[bad] = 0.
-
-    # Plot to make sure that the result is good
-    return bgframe
-
-
-
-def plt_bspline_sky(tilts, scifrcp, bgf_flat, inslit, gdp):
-    # Setup
-    srt = np.argsort(tilts[inslit].flatten())
-    # Plot
-    plt.close()
-    plt.clf()
-    ax = plt.gca()
-    ax.scatter(tilts[gdp]*tilts.shape[0], scifrcp[gdp], marker='o')
-    ax.plot(tilts[inslit].flatten()[srt]*tilts.shape[0], bgf_flat[srt], 'r-')
-    plt.show()
 
 

--- a/pypeit/flatfield.py
+++ b/pypeit/flatfield.py
@@ -239,7 +239,7 @@ class FlatField(processimages.ProcessImages, masterframe.MasterFrame):
             self.rawflatimg = self.build_pixflat()
 
         # Prep tck (sets self.ntckx, self.ntcky)
-        self._prep_tck()
+        #self._prep_tck()
 
         # Setup
         self.mspixelflat = np.ones_like(self.rawflatimg)

--- a/pypeit/par/pypeitpar.py
+++ b/pypeit/par/pypeitpar.py
@@ -404,7 +404,7 @@ class FlatFieldPar(ParSet):
     For a table with the current keywords, defaults, and descriptions,
     see :ref:`pypeitpar`.
     """
-    def __init__(self, frame=None, slitprofile=None, method=None, params=None, twodpca=None):
+    def __init__(self, frame=None, illumflatten=None, method=None): #, params=None, twodpca=None):
     
         # Grab the parameter names and values from the function
         # arguments
@@ -424,12 +424,12 @@ class FlatFieldPar(ParSet):
         # TODO: Provide a list of valid masters to use as options?
         defaults['frame'] = 'pixelflat'
         dtypes['frame'] = str
-        descr['frame'] = 'Frame to use for field flattening.  Options are: pixelflat, pinhole, ' \
-                         'or a specified master calibration file.'
+        descr['frame'] = 'Frame to use for field flattening.  Options are: "pixelflat", ' \
+                         'or a specified calibration filename.'
 
-        defaults['slitprofile'] = True
-        dtypes['slitprofile'] = bool
-        descr['slitprofile'] = 'Use the flat field to determine the spatial profile of each slit.'
+        defaults['illumflatten'] = True
+        dtypes['illumflatten'] = bool
+        descr['illumflatten'] = 'Use the flat field to determine the illumination profile of each slit.'
 
         defaults['method'] = 'bspline'
         options['method'] = FlatFieldPar.valid_methods()
@@ -437,20 +437,21 @@ class FlatFieldPar(ParSet):
         descr['method'] = 'Method used to flat field the data; use None to skip flat-fielding.  ' \
                           'Options are: None, {0}'.format(', '.join(options['method']))
 
-        defaults['params'] = [20]
-        dtypes['params'] = [int, list]
-        descr['params'] = 'Flat-field method parameters.  For \'PolyScan\', set params = order, ' \
-                          'numPixels, repeat ; for bspline, set params = spacing '
+        # JFH These parameters below are all now deprecated.
+        #defaults['params'] = [20]
+        #dtypes['params'] = [int, list]
+        #descr['params'] = 'Flat-field method parameters.  For \'PolyScan\', set params = order, ' \
+        #                  'numPixels, repeat ; for bspline, set params = spacing '
 
         # TODO:  How is twodpca used?  Is it just another method that is
         # only used for ARMED?  Could we remove twodpca and just add
         # another method option?
-        defaults['twodpca'] = 0
-        dtypes['twodpca'] = int
-        descr['twodpca'] = 'Perform a simple 2D PCA on the echelle blaze fits if the value of ' \
-                           'this argument is >1. The argument value is equal to the number of ' \
-                           'PCA components. 0 means that no PCA will be performed.  **This is ' \
-                           'only used with ARMED pipeline.'
+        #defaults['twodpca'] = 0
+        #dtypes['twodpca'] = int
+        #descr['twodpca'] = 'Perform a simple 2D PCA on the echelle blaze fits if the value of ' \
+        #                   'this argument is >1. The argument value is equal to the number of ' \
+        #                   'PCA components. 0 means that no PCA will be performed.  **This is ' \
+        #                   'only used with ARMED pipeline.'
 
         # Instantiate the parameter set
         super(FlatFieldPar, self).__init__(list(pars.keys()),
@@ -466,7 +467,7 @@ class FlatFieldPar(ParSet):
     @classmethod
     def from_dict(cls, cfg):
         k = cfg.keys()
-        parkeys = [ 'frame', 'slitprofile', 'method', 'params', 'twodpca' ]
+        parkeys = [ 'frame', 'illumflatten', 'method'] #', 'params', 'twodpca' ]
         kwargs = {}
         for pk in parkeys:
             kwargs[pk] = cfg[pk] if pk in k else None
@@ -477,29 +478,31 @@ class FlatFieldPar(ParSet):
         """
         Return the valid frame types.
         """
-        return ['pixelflat', 'pinhole']
+
+        # ToDO JFH So won't this fail if the user tries to provide a filename?
+        return ['pixelflat'] # , 'pinhole'] disabling this for now, we don't seem to be using it. JFH
 
     @staticmethod
     def valid_methods():
         """
         Return the valid flat-field methods
         """
-        return [ 'PolyScan', 'bspline' ]
+        return ['bspline'] # [ 'PolyScan', 'bspline' ]. Same here. Not sure what PolyScan is
 
     def validate(self):
         """
         Check the parameters are valid for the provided method.
         """
         # Convert param to list
-        if isinstance(self.data['params'], int):
-            self.data['params'] = [self.data['params']]
+        #if isinstance(self.data['params'], int):
+        #    self.data['params'] = [self.data['params']]
         
         # Check that there are the correct number of parameters
-        if self.data['method'] == 'PolyScan' and len(self.data['params']) != 3:
-            raise ValueError('For PolyScan method, set params = order, number of '
-                             'pixels, number of repeats')
-        if self.data['method'] == 'bspline' and len(self.data['params']) != 1:
-            raise ValueError('For bspline method, set params = spacing (integer).')
+        #if self.data['method'] == 'PolyScan' and len(self.data['params']) != 3:
+        #    raise ValueError('For PolyScan method, set params = order, number of '
+        #                     'pixels, number of repeats')
+        #if self.data['method'] == 'bspline' and len(self.data['params']) != 1:
+        #    raise ValueError('For bspline method, set params = spacing (integer).')
         if self.data['frame'] in FlatFieldPar.valid_frames() or self.data['frame'] is None:
             return
 

--- a/pypeit/processimages.py
+++ b/pypeit/processimages.py
@@ -400,7 +400,10 @@ class ProcessImages(object):
         if self.bpm is None:
             msgs.error('No bpm for {0}'.format(self.spectrograph.spectrograph))
 
+        msgs.info("Flat fielding your image")
         # Flat-field the data and return the result
+
+        from IPython import embed
         self.stack = flat.flatfield(self.stack, self.pixel_flat, self.bpm, illum_flat=self.illum_flat)
         return self.stack
 

--- a/pypeit/pypeit.py
+++ b/pypeit/pypeit.py
@@ -595,7 +595,7 @@ class MultiSlit(PypeIt):
             self.fitstbl, spectrograph=self.spectrograph,
             par=self.par['calibrations'],
             redux_path=self.par['rdx']['redux_path'],
-            save_masters=True, write_qa=True)
+            save_masters=True, write_qa=True, show=self.show)
 
 
     def _extract_one(self):

--- a/pypeit/scienceimage.py
+++ b/pypeit/scienceimage.py
@@ -507,7 +507,8 @@ class ScienceImage(processimages.ProcessImages):
 
         # Show the science image if an interactive run
         if show:
-            self.show('image', image=self.sciimg, chname='sciimg', clear=True)
+            bitmask = self._build_bitmask()
+            self.show('image', image=self.sciimg*(bitmask == 0), chname='sciimg', clear=True)
         return self.sciimg, self.sciivar, self.rn2img, self.crmask
 
 

--- a/pypeit/scienceimage.py
+++ b/pypeit/scienceimage.py
@@ -552,7 +552,11 @@ class ScienceImage(processimages.ProcessImages):
         bitmask[self.crmask == True] += np.uint64(2**1)
         bitmask[self.sciimg >= saturation] += np.uint64(2**2)
         bitmask[self.sciimg <= mincounts] += np.uint64(2**3)
-        bitmask[self.tslits_dict['slitpix'] == 0] += np.uint64(2**4)
+        # This try except is here so that the bitmask can still be created even if tslits_dict has not been instantiated yet
+        try:
+            bitmask[self.tslits_dict['slitpix'] == 0] += np.uint64(2**4)
+        except:
+            pass
         bitmask[np.isfinite(self.sciimg) == False] += np.uint64(2**5)
         bitmask[self.sciivar <= 0.0] += np.uint64(2**6)
         bitmask[np.isfinite(self.sciivar) == False] += np.uint64(2**7)
@@ -620,7 +624,7 @@ class ScienceImage(processimages.ProcessImages):
                 else:
                     bitmask_in = None
                 ch_name = chname if chname is not None else 'global_sky'
-                viewer, ch = ginga.show_image(image, chname=ch_name, bitmask = bitmask_in, clear = clear, wcs_match=True)
+                viewer, ch = ginga.show_image(image, chname=ch_name, bitmask = bitmask_in, clear = clear, wcs_match=True) #, cuts=(cut_min, cut_max))
                 #cuts=(cut_min, cut_max)
         elif attr == 'local':
             # local sky subtraction
@@ -634,7 +638,7 @@ class ScienceImage(processimages.ProcessImages):
                 else:
                     bitmask_in = None
                 ch_name = chname if chname is not None else 'local_sky'
-                viewer, ch = ginga.show_image(image, chname=ch_name, bitmask=bitmask_in, clear=clear, wcs_match=True)
+                viewer, ch = ginga.show_image(image, chname=ch_name, bitmask=bitmask_in, clear=clear, wcs_match=True) #, cuts=(cut_min, cut_max))
                 #cuts=(cut_min, cut_max),
         elif attr == 'sky_resid':
             # sky residual map with object included

--- a/pypeit/scripts/show_1dspec.py
+++ b/pypeit/scripts/show_1dspec.py
@@ -16,7 +16,7 @@ def parser(options=None):
     parser.add_argument("--list", default=False, help="List the extensions only?", action="store_true")
     parser.add_argument("--exten", type=int, default=1, help="FITS extension")
     parser.add_argument("--obj", type=str, help="Object name in lieu of extension, e.g. O424-S1466-D02-I0013")
-    parser.add_argument("--extract", type=str, default='box', help="Extraction method. Default is boxcar. ['box', 'opt']")
+    parser.add_argument("--extract", type=str, default='OPT', help="Extraction method. Default is optimal. ['BOX', 'OPT']")
     parser.add_argument("--flux", default=False, action="store_true", help="Show fluxed spectrum?")
 
     if options is None:

--- a/pypeit/scripts/show_twod.py
+++ b/pypeit/scripts/show_twod.py
@@ -141,13 +141,13 @@ def main(args):
 
     # SCIIMG
     image = (sciimg)*(bitmask == 0)  # sky subtracted image
-    #(mean, med, sigma) = sigma_clipped_stats(image[bitmask == 0], sigma_lower=5.0, sigma_upper=5.0)
-    #cut_min = mean - 1.0 * sigma
-    #cut_max = mean + 4.0 * sigma
+    (mean, med, sigma) = sigma_clipped_stats(image[bitmask == 0], sigma_lower=5.0, sigma_upper=5.0)
+    cut_min = mean - 1.0 * sigma
+    cut_max = mean + 4.0 * sigma
     chname_skysub='sciimg-det{:s}'.format(sdet)
     # Clear all channels at the beginning
     viewer, ch = ginga.show_image(image, chname=chname_skysub, waveimg=waveimg,
-                                  bitmask=bitmask_in, clear=True) #, cuts=(cut_min, cut_max))
+                                  bitmask=bitmask_in, clear=True) #, cuts=(cut_min, cut_max), wcs_match=True)
 
     # SKYSUB
     image = (sciimg - skymodel) * (bitmask == 0)  # sky subtracted image
@@ -157,7 +157,7 @@ def main(args):
     chname_skysub='skysub-det{:s}'.format(sdet)
     # Clear all channels at the beginning
     viewer, ch = ginga.show_image(image, chname=chname_skysub, waveimg=waveimg,
-                                  bitmask=bitmask_in) #, cuts=(cut_min, cut_max))
+                                  bitmask=bitmask_in) #, cuts=(cut_min, cut_max),wcs_match=True)
                                   # JFH For some reason Ginga crashes when I try to put cuts in here.
     show_trace(hdulist_1d, det_nm, viewer, ch)
     ginga.show_slits(viewer, ch, Tslits.lcen, Tslits.rcen, slit_ids)#, args.det)
@@ -166,7 +166,7 @@ def main(args):
     chname_skyresids = 'sky_resid-det{:s}'.format(sdet)
     image = (sciimg - skymodel) * np.sqrt(ivarmodel) * (bitmask == 0)  # sky residual map
     viewer, ch = ginga.show_image(image, chname_skyresids, waveimg=waveimg,
-                                  cuts=(-5.0, 5.0), bitmask = bitmask_in)
+                                  cuts=(-5.0, 5.0), bitmask = bitmask_in) #,wcs_match=True)
     show_trace(hdulist_1d, det_nm, viewer, ch)
     ginga.show_slits(viewer, ch, Tslits.lcen, Tslits.rcen, slit_ids)#, args.det)
 
@@ -174,12 +174,12 @@ def main(args):
     chname_resids = 'resid-det{:s}'.format(sdet)
     image = (sciimg - skymodel - objmodel) * np.sqrt(ivarmodel) * (bitmask == 0)  # full model residual map
     viewer, ch = ginga.show_image(image, chname=chname_resids, waveimg=waveimg,
-                                  cuts = (-5.0, 5.0), bitmask = bitmask_in)
+                                  cuts = (-5.0, 5.0), bitmask = bitmask_in) #,wcs_match=True)
     show_trace(hdulist_1d, det_nm, viewer, ch)
     ginga.show_slits(viewer, ch, Tslits.lcen, Tslits.rcen, slit_ids)#, args.det)
 
 
-    # After displaying all the images since up the images with WCS_MATCH
+    # After displaying all the images sync up the images with WCS_MATCH
     shell = viewer.shell()
     out = shell.start_global_plugin('WCSMatch')
     out = shell.call_global_plugin_method('WCSMatch', 'set_reference_channel', [chname_resids], {})

--- a/pypeit/scripts/show_twod.py
+++ b/pypeit/scripts/show_twod.py
@@ -138,6 +138,17 @@ def main(args):
 
     # Now show each image to a separate channel
 
+
+    # SCIIMG
+    image = (sciimg)*(bitmask == 0)  # sky subtracted image
+    #(mean, med, sigma) = sigma_clipped_stats(image[bitmask == 0], sigma_lower=5.0, sigma_upper=5.0)
+    #cut_min = mean - 1.0 * sigma
+    #cut_max = mean + 4.0 * sigma
+    chname_skysub='sciimg-det{:s}'.format(sdet)
+    # Clear all channels at the beginning
+    viewer, ch = ginga.show_image(image, chname=chname_skysub, waveimg=waveimg,
+                                  bitmask=bitmask_in, clear=True) #, cuts=(cut_min, cut_max))
+
     # SKYSUB
     image = (sciimg - skymodel) * (bitmask == 0)  # sky subtracted image
     (mean, med, sigma) = sigma_clipped_stats(image[bitmask == 0], sigma_lower=5.0, sigma_upper=5.0)
@@ -146,7 +157,7 @@ def main(args):
     chname_skysub='skysub-det{:s}'.format(sdet)
     # Clear all channels at the beginning
     viewer, ch = ginga.show_image(image, chname=chname_skysub, waveimg=waveimg,
-                                  bitmask=bitmask_in, clear=True) #, cuts=(cut_min, cut_max))
+                                  bitmask=bitmask_in) #, cuts=(cut_min, cut_max))
                                   # JFH For some reason Ginga crashes when I try to put cuts in here.
     show_trace(hdulist_1d, det_nm, viewer, ch)
     ginga.show_slits(viewer, ch, Tslits.lcen, Tslits.rcen, slit_ids)#, args.det)

--- a/pypeit/spectrographs/shane_kast.py
+++ b/pypeit/spectrographs/shane_kast.py
@@ -373,19 +373,19 @@ class ShaneKastRedSpectrograph(ShaneKastSpectrograph):
 
         """
         arcparam['lamps'] = ['NeI','HgI','HeI','ArI']
-        if disperser == '600/7500':
-            arcparam['disp']=1.30
-            arcparam['b1']= 1./arcparam['disp']/msarc_shape[0] / binspectral
-            arcparam['wvmnx'][0] = 5000.
-            arcparam['n_first']=2 # Should be able to lock on
-        elif disperser == '1200/5000':
-            arcparam['disp']=0.63
-            arcparam['b1']= 1./arcparam['disp']/msarc_shape[0] / binspectral
-            arcparam['wvmnx'][0] = 5000.
-            arcparam['n_first']=2 # Should be able to lock on
-            arcparam['wv_cen'] = 6600.
-        else:
-            msgs.error('Not ready for this disperser {:s}!'.format(disperser))
+#        if disperser == '600/7500':
+#            arcparam['disp']=1.30
+#            arcparam['b1']= 1./arcparam['disp']/msarc_shape[0] / binspectral
+#            arcparam['wvmnx'][0] = 5000.
+#            arcparam['n_first']=2 # Should be able to lock on
+#        elif disperser == '1200/5000':
+#            arcparam['disp']=0.63
+#            arcparam['b1']= 1./arcparam['disp']/msarc_shape[0] / binspectral
+#            arcparam['wvmnx'][0] = 5000.
+#            arcparam['n_first']=2 # Should be able to lock on
+#            arcparam['wv_cen'] = 6600.
+#        else:
+#            msgs.error('Not ready for this disperser {:s}!'.format(disperser))
 
 
 class ShaneKastRedRetSpectrograph(ShaneKastSpectrograph):
@@ -480,16 +480,16 @@ class ShaneKastRedRetSpectrograph(ShaneKastSpectrograph):
 
         """
         arcparam['lamps'] = ['NeI','HgI','HeI','ArI']
-        if disperser == '600/7500':
-            arcparam['disp']=2.35
-            arcparam['b1']= 1./arcparam['disp']/msarc_shape[0] / binspectral
-            arcparam['wvmnx'][0] = 5000.
-            arcparam['n_first']=2 # Should be able to lock on
-        elif disperser == '1200/5000':
-            arcparam['disp']=1.17
-            arcparam['b1']= 1./arcparam['disp']/msarc_shape[0] / binspectral
-            arcparam['wvmnx'][0] = 5000.
-            arcparam['n_first']=2 # Should be able to lock on
-        else:
-            msgs.error('Not ready for this disperser {:s}!'.format(disperser))
+#        if disperser == '600/7500':
+#            arcparam['disp']=2.35
+#            arcparam['b1']= 1./arcparam['disp']/msarc_shape[0] / binspectral
+#            arcparam['wvmnx'][0] = 5000.
+#            arcparam['n_first']=2 # Should be able to lock on
+#        elif disperser == '1200/5000':
+#            arcparam['disp']=1.17
+#            arcparam['b1']= 1./arcparam['disp']/msarc_shape[0] / binspectral
+#            arcparam['wvmnx'][0] = 5000.
+#            arcparam['n_first']=2 # Should be able to lock on
+#        else:
+#            msgs.error('Not ready for this disperser {:s}!'.format(disperser))
 

--- a/pypeit/utils.py
+++ b/pypeit/utils.py
@@ -251,10 +251,6 @@ def bspline_profile(xdata, ydata, invvar, profile_basis, inmask = None, upper=5,
     if profile_basis.size != nx*npoly:
         msgs.error('Profile basis is not a multiple of the number of data points.')
 
-    msgs.info("Fitting npoly =" + "{:3d}".format(npoly) + " profile basis functions, nx=" + "{:3d}".format(nx) + " pixels")
-    msgs.info("****************************  Iter  Chi^2  # rejected  Rel. fact   ****************************")
-    msgs.info("                              ----  -----  ----------  --------- ")
-
     # Init
     yfit = np.zeros(ydata.shape)
     reduced_chi = 0.
@@ -266,6 +262,13 @@ def bspline_profile(xdata, ydata, invvar, profile_basis, inmask = None, upper=5,
 
     if inmask is None:
         inmask = (invvar > 0)
+
+    nin = np.sum(inmask)
+    msgs.info("Fitting npoly =" + "{:3d}".format(npoly) + " profile basis functions, nin=" + "{:3d}".format(nin) + " good pixels")
+    msgs.info("****************************  Iter  Chi^2  # rejected  Rel. fact   ****************************")
+    msgs.info("                              ----  -----  ----------  --------- ")
+
+
     maskwork = outmask & inmask & (invvar > 0)
     if not maskwork.any():
         msgs.error('No valid data points in bspline_profile!.')

--- a/pypeit/utils.py
+++ b/pypeit/utils.py
@@ -319,10 +319,8 @@ def bspline_profile(xdata, ydata, invvar, profile_basis, inmask = None, upper=5,
             error, yfit = sset.workit(xdata, ydata, invvar*maskwork,action, laction, uaction)
         iiter += 1
         if error == -2:
-            msgs.warn(" All break points have been dropped!!")
-            from IPython import embed
-            embed()
-            return (sset, outmask, yfit, reduced_chi)
+            msgs.warn(" All break points have been dropped!! Fit failed, I hope you know what you are doing")
+            return (sset, np.zeros(xdata.shape,dtype=bool), np.zeros(xdata.shape), reduced_chi)
         elif error == 0:
             # Iterate the fit -- next rejection iteration
             chi_array = (ydata - yfit)*np.sqrt(invvar * maskwork)

--- a/pypeit/utils.py
+++ b/pypeit/utils.py
@@ -317,6 +317,8 @@ def bspline_profile(xdata, ydata, invvar, profile_basis, inmask = None, upper=5,
         iiter += 1
         if error == -2:
             msgs.warn(" All break points have been dropped!!")
+            from IPython import embed
+            embed()
             return (sset, outmask, yfit, reduced_chi)
         elif error == 0:
             # Iterate the fit -- next rejection iteration

--- a/pypeit/utils.py
+++ b/pypeit/utils.py
@@ -265,7 +265,7 @@ def bspline_profile(xdata, ydata, invvar, profile_basis, inmask = None, upper=5,
 
     nin = np.sum(inmask)
     msgs.info("Fitting npoly =" + "{:3d}".format(npoly) + " profile basis functions, nin=" + "{:3d}".format(nin) + " good pixels")
-    msgs.info("****************************  Iter  Chi^2  # rejected  Rel. fact   ****************************")
+    msgs.info("******************************  Iter  Chi^2  # rejected  Rel. fact   ******************************")
     msgs.info("                              ----  -----  ----------  --------- ")
 
 
@@ -350,7 +350,7 @@ def bspline_profile(xdata, ydata, invvar, profile_basis, inmask = None, upper=5,
             msgs.info("                             {:4d}".format(iiter) + "    ---    ---    ---    ---")
 
 
-    msgs.info("***********************************************************************************************")
+    msgs.info("***************************************************************************************************")
     msgs.info(
         "Final fit after " + "{:2d}".format(iiter) + " iterations: reduced_chi = " + "{:8.3f}".format(reduced_chi) +
         ", rejected = " + "{:7d}".format((maskwork == 0).sum()) + ", relative_factor = {:6.2f}".format(relative_factor))


### PR DESCRIPTION
This PR implements two new features: 

1) The interactive plotting with the -s option that allows the code to continue running. I would appreciate it if you guys could give this a spin in the test suite and provide some feedback. I would like to know if there are bugs on Linux etc.

You might consider changing the backend to

backend :WebAgg

In your .matplotlib/matplotlibrc

This has the effect of sending all the interactive plots to a web browser via the WebAgg server. This is nice because a) the plots can all be toggled through via web-browser tags, but don't pop up all over your screen b) the plots are all interactive while the code runs, c) it gets around the annoying bug with MacOSX that causes multiprocessing guis to crash. 

If we like this WebAgg behavior we could consider setting it in pypeit when we load matplotlib. 

The only slightly annoying thing is that when the plots launch, the browser takes the mouse focus from whatever window you were in, but this may be a platform dependent thing, and there is probably a way to toggle it off. The easy way to deal with it is to just make the web browser window small. 

2) I've re-worked the global sky subtraction to now also do polynomial 2-d fitting with the b-spline. This results in dramatically improved global fits. Not sure why were not doing this in low-redux. It slightly increases the time for the global sky-subtraction. We need to test this thouroughly, because the increased complexity of the fits may also make fits less stable sometimes. I noticed that DEIMOS is going through many iterations before the fits finally stabilize and converge, so we may need to increase the b-spline spacing to stabilize the matrices. 

Joe