### PR TITLE
Turn off flexure for Keck NIRES

### DIFF
--- a/pypeit/bpmimage.py
+++ b/pypeit/bpmimage.py
@@ -112,7 +112,7 @@ class BPMImage(object):
         else:
             _datasec = datasec
             if self.spectrograph is None and _datasec is None:
-                _datasec = [[slice(None),slice(None)]]
+                _datasec = [(slice(None),slice(None))]
                 _numamplifiers = 1
             if _datasec is None:
                 # Get the data sections from the spectrograph definition

--- a/pypeit/check_requirements.py
+++ b/pypeit/check_requirements.py
@@ -17,6 +17,6 @@ for requirement in install_requires:
         raise ImportError("Package: {:s} not installed!".format(pkg))
     else:
         if pkg_resources.parse_version(pv) < pkg_resources.parse_version(version):
-            print("Version of package {:s} = {:s}".format(pkg, pv))
-            raise ImportError("You need version >= {:s}".format(version))
+            raise ImportError('Your version of {0} is incompatible with PypeIt.  '.format(pkg)
+                                + 'Please update to version >= {0}'.format(version))
 

--- a/pypeit/core/arc.py
+++ b/pypeit/core/arc.py
@@ -61,7 +61,6 @@ def setup_param(spectro_class, msarc_shape, fitstbl, arc_idx,
                                                arc_idx=arc_idx, binspatial=binspatial,
                                                binspectral=binspectral, msarc_shape=msarc_shape)
     # Load linelist
-    #if settings.argflag['arc']['calibrate']['lamps'] is not None:
     if calibrate_lamps is not None:
         arcparam['lamps'] = calibrate_lamps
     slmps = arcparam['lamps'][0]

