### PR TITLE
Adjustments to par['calibrations']['slits']  for XSHOOTER NIR

### DIFF
--- a/pypeit/spectrographs/vlt_xshooter.py
+++ b/pypeit/spectrographs/vlt_xshooter.py
@@ -174,10 +174,10 @@ class VLTXShooterNIRSpectrograph(VLTXShooterSpectrograph):
         par['rdx']['spectrograph'] = 'vlt_xshooter_nir'
 
         # Adjustments to slit and tilts for NIR
-        par['calibrations']['slits']['sigdetect'] = 700.
+        par['calibrations']['slits']['sigdetect'] = 600.
         par['calibrations']['slits']['polyorder'] = 5
         par['calibrations']['slits']['maxshift'] = 0.5
-        par['calibrations']['slits']['pcatype'] = 'pixel'
+        par['calibrations']['slits']['pcatype'] = 'order'
         par['calibrations']['tilts']['tracethresh'] = [10,10,10,10,10,10,10,10,10, 10, 10, 20, 20, 20,20,10]
 
 


### PR DESCRIPTION
This is the smallest PR ever (only 6 characters changed) to tweak xshooter NIR par for order finding. In this way we loose some precision on the last order, but we manage to get the first one that was previously missed.

![xshooter_nirslits](https://user-images.githubusercontent.com/30442285/48547310-28ee5a00-e87f-11e8-9cb0-55e24b553ccb.png)
