### PR TITLE
Bad pixel mask for DEIMOS + LACosmics adjustments

### DIFF
--- a/pypeit/par/pypeitpar.py
+++ b/pypeit/par/pypeitpar.py
@@ -280,7 +280,7 @@ class ProcessImagesPar(ParSet):
         dtypes['sigfrac'] = [int, float]
         descr['sigfrac'] = 'Fraction for the lower clipping threshold in LA cosmics routine.'
 
-        defaults['objlim'] = 2.5
+        defaults['objlim'] = 3.0
         dtypes['objlim'] = [int, float]
         descr['objlim'] = 'Object detection limit in LA cosmics routine'
 

--- a/pypeit/par/pypeitpar.py
+++ b/pypeit/par/pypeitpar.py
@@ -272,7 +272,7 @@ class ProcessImagesPar(ParSet):
         dtypes['rmcompact'] = bool
         descr['rmcompact'] = 'Remove compact detections in LA cosmics routine'
 
-        defaults['sigclip'] = 5.0
+        defaults['sigclip'] = 4.5
         dtypes['sigclip'] = [int, float]
         descr['sigclip'] = 'Sigma level for rejection in LA cosmics routine'
 
@@ -280,7 +280,7 @@ class ProcessImagesPar(ParSet):
         dtypes['sigfrac'] = [int, float]
         descr['sigfrac'] = 'Fraction for the lower clipping threshold in LA cosmics routine.'
 
-        defaults['objlim'] = 5.0
+        defaults['objlim'] = 1.0
         dtypes['objlim'] = [int, float]
         descr['objlim'] = 'Object detection limit in LA cosmics routine'
 

--- a/pypeit/par/pypeitpar.py
+++ b/pypeit/par/pypeitpar.py
@@ -272,7 +272,7 @@ class ProcessImagesPar(ParSet):
         dtypes['rmcompact'] = bool
         descr['rmcompact'] = 'Remove compact detections in LA cosmics routine'
 
-        defaults['sigclip'] = 5.0
+        defaults['sigclip'] = 4.5
         dtypes['sigclip'] = [int, float]
         descr['sigclip'] = 'Sigma level for rejection in LA cosmics routine'
 
@@ -280,7 +280,7 @@ class ProcessImagesPar(ParSet):
         dtypes['sigfrac'] = [int, float]
         descr['sigfrac'] = 'Fraction for the lower clipping threshold in LA cosmics routine.'
 
-        defaults['objlim'] = 5.0
+        defaults['objlim'] = 2.5
         dtypes['objlim'] = [int, float]
         descr['objlim'] = 'Object detection limit in LA cosmics routine'
 

--- a/pypeit/par/pypeitpar.py
+++ b/pypeit/par/pypeitpar.py
@@ -272,7 +272,7 @@ class ProcessImagesPar(ParSet):
         dtypes['rmcompact'] = bool
         descr['rmcompact'] = 'Remove compact detections in LA cosmics routine'
 
-        defaults['sigclip'] = 4.5
+        defaults['sigclip'] = 5.0
         dtypes['sigclip'] = [int, float]
         descr['sigclip'] = 'Sigma level for rejection in LA cosmics routine'
 
@@ -280,7 +280,7 @@ class ProcessImagesPar(ParSet):
         dtypes['sigfrac'] = [int, float]
         descr['sigfrac'] = 'Fraction for the lower clipping threshold in LA cosmics routine.'
 
-        defaults['objlim'] = 1.0
+        defaults['objlim'] = 5.0
         dtypes['objlim'] = [int, float]
         descr['objlim'] = 'Object detection limit in LA cosmics routine'
 

--- a/pypeit/processimages.py
+++ b/pypeit/processimages.py
@@ -366,14 +366,15 @@ class ProcessImages(object):
         # Run LA Cosmic to get the cosmic ray mask
         saturation = self.spectrograph.detector[self.det-1]['saturation']
         nonlinear = self.spectrograph.detector[self.det-1]['nonlinear']