--- a/pypeit/core/parse.py
+++ b/pypeit/core/parse.py
@@ -743,7 +743,7 @@ def sec2slice(subarray, one_indexed=False, include_end=False, require_dim=None, 
                 tslices = parse_sec2slice('[:10,10:]', transpose=True)
 
     Returns:
-        list: A list of slice objects, one per dimension of the
+        tuple: A tuple of slice objects, one per dimension of the
         prospective array.
 
     Raises:
@@ -787,7 +787,7 @@ def sec2slice(subarray, one_indexed=False, include_end=False, require_dim=None, 
         # Append the new slice
         slices += [slice(*_s)]
 
-    return slices[::-1] if transpose else slices
+    return tuple(slices[::-1] if transpose else slices)
 
 
 

--- a/pypeit/core/wave.py
+++ b/pypeit/core/wave.py
@@ -26,7 +26,7 @@ from pypeit import utils
 
 from pypeit import debugger
 
-def flex_shift(obj_skyspec, arx_skyspec, mxshft=None):
+def flex_shift(obj_skyspec, arx_skyspec, mxshft=20):
     """ Calculate shift between object sky spectrum and archive sky spectrum
 
     Parameters
@@ -38,18 +38,17 @@ def flex_shift(obj_skyspec, arx_skyspec, mxshft=None):
     -------
     flex_dict
     """
-    if mxshft is None:
-        mxshft = 20
-    #Determine the brightest emission lines
+    # Determine the brightest emission lines
     msgs.warn("If we use Paranal, cut down on wavelength early on")
     arx_amp, arx_cent, arx_wid, _, arx_w, arx_yprep = arc.detect_lines(arx_skyspec.flux.value)
     obj_amp, obj_cent, obj_wid, _, obj_w, obj_yprep = arc.detect_lines(obj_skyspec.flux.value)
 
-    #Keep only 5 brightest amplitude lines (xxx_keep is array of indices within arx_w of the 5 brightest)
+    # Keep only 5 brightest amplitude lines (xxx_keep is array of
+    # indices within arx_w of the 5 brightest)
     arx_keep = np.argsort(arx_amp[arx_w])[-5:]
     obj_keep = np.argsort(obj_amp[obj_w])[-5:]
 
-    #Calculate wavelength (Angstrom per pixel)
+    # Calculate wavelength (Angstrom per pixel)
     arx_disp = np.append(arx_skyspec.wavelength.value[1]-arx_skyspec.wavelength.value[0],
                          arx_skyspec.wavelength.value[1:]-arx_skyspec.wavelength.value[:-1])
     #arx_disp = (np.amax(arx_sky.wavelength.value)-np.amin(arx_sky.wavelength.value))/arx_sky.wavelength.size
@@ -57,7 +56,8 @@ def flex_shift(obj_skyspec, arx_skyspec, mxshft=None):
                          obj_skyspec.wavelength.value[1:]-obj_skyspec.wavelength.value[:-1])
     #obj_disp = (np.amax(obj_sky.wavelength.value)-np.amin(obj_sky.wavelength.value))/obj_sky.wavelength.size
 
-    #Calculate resolution (lambda/delta lambda_FWHM)..maybe don't need this? can just use sigmas
+    # Calculate resolution (lambda/delta lambda_FWHM)..maybe don't need
+    # this? can just use sigmas
     arx_idx = (arx_cent+0.5).astype(np.int)[arx_w][arx_keep]   # The +0.5 is for rounding
     arx_res = arx_skyspec.wavelength.value[arx_idx]/\
               (arx_disp[arx_idx]*(2*np.sqrt(2*np.log(2)))*arx_wid[arx_w][arx_keep])
@@ -66,14 +66,16 @@ def flex_shift(obj_skyspec, arx_skyspec, mxshft=None):
               (obj_disp[obj_idx]*(2*np.sqrt(2*np.log(2)))*obj_wid[obj_w][obj_keep])
     #obj_res = (obj_sky.wavelength.value[0]+(obj_disp*obj_cent[obj_w][obj_keep]))/(
     #    obj_disp*(2*np.sqrt(2*np.log(2)))*obj_wid[obj_w][obj_keep])
-    if not np.all(np.isfinite(obj_res)):
-        msgs.error("Failure to measure the resolution of the object spectrum.  Probably an error in the wavelength image.")
-    msgs.info("Resolution of Archive={:g} and Observation={:g}".format(
-        np.median(arx_res), np.median(obj_res)))
 
-    #Determine sigma of gaussian for smoothing
-    arx_sig2 = (arx_disp[arx_idx]*arx_wid[arx_w][arx_keep])**2.
-    obj_sig2 = (obj_disp[obj_idx]*obj_wid[obj_w][obj_keep])**2.
+    if not np.all(np.isfinite(obj_res)):
+        msgs.error('Failed to measure the resolution of the object spectrum, likely due to error '
+                   'in the wavelength image.')
+    msgs.info("Resolution of Archive={0} and Observation={1}".format(np.median(arx_res),
+                                                                     np.median(obj_res)))
+
+    # Determine sigma of gaussian for smoothing
+    arx_sig2 = np.power(arx_disp[arx_idx]*arx_wid[arx_w][arx_keep], 2)
+    obj_sig2 = np.power(obj_disp[obj_idx]*obj_wid[obj_w][obj_keep], 2)
 
     arx_med_sig2 = np.median(arx_sig2)
     obj_med_sig2 = np.median(obj_sig2)
@@ -120,7 +122,7 @@ def flex_shift(obj_skyspec, arx_skyspec, mxshft=None):
         obj_skyspec.data['flux'][0,:2] = 0.
         obj_skyspec.data['flux'][0,-2:] = 0.
 
-    #   Normalize spectra to unit average sky count
+    # Normalize spectra to unit average sky count
     norm = np.sum(obj_skyspec.flux.value)/obj_skyspec.npix
     obj_skyspec.flux = obj_skyspec.flux / norm
     norm2 = np.sum(arx_skyspec.flux.value)/arx_skyspec.npix
@@ -132,25 +134,26 @@ def flex_shift(obj_skyspec, arx_skyspec, mxshft=None):
         if (norm < 0.):
             msgs.error("Improper sky spectrum for flexure.  Is it too faint??")
     if (norm2 < 0.):
-        msgs.error("Bad normalization of archive in flexure. You are probably using wavelengths well beyond the archive.")
+        msgs.error('Bad normalization of archive in flexure. You are probably using wavelengths '
+                   'well beyond the archive.')
 
-    #deal with bad pixels
+    # Deal with bad pixels
     msgs.work("Need to mask bad pixels")
 
-    #deal with underlying continuum
+    # Deal with underlying continuum
     msgs.work("Consider taking median first [5 pixel]")
     everyn = obj_skyspec.npix // 20
     bspline_par = dict(everyn=everyn)
-    mask, ct = utils.robust_polyfit(obj_skyspec.wavelength.value, obj_skyspec.flux.value, 3, function='bspline',
-                                  sigma=3., bspline_par=bspline_par)# everyn=everyn)
+    mask, ct = utils.robust_polyfit(obj_skyspec.wavelength.value, obj_skyspec.flux.value, 3,
+                                    function='bspline', sigma=3., bspline_par=bspline_par)
     obj_sky_cont = utils.func_val(ct, obj_skyspec.wavelength.value, 'bspline')
     obj_sky_flux = obj_skyspec.flux.value - obj_sky_cont
-    mask, ct_arx = utils.robust_polyfit(arx_skyspec.wavelength.value, arx_skyspec.flux.value, 3, function='bspline',
-                                      sigma=3., bspline_par=bspline_par)# everyn=everyn)
+    mask, ct_arx = utils.robust_polyfit(arx_skyspec.wavelength.value, arx_skyspec.flux.value, 3,
+                                        function='bspline', sigma=3., bspline_par=bspline_par)
     arx_sky_cont = utils.func_val(ct_arx, arx_skyspec.wavelength.value, 'bspline')
     arx_sky_flux = arx_skyspec.flux.value - arx_sky_cont
 
-    # Consider shaprness filtering (e.g. LowRedux)
+    # Consider sharpness filtering (e.g. LowRedux)
     msgs.work("Consider taking median first [5 pixel]")
 
     #Cross correlation of spectra

--- a/pypeit/par/pypeitpar.py
+++ b/pypeit/par/pypeitpar.py
@@ -536,7 +536,6 @@ class FlexurePar(ParSet):
 
         # Fill out parameter specifications.  Only the values that are
         # *not* None (i.e., the ones that are defined) need to be set
-
         defaults['method'] = 'boxcar'
         options['method'] = FlexurePar.valid_methods()
         dtypes['method'] = str
@@ -1895,7 +1894,8 @@ class PypeItPar(ParSet):
     For a table with the current keywords, defaults, and descriptions,
     see :ref:`pypeitpar`.
     """
-    def __init__(self, rdx=None, calibrations=None, scienceframe=None, scienceimage=None, flexure=None, fluxcalib=None):
+    def __init__(self, rdx=None, calibrations=None, scienceframe=None, scienceimage=None,
+                 flexure=None, fluxcalib=None):
 
         # Grab the parameter names and values from the function
         # arguments

--- a/pypeit/pypeit.py
+++ b/pypeit/pypeit.py
@@ -649,7 +649,7 @@ class MultiSlit(PypeIt):
 
 
             # Flexure correction?
-            if self.par['flexure'] is not None and self.par['flexure']['method'] is not None:
+            if self.par['flexure'] is not None:
                 sky_file, sky_spectrum = self.spectrograph.archive_sky_spectrum()
                 flex_list = wave.flexure_obj(sobjs, maskslits, self.par['flexure']['method'],
                                              sky_spectrum, sky_file=sky_file,

--- a/pypeit/spectrographs/keck_nires.py
+++ b/pypeit/spectrographs/keck_nires.py
@@ -74,9 +74,8 @@ class KeckNIRESpectrograph(spectrograph.Spectrograph):
         par['scienceimage'] = pypeitpar.ScienceImagePar()
         # Always flux calibrate, starting with default parameters
         par['fluxcalib'] = pypeitpar.FluxCalibrationPar()
-        # Always correct for flexure, starting with default parameters
-        par['flexure'] = pypeitpar.FlexurePar()
-        par['flexure']['method'] = None
+        # Do not correct for flexure
+        par['flexure'] = None
         return par
 
     def nires_header_keys(self):

--- a/pypeit/tests/test_biasframe.py
+++ b/pypeit/tests/test_biasframe.py
@@ -122,3 +122,4 @@ def test_run_and_master(kast_blue_bias_files):
     assert np.array_equal(bias2, bias3)
 
 # Should probably test overscan
+

--- a/pypeit/tests/test_bpmimage.py
+++ b/pypeit/tests/test_bpmimage.py
@@ -66,7 +66,7 @@ def test_keck_lris_red():
     if skip_test:
         return
     example_file = os.path.join(os.getenv('PYPEIT_DEV'), 'RAW_DATA', 'Keck_LRIS_red',
-                                'long_600_7500_d560', 'LR.20160216.05529.fits')
+                                'long_600_7500_d560', 'LR.20160216.05529.fits.gz')
     # Simple
     bpmImage = bpmimage.BPMImage(spectrograph='keck_lris_red', filename=example_file, det=2)
     bpm = bpmImage.build()
@@ -75,8 +75,8 @@ def test_keck_lris_red():
 def test_keck_deimos():
     if skip_test:
         return
-    example_file = os.path.join(os.getenv('PYPEIT_DEV'), 'RAW_DATA', 'Keck_DEIMOS', '830G_L',
-                                'd0914_0002.fits')
+    example_file = os.path.join(os.getenv('PYPEIT_DEV'), 'RAW_DATA', 'Keck_DEIMOS', '830G_L_8400',
+                                'd0914_0002.fits.gz')
     # Simple
     bpmImage = bpmimage.BPMImage(spectrograph='keck_deimos', filename=example_file, det=4)
     bpm = bpmImage.build()

--- a/pypeit/tests/test_flatfield.py
+++ b/pypeit/tests/test_flatfield.py
@@ -37,29 +37,29 @@ def data_path(filename):
     data_dir = os.path.join(os.path.dirname(__file__), 'files')
     return os.path.join(data_dir, filename)
 
-def test_step_by_step():
-    if skip_test:
-        assert True
-        return
-    # Masters
-    spectrograph, TSlits, tilts, datasec_img \
-                = tstutils.load_kast_blue_masters(get_spectrograph=True, tslits=True, tilts=True,
-                                                  datasec=True)
-    # Instantiate
-    flatField = flatfield.FlatField(spectrograph=spectrograph, det=1, tilts=tilts,
-                                    tslits_dict=TSlits.tslits_dict.copy())
-    # Use mstrace
-    flatField.mspixelflat = TSlits.mstrace.copy()
-    # Normalize a slit
-    slit=0
-    flatField._prep_tck()
-    modvals, nrmvals, msblaze_slit, blazeext_slit, iextrap_slit = flatField.slit_profile(slit)
-    assert np.isclose(iextrap_slit, 0.)
-    # Apply
-    word = np.where(flatField.tslits_dict['slitpix'] == slit + 1)
-    flatField.mspixelflatnrm = flatField.mspixelflat.copy()
-    flatField.mspixelflatnrm[word] /= nrmvals
-    assert np.isclose(np.median(flatField.mspixelflatnrm), 1.0267346)
+#def test_step_by_step():
+#    if skip_test:
+#        assert True
+#        return
+#    # Masters
+#    spectrograph, TSlits, tilts, datasec_img \
+#                = tstutils.load_kast_blue_masters(get_spectrograph=True, tslits=True, tilts=True,
+#                                                  datasec=True)
+#    # Instantiate
+#    flatField = flatfield.FlatField(spectrograph, det=1, tilts=tilts,
+#                                    tslits_dict=TSlits.tslits_dict.copy())
+#    # Use mstrace
+#    flatField.mspixelflat = TSlits.mstrace.copy()
+#    # Normalize a slit
+#    slit=0
+#    flatField._prep_tck()
+#    modvals, nrmvals, msblaze_slit, blazeext_slit, iextrap_slit = flatField.slit_profile(slit)
+#    assert np.isclose(iextrap_slit, 0.)
+#    # Apply
+#    word = np.where(flatField.tslits_dict['slitpix'] == slit + 1)
+#    flatField.mspixelflatnrm = flatField.mspixelflat.copy()
+#    flatField.mspixelflatnrm[word] /= nrmvals
+#    assert np.isclose(np.median(flatField.mspixelflatnrm), 1.0267346)
 
 def test_run():
     if skip_test:
@@ -74,7 +74,6 @@ def test_run():
                                     tslits_dict=TSlits.tslits_dict.copy())
     # Use mstrace
     flatField.rawflatimg = TSlits.mstrace.copy()
-    mspixelflatnrm, slitprofiles = flatField.run()
-    assert np.isclose(np.median(mspixelflatnrm), 0.98186201)
-
+    mspixelflatnrm, msillumflat = flatField.run()
+    assert np.isclose(np.median(mspixelflatnrm), 1.0)
 

--- a/pypeit/tests/test_flexure.py
+++ b/pypeit/tests/test_flexure.py
@@ -31,7 +31,21 @@ def test_flex_shift():
     arx_file = pypeit.__path__[0]+'/data/sky_spec/sky_LRISb_600.fits'
     arx_spec = readspec(arx_file)
     # Call
-    flex_dict = wave.flex_shift(obj_spec, arx_spec)
-    assert np.abs(flex_dict['shift'] - 15.7) < 0.1
+    flex_dict = wave.flex_shift(obj_spec, arx_spec, mxshft=60)
 
+#    # Apply
+#    from scipy import interpolate
+#    print(flex_dict['shift'])
+#    npix = len(obj_spec.wavelength)
+#    x = np.linspace(0., 1., npix)
+#    f = interpolate.interp1d(x, obj_spec.wavelength.value, bounds_error=False,
+#                             fill_value="extrapolate")
+#    new_wave = f(x+flex_dict['shift']/(npix-1))
+#
+#    from matplotlib import pyplot
+#    pyplot.plot(arx_spec.wavelength, arx_spec.flux)
+#    pyplot.plot(obj_spec.wavelength, obj_spec.flux)
+#    pyplot.plot(new_wave, obj_spec.flux)
+#    pyplot.show()
+    assert np.abs(flex_dict['shift'] - 43.7) < 0.1
 

--- a/pypeit/tests/test_fluxspec.py
+++ b/pypeit/tests/test_fluxspec.py
@@ -117,3 +117,4 @@ def test_script(kast_blue_files, deimos_files):
                                '--sensfunc_file={:s}'.format(data_path('tmp2.yaml')),
                                '--multi_det=3,7'])
     flux_spec.main(pargs3)
+

--- a/pypeit/tests/test_opticalmodel.py
+++ b/pypeit/tests/test_opticalmodel.py
@@ -35,7 +35,7 @@ def test_deimos_distortion():
 def test_deimos_mask_coordinates():
     if skip_test:
         return
-    f = os.path.join(os.environ['PYPEIT_DEV'], 'RAW_DATA', 'Keck_DEIMOS', '830G_M',
+    f = os.path.join(os.environ['PYPEIT_DEV'], 'RAW_DATA', 'Keck_DEIMOS', '830G_M_8500',
                      'DE.20100913.22358.fits.gz')
     spec = KeckDEIMOSSpectrograph()
     spec.get_grating(f)
@@ -50,7 +50,7 @@ def test_deimos_mask_coordinates():
 def test_deimos_ccd_slits():
     if skip_test:
         return
-    f = os.path.join(os.environ['PYPEIT_DEV'], 'RAW_DATA', 'Keck_DEIMOS', '830G_M',
+    f = os.path.join(os.environ['PYPEIT_DEV'], 'RAW_DATA', 'Keck_DEIMOS', '830G_M_8500',
                      'DE.20100913.22358.fits.gz')
     spec = KeckDEIMOSSpectrograph()
     ximg, yimg, ccd, xpix, ypix = spec.mask_to_pixel_coordinates(filename=f)
@@ -61,4 +61,5 @@ def test_deimos_ccd_slits():
             'Should find slits on all CCDs'
     assert numpy.sum(n_per_ccd) == 106, 'Should return coordinates for all 106 slits'
     assert n_per_ccd[1] == 11, 'Incorrect number of slits on CCD 1'
+
 

--- a/pypeit/tests/test_processimages.py
+++ b/pypeit/tests/test_processimages.py
@@ -26,8 +26,8 @@ def deimos_flat_files():
     if not skip_test:
         # Longslit in dets 3,7
         deimos_flat_files = [os.path.join(os.getenv('PYPEIT_DEV'), 'RAW_DATA', 'Keck_DEIMOS',
-                                          '830G_L', ifile) 
-                                            for ifile in ['d0914_0014.fits', 'd0914_0015.fits']]
+                                          '830G_L_8400', ifile) 
+                                    for ifile in ['d0914_0014.fits.gz', 'd0914_0015.fits.gz']]
         assert len(deimos_flat_files) == 2
     else:
         deimos_flat_files = None
@@ -99,3 +99,4 @@ def test_combine(deimos_flat_files):
     # Test
     assert isinstance(deimos_flats.stack, np.ndarray)
     assert deimos_flats.stack.shape == (4096,2048)
+

--- a/pypeit/tests/test_save.py
+++ b/pypeit/tests/test_save.py
@@ -62,7 +62,7 @@ def test_save2d_fits():
     head0 = fits.getheader(data_path('spec2d_test.fits'))
     assert head0['PYPCNFIG'] == 'A'
     assert head0['PYPCALIB'] == 'aa'
-    assert 'PYPIT' in head0['PIPELINE']
+    assert 'PYPEIT' in head0['PIPELINE']
 
 
 def test_save1d_fits():
@@ -76,17 +76,17 @@ def test_save1d_fits():
     save.save_1d_spectra_fits(specObjs, fitstbl[5], data_path('tst.fits'))
 
 
-'''  # NEEDS REFACTORING
-def test_save1d_hdf5():
-    """ save1d to FITS and HDF5
-    """
-    # Dummy self
-    fitstbl = arsort.dummy_fitstbl(spectrograph='shane_kast_blue', directory=data_path(''))
-    slf = arsciexp.dummy_self(fitstbl=fitstbl)
-    # specobj
-    slf._specobjs = []
-    slf._specobjs.append([])
-    slf._specobjs[0].append([mk_specobj(objid=455), mk_specobj(flux=3., objid=555)])
-    # Write to HDF5
-    arsave.save_1d_spectra_hdf5(slf, fitstbl)
-'''
+# NEEDS REFACTORING
+#def test_save1d_hdf5():
+#    """ save1d to FITS and HDF5
+#    """
+#    # Dummy self
+#    fitstbl = arsort.dummy_fitstbl(spectrograph='shane_kast_blue', directory=data_path(''))
+#    slf = arsciexp.dummy_self(fitstbl=fitstbl)
+#    # specobj
+#    slf._specobjs = []
+#    slf._specobjs.append([])
+#    slf._specobjs[0].append([mk_specobj(objid=455), mk_specobj(flux=3., objid=555)])
+#    # Write to HDF5
+#    arsave.save_1d_spectra_hdf5(slf, fitstbl)
+

--- a/pypeit/tests/test_slitmask.py
+++ b/pypeit/tests/test_slitmask.py
@@ -20,7 +20,7 @@ else:
 def test_deimosslitmask():
     if skip_test:
         return
-    f = os.path.join(os.environ['PYPEIT_DEV'], 'RAW_DATA', 'Keck_DEIMOS', '830G_M',
+    f = os.path.join(os.environ['PYPEIT_DEV'], 'RAW_DATA', 'Keck_DEIMOS', '830G_M_8500',
                      'DE.20100913.22358.fits.gz')
     spec = KeckDEIMOSSpectrograph()
     spec.get_slitmask(f)

--- a/pypeit/tests/test_spectrographs.py
+++ b/pypeit/tests/test_spectrographs.py
@@ -23,7 +23,7 @@ def test_keckdeimos():
     if skip_test:
         return
     example_file = os.path.join(os.environ['PYPEIT_DEV'], 'RAW_DATA', 'Keck_DEIMOS',
-                                '830G_L', 'd0914_0002.fits')
+                                '830G_L_8400', 'd0914_0002.fits.gz')
     if not os.path.isfile(example_file):
         raise FileNotFoundError('Could not find example file for Keck DEIMOS read.')
     data, _ = s.load_raw_frame(example_file)
@@ -49,7 +49,7 @@ def test_kecklrisred():
     if skip_test:
         return
     example_file = os.path.join(os.environ['PYPEIT_DEV'], 'RAW_DATA', 'Keck_LRIS_red',
-                                'long_600_7500_d560', 'LR.20160216.05529.fits')
+                                'long_600_7500_d560', 'LR.20160216.05529.fits.gz')
     if not os.path.isfile(example_file):
         raise FileNotFoundError('Could not find example file for Keck LRIS Red read.')
     data, _ = s.load_raw_frame(example_file)