+        sigclip, objlim = self.spectrograph.get_lacosmics_par(self.proc_par,binning=self.fitstbl['binning'][0])
         self.crmask = procimg.lacosmic(self.det, self.stack, saturation, nonlinear,
                                          varframe=varframe, maxiter=self.proc_par['lamaxiter'],
                                          grow=self.proc_par['grow'],
                                          remove_compact_obj=self.proc_par['rmcompact'],
-                                         sigclip=self.proc_par['sigclip'],
+                                         sigclip=sigclip,
                                          sigfrac=self.proc_par['sigfrac'],
-                                         objlim=self.proc_par['objlim'])
-
+                                         objlim=objlim)
+                            
         # Step
         self.steps.append(inspect.stack()[0][3])
         # Return

--- a/pypeit/spectrographs/keck_deimos.py
+++ b/pypeit/spectrographs/keck_deimos.py
@@ -233,6 +233,10 @@ class KeckDEIMOSSpectrograph(spectrograph.Spectrograph):
         par['calibrations']['pixelflatframe']['exprng'] = [None, 30]
         par['calibrations']['traceframe']['exprng'] = [None, 30]
         par['scienceframe']['exprng'] = [30, None]
+        
+        # LACosmics parameters
+        par['scienceframe']['process']['sigclip'] = 4.5
+        par['scienceframe']['process']['objlim'] = 2.0
 
         return par
 

--- a/pypeit/spectrographs/keck_deimos.py
+++ b/pypeit/spectrographs/keck_deimos.py
@@ -494,20 +494,40 @@ class KeckDEIMOSSpectrograph(spectrograph.Spectrograph):
             self.bpm_img[:,1052:1054] = 1
         elif det == 2:
             self.bpm_img[:,0:4] = 1
-            self.bpm_img[:,376:380] = 1
+            self.bpm_img[:,376:381] = 1
+            self.bpm_img[:,489] = 1
+            self.bpm_img[:,1333:1335] = 1
             self.bpm_img[:,2047] = 1
         elif det == 3:
+            self.bpm_img[:,221] = 1
+            self.bpm_img[:,260] = 1
+            self.bpm_img[:,366] = 1
+            self.bpm_img[:,816:819] = 1
             self.bpm_img[:,851] = 1
+            self.bpm_img[:,940] = 1
+            self.bpm_img[:,1167] = 1
+            self.bpm_img[:,1280] = 1
+            self.bpm_img[:,1301:1303] = 1
+            self.bpm_img[:,1744:1747] = 1
         elif det == 4:
             self.bpm_img[:,0:4] = 1
-            self.bpm_img[:,997:998] = 1
+            self.bpm_img[:,47] = 1
+            self.bpm_img[:,744] = 1
+            self.bpm_img[:,790:792] = 1
+            self.bpm_img[:,997:999] = 1
         elif det == 5:
-            self.bpm_img[:,129] = 1
+            self.bpm_img[:,25:27] = 1
+            self.bpm_img[:,128:130] = 1
+            self.bpm_img[:,1535:1539] = 1
         elif det == 7:
             self.bpm_img[:,426:428] = 1
+            self.bpm_img[:,676] = 1
+            self.bpm_img[:,1176:1178] = 1
         elif det == 8:
-            self.bpm_img[:,931] = 1
-            self.bpm_img[:,933] = 1
+            self.bpm_img[:,440] = 1
+            self.bpm_img[:,509:513] = 1
+            self.bpm_img[:,806] = 1
+            self.bpm_img[:,931:934] = 1
 
         return self.bpm_img
 

--- a/pypeit/spectrographs/keck_deimos.py
+++ b/pypeit/spectrographs/keck_deimos.py
@@ -235,8 +235,8 @@ class KeckDEIMOSSpectrograph(spectrograph.Spectrograph):
         par['scienceframe']['exprng'] = [30, None]
         
         # LACosmics parameters