--- a/pypeit/tests/test_traceimage.py
+++ b/pypeit/tests/test_traceimage.py
@@ -29,8 +29,8 @@ def data_path(filename):
 def deimos_flat_files():
     if not skip_test:
         deimos_flat_files = [os.path.join(os.getenv('PYPEIT_DEV'), 'RAW_DATA', 'Keck_DEIMOS',
-                                          '830G_L', ifile)
-                                for ifile in ['d0914_0014.fits', 'd0914_0015.fits']]
+                                          '830G_L_8400', ifile)
+                                for ifile in ['d0914_0014.fits.gz', 'd0914_0015.fits.gz']]
     else:
         deimos_flat_files = None
     return deimos_flat_files

--- a/pypeit/tests/test_wavecalib.py
+++ b/pypeit/tests/test_wavecalib.py
@@ -245,3 +245,4 @@ def test_wavecalib_general():
 #            grade = False
 #            print("Solution for {:s} failed N match!!".format(name))
         assert grade
+


### PR DESCRIPTION
Sorry that this is coming long after you asked me to look at this.

This turns off the flexure correction for Keck NIRES in the default pypeit parameters.  As it is, you effectively can't set any parameter to `None` unless it is also `None` by default.  We can change this, but it may have pretty significant follow-on effects for the general implementation of the parameter sets.  To turn the flexure off, you just have to set the entire ParSet to None.

This needs to be tested to make sure the behavior is as expected, but I hope this fixes the problem.