-        par['scienceframe']['process']['sigclip'] = 4.5
-        par['scienceframe']['process']['objlim'] = 2.0
+        par['scienceframe']['process']['sigclip'] = 4.0
+        par['scienceframe']['process']['objlim'] = 1.5
 
         return par
 

--- a/pypeit/spectrographs/keck_lris.py
+++ b/pypeit/spectrographs/keck_lris.py
@@ -452,8 +452,6 @@ class KeckLRISRSpectrograph(KeckLRISSpectrograph):
         else:
             sigclip = proc_par['sigclip']
             objlim = proc_par['objlim']
-        from IPython import embed
-        embed()
         return sigclip, objlim
         
     def check_headers(self, headers):

--- a/pypeit/spectrographs/keck_lris.py
+++ b/pypeit/spectrographs/keck_lris.py
@@ -437,13 +437,13 @@ class KeckLRISRSpectrograph(KeckLRISSpectrograph):
         return par
     
     def get_lascosmics_par(self,binning='1x1'):
-        # Good LACosmics parameters depends strongly on binning.
+        # Unbinned LRISr needs very aggressive LACosmics parameters.
         if binning is '1x1':
             sigclip = 3.0
             objlim = 0.5
         else:
             sigclip = 5.0
-            objlim = 3.0
+            objlim = 5.0
         return sigclip, objlim
         
     def check_headers(self, headers):

--- a/pypeit/spectrographs/keck_lris.py
+++ b/pypeit/spectrographs/keck_lris.py
@@ -436,14 +436,22 @@ class KeckLRISRSpectrograph(KeckLRISSpectrograph):
         
         return par
     
-    def get_lascosmics_par(self,binning='1x1'):
-        # Unbinned LRISr needs very aggressive LACosmics parameters.
-        if binning is '1x1':
-            sigclip = 3.0
-            objlim = 0.5
+    def get_lascosmics_par(proc_par,binning='1x1'):
+        par = self.default_pypeit_par()
+        default_sigclip = par['scienceframe']['process']['sigclip']
+        default_objlim = par['scienceframe']['process']['objlim']
+        # Check whether the user has changed the parameters.
+        if [proc_par['sigclip'],proc_par['objlim']] is [default_sigclip,default_objlim]:
+            # Unbinned LRISr needs very aggressive LACosmics parameters.
+            if binning is '1x1':
+                sigclip = 3.0
+                objlim = 0.5
+            else:
+                sigclip = 5.0
+                objlim = 5.0
         else:
-            sigclip = 5.0
-            objlim = 5.0
+            sigclip = default_sigclip
+            objlim = default_objlim
         return sigclip, objlim
         
     def check_headers(self, headers):

--- a/pypeit/spectrographs/keck_lris.py
+++ b/pypeit/spectrographs/keck_lris.py
@@ -433,11 +433,19 @@ class KeckLRISRSpectrograph(KeckLRISSpectrograph):
         par['calibrations']['wavelengths']['nonlinear_counts'] = self.detector[0]['nonlinear'] * self.detector[0]['saturation']
         par['calibrations']['wavelengths']['min_nsig'] = 10.0
         par['calibrations']['wavelengths']['lowest_nsig'] =5.0
-
-
-
+        
         return par
-
+    
+    def get_lascosmics_par(self,binning='1x1'):
+        # Good LACosmics parameters depends strongly on binning.
+        if binning is '1x1':
+            sigclip = 3.0
+            objlim = 0.5
+        else:
+            sigclip = 5.0
+            objlim = 3.0
+        return sigclip, objlim
+        
     def check_headers(self, headers):
         """
         Check headers match expectations for an LRISr exposure.

--- a/pypeit/spectrographs/keck_lris.py
+++ b/pypeit/spectrographs/keck_lris.py
@@ -436,12 +436,12 @@ class KeckLRISRSpectrograph(KeckLRISSpectrograph):
         
         return par
     
-    def get_lascosmics_par(proc_par,binning='1x1'):
+    def get_lacosmics_par(self,proc_par,binning='1x1'):
         par = self.default_pypeit_par()
         default_sigclip = par['scienceframe']['process']['sigclip']
         default_objlim = par['scienceframe']['process']['objlim']
         # Check whether the user has changed the parameters.
-        if [proc_par['sigclip'],proc_par['objlim']] is [default_sigclip,default_objlim]:
+        if (proc_par['sigclip'] == default_sigclip) and (proc_par['objlim'] == default_objlim):
             # Unbinned LRISr needs very aggressive LACosmics parameters.
             if binning is '1x1':
                 sigclip = 3.0
@@ -450,8 +450,10 @@ class KeckLRISRSpectrograph(KeckLRISSpectrograph):
                 sigclip = 5.0
                 objlim = 5.0
         else:
-            sigclip = default_sigclip
-            objlim = default_objlim
+            sigclip = proc_par['sigclip']
+            objlim = proc_par['objlim']
+        from IPython import embed
+        embed()
         return sigclip, objlim
         
     def check_headers(self, headers):

--- a/pypeit/spectrographs/spectrograph.py
+++ b/pypeit/spectrographs/spectrograph.py
@@ -87,12 +87,10 @@ class Spectrograph(object):
     def default_pypeit_par():
         return pypeitpar.PypeItPar()
     
-    def get_lacosmics_par(self,binning=None):
+    def get_lacosmics_par(proc_par,binning=None):
         # Workaround to make these parameters a function of binning for LRIS.
-        # Set parameters to default values.
-        par = self.default_pypeit_par()
-        sigclip = par['scienceframe']['process']['sigclip']
-        objlim = par['scienceframe']['process']['objlim']
+        sigclip = proc_par['sigclip']
+        objlim = proc_par['objlim']
         return sigclip, objlim
 
     def _check_telescope(self):

--- a/pypeit/spectrographs/spectrograph.py
+++ b/pypeit/spectrographs/spectrograph.py
@@ -87,7 +87,7 @@ class Spectrograph(object):
     def default_pypeit_par():
         return pypeitpar.PypeItPar()
     
-    def get_lacosmics_par(proc_par,binning=None):
+    def get_lacosmics_par(self,proc_par,binning=None):
         # Workaround to make these parameters a function of binning for LRIS.
         sigclip = proc_par['sigclip']
         objlim = proc_par['objlim']

--- a/pypeit/spectrographs/spectrograph.py
+++ b/pypeit/spectrographs/spectrograph.py
@@ -86,6 +86,14 @@ class Spectrograph(object):
     @staticmethod
     def default_pypeit_par():
         return pypeitpar.PypeItPar()
+    
+    def get_lacosmics_par(self,binning=None):
+        # Workaround to make these parameters a function of binning for LRIS.
+        # Set parameters to default values.
+        par = self.default_pypeit_par()
+        sigclip = par['scienceframe']['process']['sigclip']
+        objlim = par['scienceframe']['process']['objlim']
+        return sigclip, objlim
 
     def _check_telescope(self):
         # Check the detector


### PR DESCRIPTION
Fleshes out the DEIMOS bad pixel mask after hunting for bad columns on all detectors across a few different exposures.

Also starts to adjust LACosmics parameters for different instruments. Particularly, setting `objlim` to lower values greatly improves the cosmic ray rejection for DEIMOS and LRIS red with no adverse effects. The latter is quite sensitive to the binning on the detector, however, so some additional functionality was added to use different parameter values depending on the binning.

I also made the global default parameters modestly more aggressive, which seems to work well for various instruments on the dev suite. But, it's probably worth a closer look. See Figure 4 in http://adsabs.harvard.edu/abs/2001PASP..113.1420V -- the previous default `objlim=5` is more tuned towards heavily undersampled data (a la HST imaging), but I don't know how exactly that translates to spectra.