### PR TITLE
fix near-IR differencing,  revamp processimages, optimal breakpoints, starting coadd2d functionality. 

### DIFF
--- a/pypeit/core/extract.py
+++ b/pypeit/core/extract.py
@@ -2042,6 +2042,9 @@ def ech_objfind(image, ivar, slitmask, slit_left, slit_righ, inmask=None, fof_li
       Skymask indicating which pixels can be used for global sky subtraction
     """
 
+
+    debug=True
+    show_peaks=True
     if specobj_dict is None:
         specobj_dict = {'setup': 'unknown', 'slitid': 999, 'det': 1, 'objtype': 'unknown', 'pypeline': 'Echelle'}
 
@@ -2182,7 +2185,6 @@ def ech_objfind(image, ivar, slitmask, slit_left, slit_righ, inmask=None, fof_li
                 spec.ech_objid = uni_obj_id[iobj]
                 spec.objid = uni_obj_id[iobj]
                 spec.ech_frac_was_fit = False
-
 
     # Now loop over objects and fill in the missing objects and their traces. We will fit the fraction slit position of
     # the good orders where an object was found and use that fit to predict the fractional slit position on the bad orders

--- a/pypeit/core/extract.py
+++ b/pypeit/core/extract.py
@@ -2042,9 +2042,6 @@ def ech_objfind(image, ivar, slitmask, slit_left, slit_righ, inmask=None, fof_li
       Skymask indicating which pixels can be used for global sky subtraction
     """
 
-
-    debug=True
-    show_peaks=True
     if specobj_dict is None:
         specobj_dict = {'setup': 'unknown', 'slitid': 999, 'det': 1, 'objtype': 'unknown', 'pypeline': 'Echelle'}
 

--- a/pypeit/core/extract.py
+++ b/pypeit/core/extract.py
@@ -1464,6 +1464,7 @@ def objfind(image, thismask, slit_left, slit_righ, inmask = None, fwhm = 3.0,
         fluxsub = flux_mean - np.median(flux_mean)
     else:
         kernel_size= int(np.ceil(bg_smth*fwhm) // 2 * 2 + 1) # This ensure kernel_size is odd
+        # TODO should we be using  scipy.ndimage.filters.median_filter to better control the boundaries?
         fluxsub = flux_mean - scipy.signal.medfilt(flux_mean, kernel_size=kernel_size)
         # This little bit below deals with degenerate cases for which the slit gets brighter toward the edge, i.e. when
         # alignment stars saturate and bleed over into other slits. In this case the median smoothed profile is the nearly

--- a/pypeit/core/extract.py
+++ b/pypeit/core/extract.py
@@ -43,8 +43,6 @@ from pypeit.core.pydl import spheregroup
 
 mask_flags = dict(bad_pix=2**0, CR=2**1, NAN=2**5, bad_row=2**6)
 
-import multiprocessing
-
 
 def extract_asymbox2(image,left_in,right_in,ycen = None,weight_image = None):
     """ Extract the total flux within a variable window at many positions. This routine will accept an asymmetric/variable window

--- a/pypeit/core/flat.py
+++ b/pypeit/core/flat.py
@@ -487,7 +487,8 @@ def flatfield(sciframe, flatframe, bpix, illum_flat=None, snframe=None, varframe
 
     # Fold in the slit profile
     if illum_flat is not None:
-        msgs.info('Dividing by illumination flat')
+        if np.any(illum_flat != 1.0):
+            msgs.info('Dividing by illumination flat')
         flatframe *= illum_flat
 
     # New image
@@ -1206,61 +1207,61 @@ def sn_frame(slf, sciframe, idx):
     return snframe
 '''
 
-
-def flatfield(sciframe, flatframe, bpix, illum_flat=None, snframe=None, varframe=None):
-    """ Flat field the input image
-
-    .. todo::
-        - Is bpix required?
-
-    Parameters
-    ----------
-    sciframe : 2d image
-    flatframe : 2d image
-    illum_flat : 2d image, optional
-      slit profile image
-    snframe : 2d image, optional
-    det : int
-      Detector index
-    varframe : ndarray
-      variance image
-
-    Returns
-    -------
-    flat-field image
-    and updated sigma array if snframe is input
-    or updated variance array if varframe is input
-
-    """
-    if (varframe is not None) & (snframe is not None):
-        msgs.error("Cannot set both varframe and snframe")
-
-    # Fold in the slit profile
-    if illum_flat is not None:
-        msgs.info('Dividing by illumination flat')
-        flatframe *= illum_flat
-
-    # New image
-    retframe = np.zeros_like(sciframe)
-    w = np.where(flatframe > 0.0)
-    retframe[w] = sciframe[w]/flatframe[w]
-    if w[0].size != flatframe.size:
-        ww = np.where(flatframe <= 0.0)
-        bpix[ww] = 1.0
-    # Variance?
-    if varframe is not None:
-        # This is risky -- Be sure your flat is well behaved!!
-        retvar = np.zeros_like(sciframe)
-        retvar[w] = varframe[w]/flatframe[w]**2
-        return retframe, retvar
-    # Error image
-    if snframe is None:
-        return retframe
-    else:
-        errframe = np.zeros_like(sciframe)
-        wnz = np.where(snframe>0.0)
-        errframe[wnz] = retframe[wnz]/snframe[wnz]
-        return retframe, errframe
+#
+# def flatfield(sciframe, flatframe, bpix, illum_flat=None, snframe=None, varframe=None):
+#     """ Flat field the input image
+#
+#     .. todo::
+#         - Is bpix required?
+#
+#     Parameters
+#     ----------
+#     sciframe : 2d image
+#     flatframe : 2d image
+#     illum_flat : 2d image, optional
+#       slit profile image
+#     snframe : 2d image, optional
+#     det : int
+#       Detector index
+#     varframe : ndarray
+#       variance image
+#
+#     Returns
+#     -------
+#     flat-field image
+#     and updated sigma array if snframe is input
+#     or updated variance array if varframe is input
+#
+#     """
+#     if (varframe is not None) & (snframe is not None):
+#         msgs.error("Cannot set both varframe and snframe")
+#
+#     # Fold in the slit profile
+#     if illum_flat is not None:
+#         msgs.info('Dividing by illumination flat')
+#         flatframe *= illum_flat
+#
+#     # New image
+#     retframe = np.zeros_like(sciframe)
+#     w = np.where(flatframe > 0.0)
+#     retframe[w] = sciframe[w]/flatframe[w]
+#     if w[0].size != flatframe.size:
+#         ww = np.where(flatframe <= 0.0)
+#         bpix[ww] = 1.0
+#     # Variance?
+#     if varframe is not None:
+#         # This is risky -- Be sure your flat is well behaved!!
+#         retvar = np.zeros_like(sciframe)
+#         retvar[w] = varframe[w]/flatframe[w]**2
+#         return retframe, retvar
+#     # Error image
+#     if snframe is None:
+#         return retframe
+#     else:
+#         errframe = np.zeros_like(sciframe)
+#         wnz = np.where(snframe>0.0)
+#         errframe[wnz] = retframe[wnz]/snframe[wnz]
+#         return retframe, errframe
 
 
 '''

--- a/pypeit/core/procimg.py
+++ b/pypeit/core/procimg.py
@@ -2,19 +2,111 @@
 """
 from __future__ import (print_function, absolute_import, division, unicode_literals)
 
-import time
-
+import astropy.stats
 import numpy as np
-import os
-
 from scipy import signal, ndimage
-
 from pypeit import msgs
-
 from pypeit import utils
 from pypeit.core import parse
 
-from pypeit import debugger
+"""
+
+Args:
+    weights: ndarray, float shape (nimgs)
+    sciimg_stack: ndarray, float, shape (nimgs, nspec, nspat)
+        Array of science images
+    sciivar_stack: ndarray, float, shape (nimgs, nspec, nspat)
+        Array of inverse variance images
+    rn2img_stack:  ndarray, float, shape (nimgs, nspec, nspat)
+        Array of effective read noise squred images (i.e. RN^2, digitization noise, dark current)
+    inmask_stack: ndarray, boolean, shape (nimgs, nspec, nspat)
+        Array of input masks for the images. True = Good, False=Bad
+
+Returns:
+"""
+
+def weighted_combine(weights, sciimg_stack, sciivar_stack, rn2img_stack, inmask_stack,
+                     sigma_clip=False, sigrej=None, maxiters=5):
+    """
+
+    Args:
+        weights: ndarray, float shape (nimgs)
+        sciimg_stack: ndarray, float, shape (nimgs, nspec, nspat)
+            Array of science images
+        sciivar_stack: ndarray, float, shape (nimgs, nspec, nspat)
+            Array of inverse variance images
+        rn2img_stack:  ndarray, float, shape (nimgs, nspec, nspat)
+            Array of effective read noise squred images (i.e. RN^2, digitization noise, dark current)
+        inmask_stack: ndarray, boolean, shape (nimgs, nspec, nspat)
+            Array of input masks for the images. True = Good, False=Bad
+        sigma_clip: bool, default = False
+            Combine with a mask by sigma clipping the image stack. Only valid if nimgs > 2
+        sigrej: int or float, default = None
+            Rejection threshold for sigma clipping. Code defaults to determining this automatically based
+            on the numberr of images provided.
+        maxiters:
+            Maximum number of iterations for sigma clipping using astropy.stats.SigmaClip
+
+    Returns:
+        sciimg: float ndarray, shape (nspec, nspat)
+           Scince image
+        sciivar: float ndarray, shape (nspec, nspat)
+           Propagated inverse variance image
+        rn2img:  float ndarray, shape (nspec, nspat)
+           Propagated rn2img
+        outmask: bool ndarray, shape (nspec, nspat)
+           Mask for combined image. True=Good, False=Bad
+    """
+
+    if sciimg_stack.ndim == 3:
+        nimgs = sciimg_stack.shape[0]
+    elif sciimg_stack.ndim == 2:
+        nimgs = 1
+    else:
+        msgs.error('Invalid size for image stacks')
+
+    if nimgs < 2:
+        msgs.error('Cannot combine a single image')
+
+    if sigma_clip and nimgs < 3:
+        msgs.warn('Sigma clipping requested, but you cannot sigma clip with less than 3 images. '
+                  'Proceeding without sigma clipping')
+
+    if sigma_clip and self.nsci >= 3:
+        msgs.error('Sigma clipping is not yet supported')
+        if sigrej is None:
+            if nimgs <= 2:
+                sigrej = 100.0  # Irrelevant for only 1 or 2 files, we don't sigma clip below
+            elif nimgs == 3:
+                sigrej = 1.1
+            elif nimgs == 4:
+                sigrej = 1.3
+            elif nimgs == 5:
+                sigrej = 1.6
+            elif nimgs == 6:
+                sigrej = 1.9
+            else:
+                sigrej = 2.0
+        # sigma clip if we have enough images
+        # mask_stack > 0 is a masked value. numpy masked arrays are True for masked (bad) values
+        data = np.ma.MaskedArray(sciimg_stack, np.invert(inmask_stack))
+        sigclip = astropy.stats.SigmaClip(sigma=sigrej, maxiters=maxiters, cenfunc='median')
+        data_clipped = sigclip(data, axis=0, masked=True)
+        mask_stack = np.invert(data_clipped.mask)  # mask_stack = True are good values
+    else:
+        mask_stack = inmask_stack  # mask_stack = True are good values
+
+    weights_stack = np.einsum('i,ijk->ijk', weights, mask_stack)
+    weights_sum = np.sum(weights_stack, axis=0)
+    sciimg = np.sum(sciimg_stack * weights_stack, axis=0) / (weights_sum + (weights_sum == 0.0))
+    var_stack = utils.calc_ivar(sciivar_stack)
+    varfinal = np.sum(var_stack * weights_stack ** 2, axis=0) / (weights_sum + (weights_sum == 0.0)) ** 2
+    sciivar = utils.calc_ivar(varfinal)
+    rn2img = np.sum(rn2img_stack * weights_stack ** 2, axis=0) / (weights_sum + (weights_sum == 0.0)) ** 2
+    # Was it masked everywhere?
+    outmask = np.any(mask_stack, axis=0)
+
+    return sciimg, sciivar, rn2img, outmask
 
 
 # TODO: Add sigdev to the high-level parameter set so that it can be

--- a/pypeit/core/procimg.py
+++ b/pypeit/core/procimg.py
@@ -38,12 +38,10 @@ def weighted_combine(weights, sci_list, var_list, inmask_stack,
             Maximum number of iterations for sigma clipping using astropy.stats.SigmaClip
 
     Returns:
-        sciimg: float ndarray, shape (nspec, nspat)
-           Scince image
-        sciivar: float ndarray, shape (nspec, nspat)
-           Propagated inverse variance image
-        rn2img:  float ndarray, shape (nspec, nspat)
-           Propagated rn2img
+        sci_list_out: list
+           The list of ndarray float combined images with shape (nspec, nspat)
+        var_list_out: list
+           The list of ndarray propagated variance images with shape (nspec, nspat)
         outmask: bool ndarray, shape (nspec, nspat)
            Mask for combined image. True=Good, False=Bad
         nused: int ndarray, shape (nspec, nspat)

--- a/pypeit/core/procimg.py
+++ b/pypeit/core/procimg.py
@@ -88,8 +88,6 @@ def weighted_combine(weights, sci_list, var_list, inmask_stack,
         nused = outmask.astype(int)
         return sci_list_out, var_list_out, outmask, nused
 
-
-
     if sigma_clip and nimgs >= 3:
         if sigma_clip_stack is None:
             msgs.error('You must specify sigma_clip_stack, i.e. which quantity to use for sigma clipping')
@@ -126,7 +124,7 @@ def weighted_combine(weights, sci_list, var_list, inmask_stack,
         sci_list_out.append(np.sum(sci_stack*weights_stack, axis=0)/(weights_sum + (weights_sum == 0.0)))
     var_list_out = []
     for var_stack in var_list:
-        var_list_out.append(np.sum(var_stack * weights_stack ** 2, axis=0) / (weights_sum + (weights_sum == 0.0)) ** 2)
+        var_list_out.append(np.sum(var_stack * weights_stack**2, axis=0) / (weights_sum + (weights_sum == 0.0))**2)
     # Was it masked everywhere?
     outmask = np.any(mask_stack, axis=0)
 

--- a/pypeit/core/skysub.py
+++ b/pypeit/core/skysub.py
@@ -329,6 +329,7 @@ def optimal_bkpts(bkpts_optimal, bsp_min, piximg, sampmask, debug=False,
     fullbkpt_grid = fullbkpt_grid[keep]
     used_grid = False
     if not bkpts_optimal:
+        msgs.info('bkpts_optimal = False --> using uniform bkpt spacing spacing: bsp={:5.3f}'.format(bsp_min))
         fullbkpt = fullbkpt_grid
         used_grid = True
     else:
@@ -356,8 +357,8 @@ def optimal_bkpts(bkpts_optimal, bsp_min, piximg, sampmask, debug=False,
         dsamp = scipy.ndimage.convolve(dsamp_med, kernel, mode='reflect')
         # if more than 80% of the pixels have dsamp < bsp_min than just use a uniform breakpoint spacing
         if np.sum(dsamp <= bsp_min) > 0.8*nbkpt:
-            msgs.info('Sampling of wavelengths is nearly continuous. Using uniform spacing:' + msgs.newline() +
-                      'bsp={:5.3f}'.format(bsp_min))
+            msgs.info('Sampling of wavelengths is nearly continuous.')
+            msgs.info('Using uniform bkpt spacing: bsp={:5.3f}'.format(bsp_min))
             fullbkpt = fullbkpt_grid
             used_grid = True
         else:

--- a/pypeit/core/skysub.py
+++ b/pypeit/core/skysub.py
@@ -391,10 +391,10 @@ def local_skysub_extract(sciimg, sciivar, tilts, waveimg, global_sky, rn2_img, t
     spat_img = np.outer(np.ones(nspec), np.arange(nspat))
     spec_img = np.outer(np.arange(nspec), np.ones(nspat))
 
-    xa_min = spat_img[thismask].min()
-    xa_max = spat_img[thismask].max()
-    ya_min = spec_img[thismask].min()
-    ya_max = spec_img[thismask].max()
+    spat_min = spat_img[thismask].min()
+    spat_max = spat_img[thismask].max()
+    spec_min = spec_img[thismask].min()
+    spec_max = spec_img[thismask].max()
 
     xsize = slit_righ - slit_left
     spatial_img = thismask * ximg * (np.outer(xsize, np.ones(nspat)))
@@ -527,7 +527,7 @@ def local_skysub_extract(sciimg, sciivar, tilts, waveimg, global_sky, rn2_img, t
                     fullbkpt = bset0.breakpoints
                 # check to see if only a subset of the image is used.
                 # if so truncate input pixels since this can result in singular matrices
-                ibool = (spec_img >= ya_min) & (spec_img <= ya_max) & (spat_img >= xa_min) & (spat_img <= xa_max) & (spat_img >= mincol) & (
+                ibool = (spec_img >= spec_min) & (spec_img <= spec_max) & (spat_img >= spat_min) & (spat_img <= spat_max) & (spat_img >= mincol) & (
                             spat_img <= maxcol) & thismask
                 isub, = np.where(ibool.flatten())
                 sortpix = (piximg.flat[isub]).argsort()

--- a/pypeit/core/skysub.py
+++ b/pypeit/core/skysub.py
@@ -298,6 +298,10 @@ def skyoptimal(wave,data,ivar, oprof, sortpix, sigrej = 3.0, npoly = 1, spatial 
 
     return sky_bmodel, obj_bmodel, outmask
 
+def skybkpts(piximg, ):
+    pass
+
+
 def local_skysub_extract(sciimg, sciivar, tilts, waveimg, global_sky, rn2_img, thismask, slit_left, slit_righ, sobjs,
                          bsp = 0.6, inmask = None, extract_maskwidth = 4.0, trim_edg = (3,3), std = False, prof_nsigma = None,
                          niter=4, box_rad = 7, sigrej = 3.5,skysample = False, sn_gauss = 4.0, model_noise = True,
@@ -384,13 +388,13 @@ def local_skysub_extract(sciimg, sciivar, tilts, waveimg, global_sky, rn2_img, t
     skyimage = np.copy(global_sky)
     #varnoobj = np.abs(skyimage - np.sqrt(2.0) * np.sqrt(rn2_img)) + rn2_img
 
-    xarr = np.outer(np.ones(nspec), np.arange(nspat))
-    yarr = np.outer(np.arange(nspec), np.ones(nspat))
+    spat_img = np.outer(np.ones(nspec), np.arange(nspat))
+    spec_img = np.outer(np.arange(nspec), np.ones(nspat))
 
-    xa_min = xarr[thismask].min()
-    xa_max = xarr[thismask].max()
-    ya_min = yarr[thismask].min()
-    ya_max = yarr[thismask].max()
+    xa_min = spat_img[thismask].min()
+    xa_max = spat_img[thismask].max()
+    ya_min = spec_img[thismask].min()
+    ya_max = spec_img[thismask].max()
 
     xsize = slit_righ - slit_left
     spatial_img = thismask * ximg * (np.outer(xsize, np.ones(nspat)))
@@ -465,7 +469,7 @@ def local_skysub_extract(sciimg, sciivar, tilts, waveimg, global_sky, rn2_img, t
                     # For later iterations, profile fitting is based on an optimal extraction
                     last_profile = obj_profiles[:, :, ii]
                     trace = np.outer(sobjs[iobj].trace_spat, np.ones(nspat))
-                    objmask = ((xarr >= (trace - 2.0 * box_rad)) & (xarr <= (trace + 2.0 * box_rad)))
+                    objmask = ((spat_img >= (trace - 2.0 * box_rad)) & (spat_img <= (trace + 2.0 * box_rad)))
                     extract.extract_optimal(sciimg, modelivar, (outmask & objmask), waveimg, skyimage, rn2_img, last_profile,
                                     box_rad, sobjs[iobj])
                     # If the extraction is bad do not update
@@ -523,8 +527,8 @@ def local_skysub_extract(sciimg, sciivar, tilts, waveimg, global_sky, rn2_img, t
                     fullbkpt = bset0.breakpoints
                 # check to see if only a subset of the image is used.
                 # if so truncate input pixels since this can result in singular matrices
-                ibool = (yarr >= ya_min) & (yarr <= ya_max) & (xarr >= xa_min) & (xarr <= xa_max) & (xarr >= mincol) & (
-                            xarr <= maxcol) & thismask
+                ibool = (spec_img >= ya_min) & (spec_img <= ya_max) & (spat_img >= xa_min) & (spat_img <= xa_max) & (spat_img >= mincol) & (
+                            spat_img <= maxcol) & thismask
                 isub, = np.where(ibool.flatten())
                 sortpix = (piximg.flat[isub]).argsort()
                 ithis, = np.where(thismask.flat[isub])
@@ -600,7 +604,7 @@ def local_skysub_extract(sciimg, sciivar, tilts, waveimg, global_sky, rn2_img, t
                       ' at x = {:5.2f}'.format(sobjs[iobj].spat_pixpos))
             this_profile = obj_profiles[:, :, ii]
             trace = np.outer(sobjs[iobj].trace_spat, np.ones(nspat))
-            objmask = ((xarr >= (trace - 2.0 * box_rad)) & (xarr <= (trace + 2.0 * box_rad)))
+            objmask = ((spat_img >= (trace - 2.0 * box_rad)) & (spat_img <= (trace + 2.0 * box_rad)))
             extract.extract_optimal(sciimg, modelivar * thismask, (outmask & objmask), waveimg, skyimage, rn2_img, this_profile,
                             box_rad, sobjs[iobj])
             sobjs[iobj].mincol = mincol

--- a/pypeit/core/skysub.py
+++ b/pypeit/core/skysub.py
@@ -17,6 +17,7 @@ from pypeit.core import extract
 from matplotlib import pyplot as plt
 
 from scipy.special import ndtr
+import scipy
 
 
 
@@ -298,13 +299,90 @@ def skyoptimal(wave,data,ivar, oprof, sortpix, sigrej = 3.0, npoly = 1, spatial 
 
     return sky_bmodel, obj_bmodel, outmask
 
-def skybkpts(piximg, ):
-    pass
+def skybkpts(bsp_min, piximg, sampmask):
+    """
+
+    Args:
+        bsp_min: float
+           Desired B-spline breakpoint spacing in pixels
+        piximg: ndarray float, shape = (nspec, nspat)
+           Image containing the pixel sampling, i.e. (nspec-1)*tilts
+        sampmask: ndarray, bool
+           Boolean array indicating the pixels for which the B-spline fit will actually be evaluated. True = Good, False=Bad
+
+    Returns:
+        skybkpt: ndarray, float
+           Locations of the optimally sampled breakpoints
+
+    """
+
+    sky_pix = piximg[sampmask].sort()
+    piximg_temp = np.ma.array(np.copy(piximg))
+    piximg_temp.mask = np.invert(sampmask)
+    samplmin = np.ma.min(piximg_temp,fill_value=np.inf,axis=1)
+    samplmin = samplmin[np.invert(samplmin.mask)].data
+    samplmax = np.ma.max(piximg_temp,fill_value=-np.inf,axis=1)
+    samplmax = samplmax[np.invert(samplmax.mask)].data
+    if samplmax.size != samplmin.size:
+        msgs.error('This should not happen')
+    nbkpt = samplmax.size
+    # Determine the sampling. dsamp represents the gap in spectral pixel (wavelength) coverage between
+    # subsequent spectral direction pixels in the piximg, i.e. it is the difference between the minimum
+    # value of the piximg at spectral direction pixel i+1, and the maximum value of the piximg at spectral
+    # direction pixel i. A negative value dsamp < 0 implies continuous sampling with no gaps, i.e. the
+    # the arc lines are sufficiently tilted that there is no sampling gap.
+    dsamp_init = np.roll(samplmin, -1) - samplmax
+    dsamp_init[nbkpt - 1] = dsamp_init[nbkpt - 2]
+    kernel_size = int(np.fmax(np.ceil(dsamp_init.size*0.01)//2*2 + 1,15))  # This ensures kernel_size is odd
+    dsamp_med = scipy.ndimage.filters.median_filter(dsamp_init, size=kernel_size, mode='reflect')
+    boxcar_size = int(np.fmax(np.ceil(dsamp_med.size*0.005)//2*2 + 1,5))
+    # Boxcar smooth median dsamp
+    kernel = np.ones(boxcar_size)/ float(boxcar_size)
+    dsamp = scipy.ndimage.convolve(dsamp_med, kernel, mode='reflect')
+    # if more than 80% of the pixels have dsamp < bsp_min than just use a uniform breakpoint spacing
+    if np.sum(dsamp <= bsp_min) > 0.8*nbkpt:
+        bset0 = pydl.bspline(sky_pix, nord=4, bkspace=bsp_min)
+        skybkpt = bset0.breakpoints
+        msgs.info('Sampling of wavelengths is nearly continuous. Using uniform spacing:' + msgs.newline() +
+                  'bsp={:5.3f}'.format(bsp_min))
+        return skybkpt
+    else:
+        skybkpt_orig = samplmax + dsamp/2.0
+        skybkpt_orig.sort()
+        # Compute the distance between breakpoints
+        dsamp_bkpt = skybkpt_orig-np.roll(skybkpt_orig, 1)
+        dsamp_bkpt[0] = dsamp_bkpt[1]
+        # Good breakpoints are those that are at least separated by our original desired bkpt spacing
+        igood = dsamp_bkpt >= bsp_min
+        if np.any(igood):
+            skybkpt_orig = skybkpt_orig[igood]
+        skybkpt = skybkpt_orig.copy()
+        # Recompute the distance between breakpoints
+        dsamp_bkpt = skybkpt_orig-np.roll(skybkpt_orig, 1)
+        dsamp_bkpt[0] = dsamp_bkpt[1]
+        nbkpt = skybkpt_orig.size
+        for ibkpt in range(nbkpt):
+            dsamp_eff = np.fmax(dsamp_bkpt[ibkpt], bsp_min)
+            # can we fit in another bkpt?
+            if dsamp_bkpt[ibkpt] > 2*dsamp_eff:
+                nsmp = int(np.fmax(np.floor(dsamp_bkpt[ibkpt]/dsamp_eff),2))
+                bkpt_new = skybkpt_orig[ibkpt - 1] + (np.arange(nsmp - 1) + 1)*dsamp_bkpt[ibkpt]/float(nsmp)
+                indx_arr = np.where(skybkpt == skybkpt_orig[ibkpt-1])[0]
+                if len(indx_arr) > 0:
+                    indx_bkpt = indx_arr[0]
+                    if indx_bkpt == 0:
+                        skybkpt = np.hstack((skybkpt[0], bkpt_new, skybkpt[indx_bkpt + 1:]))
+                    elif indx_bkpt == (skybkpt.size-2):
+                        skybkpt = np.hstack((skybkpt[0:indx_bkpt], bkpt_new, skybkpt[indx_bkpt + 1]))
+                    else:
+                        skybkpt = np.hstack((skybkpt[0:indx_bkpt], bkpt_new, skybkpt[indx_bkpt + 1:]))
+
+        return skybkpt
 
 
 def local_skysub_extract(sciimg, sciivar, tilts, waveimg, global_sky, rn2_img, thismask, slit_left, slit_righ, sobjs,
                          bsp = 0.6, inmask = None, extract_maskwidth = 4.0, trim_edg = (3,3), std = False, prof_nsigma = None,
-                         niter=4, box_rad = 7, sigrej = 3.5,skysample = False, sn_gauss = 4.0, model_noise = True,
+                         niter=4, box_rad = 7, sigrej = 3.5,skysample = True, sn_gauss = 4.0, model_noise = True,
                          show_profile=False,show_resids=False):
 
     """Perform local sky subtraction and  extraction
@@ -337,7 +415,6 @@ def local_skysub_extract(sciimg, sciivar, tilts, waveimg, global_sky, rn2_img, t
      :func:`tuple`
 
      """
-
 
     ximg, edgmask = pixels.ximg_and_edgemask(slit_left, slit_righ, thismask, trim_edg = trim_edg)
 
@@ -512,23 +589,28 @@ def local_skysub_extract(sciimg, sciivar, tilts, waveimg, global_sky, rn2_img, t
             iterbsp = 0
             while (not sky_bmodel.any()) & (iterbsp <= 5):
                 bsp_now = (1.2 ** iterbsp) * bsp
+                ibool = (spec_img >= spec_min) & (spec_img <= spec_max) & \
+                        (spat_img >= spat_min) & (spat_img <= spat_max) & \
+                        (spat_img >= mincol) & (spat_img <= maxcol) & \
+                        thismask
                 # if skysample is set, determine optimal break-point spacing
                 # directly measuring how well we are sampling of the sky. The
                 # bsp in this case correspons to the minimum distance between
                 # breakpoints which we allow.
                 if skysample:
-                    sampmask = (waveimg > 0.0) & (thismask == True)
-                    # fullbkpt = skybkpts()
+                    sampmask = (waveimg > 0.0) & ibool
+                    fullbkpt = skybkpts(bsp_now, piximg, sampmask)
                     # TODO Port long_skybkpts.pro code and put it here.
                 else:
+                    # TODO Clean this up no need to flatten here
                     pixvec = piximg[skymask]
                     srt = pixvec.flatten().argsort()
                     bset0 = pydl.bspline(pixvec.flat[srt], nord=4, bkspace=bsp_now)
                     fullbkpt = bset0.breakpoints
+                from IPython import embed
+                embed()
                 # check to see if only a subset of the image is used.
                 # if so truncate input pixels since this can result in singular matrices
-                ibool = (spec_img >= spec_min) & (spec_img <= spec_max) & (spat_img >= spat_min) & (spat_img <= spat_max) & (spat_img >= mincol) & (
-                            spat_img <= maxcol) & thismask
                 isub, = np.where(ibool.flatten())
                 sortpix = (piximg.flat[isub]).argsort()
                 ithis, = np.where(thismask.flat[isub])

--- a/pypeit/processimages.py
+++ b/pypeit/processimages.py
@@ -16,12 +16,38 @@ from pypeit.core import combine
 from pypeit.core import procimg
 from pypeit.core import flat
 from pypeit.core import parse
+from pypeit import utils
 
 from pypeit.par import pypeitpar
 
 from pypeit.spectrographs.util import load_spectrograph
+from pypeit.bitmask import BitMask
+
 
 from pypeit import debugger
+
+
+class ProcessImagesBitMask(BitMask):
+    """
+    Define a bitmask used to set the reasons why each pixel in a science
+    image was masked.
+    """
+    def __init__(self):
+        # TODO:
+        #   - Can IVAR0 and IVAR_NAN be consolidated into a single bit?
+        #   - Is EXTRACT ever set?
+        mask = {       'BPM': 'Component of the instrument-specific bad pixel mask',
+                        'CR': 'Cosmic ray detected',
+                'SATURATION': 'Saturated pixel',
+                 'MINCOUNTS': 'Pixel below the instrument-specific minimum counts',
+                  'OFFSLITS': 'Pixel does not belong to any slit',
+                    'IS_NAN': 'Pixel value is undefined',
+                     'IVAR0': 'Inverse variance is undefined',
+                  'IVAR_NAN': 'Inverse variance is NaN',
+                   'EXTRACT': 'Pixel masked during local skysub and extraction'
+               }
+        super(ProcessImagesBitMask, self).__init__(list(mask.keys()), descr=list(mask.values()))
+
 
 class ProcessImages(object):
     """
@@ -73,6 +99,7 @@ class ProcessImages(object):
 
     # Class attribute is unknown.  Will be overwritten by children
     frametype='Unknown'
+    bitmask = ProcessImagesBitMask()  # The bit mask interpreter
 
     def __init__(self, spectrograph, file_list, det=1, par=None):
 
@@ -339,47 +366,7 @@ class ProcessImages(object):
         self.steps.append(inspect.stack()[0][3])
         return self.stack
 
-    ## JFH ToDO Scienceimage is the only class currently using this method, and it is not used in this method.
-    # Since I prefer not to make a ScienceImage a child of processimages (since it does not make sense with
-    # Science image working on lists of images) I'm moving this method there.
-#    def build_crmask(self, stack, varframe=None, par=None, binning=None):
-#        """
-#        Generate the CR mask frame
-#
-#        Wrapper to procimg.lacosmic
-#
-#        Parameters
-#        ----------
-#        varframe : ndarray, optional
-#
-#        Returns
-#        -------
-#        self.crmask : ndarray
-#          1. = Masked CR
-#
-#        """
-#        # Set the parameters
-#        if par is not None and not isinstance(par, pypeitpar.ProcessImagesPar):
-#            raise TypeError('Provided ParSet for must be type ProcessImagesPar.')
-#        if par is not None:
-#            self.proc_par = par
-#
-#        # Run LA Cosmic to get the cosmic ray mask
-#        saturation = self.spectrograph.detector[self.det-1]['saturation']
-#        nonlinear = self.spectrograph.detector[self.det-1]['nonlinear']
-#        sigclip, objlim = self.spectrograph.get_lacosmics_par(self.proc_par,binning=binning)
-#        self.crmask = procimg.lacosmic(self.det, stack, saturation, nonlinear,
-#                                         varframe=varframe, maxiter=self.proc_par['lamaxiter'],
-#                                         grow=self.proc_par['grow'],
-#                                         remove_compact_obj=self.proc_par['rmcompact'],
-#                                         sigclip=sigclip,
-#                                         sigfrac=self.proc_par['sigfrac'],
-#                                         objlim=objlim)
-#
-#        # Step
-#        self.steps.append(inspect.stack()[0][3])
-#        # Return
-#        return self.crmask
+
 
     def flat_field(self, pixel_flat, bpm, illum_flat=None):
         """
@@ -438,9 +425,6 @@ class ProcessImages(object):
         if (inspect.stack()[0][3] in self.steps) & (not overwrite):
             msgs.warn("Images already combined.  Use overwrite=True to do it again.")
             return
-
-        # JFH The fact that all these codes have no arguments and no return values make the control flow very hard to follow.
-        # I realize that everything has global scope in a class, but inputs and outputs to functions make code flow understandable.
 
         # Load images
         if 'load_images' not in self.steps:
@@ -535,6 +519,165 @@ class ProcessImages(object):
         return self.rawvarframe
 
 
+    # This is a static method because I need to be able to run it from outside the class and would prefer
+    # to not have to create an instance of the class everytime I want to do that.
+    @staticmethod
+    def build_crmask(stack, proc_par, det, spectrograph, ivar=None, binning=None):
+        """
+        Generate the CR mask frame
+
+        Wrapper to procimg.lacosmic
+
+        Parameters
+        ----------
+        varframe : ndarray, optional
+
+        Returns
+        -------
+        self.crmask : ndarray
+          1. = Masked CR
+
+        """
+        # Run LA Cosmic to get the cosmic ray mask
+        varframe = utils.calc_ivar(ivar)
+        saturation = spectrograph.detector[det-1]['saturation']
+        nonlinear = spectrograph.detector[det-1]['nonlinear']
+        sigclip, objlim = spectrograph.get_lacosmics_par(proc_par,binning=binning)
+        crmask = procimg.lacosmic(det, stack, saturation, nonlinear,
+                                  varframe=varframe, maxiter=proc_par['lamaxiter'],
+                                  grow=proc_par['grow'],
+                                  remove_compact_obj=proc_par['rmcompact'],
+                                  sigclip=sigclip,
+                                  sigfrac=proc_par['sigfrac'],
+                                  objlim=objlim)
+
+        # Return
+        return crmask
+
+    @classmethod
+    def build_mask(cls, sciimg, sciivar, crmask, bpm, saturation=1e10, mincounts=-1e10, slitmask=None):
+        """
+        Return the bit value mask used during extraction.
+
+        The mask keys are defined by :class:`ScienceImageBitMask`.  Any
+        pixel with mask == 0 is valid, otherwise the pixel has been
+        masked.  To determine why a given pixel has been masked::
+
+            bitmask = ScienceImageBitMask()
+            reasons = bm.flagged_bits(mask[i,j])
+
+        To get all the pixel masked for a specific set of reasons::
+
+            indx = bm.flagged(mask, flag=['CR', 'SATURATION'])
+
+        Returns:
+            numpy.ndarray: The bit value mask for the science image.
+        """
+        # Instatiate the mask
+        mask = np.zeros_like(sciimg, dtype=cls.bitmask.minimum_dtype(asuint=True))
+
+        # Bad pixel mask
+        indx = bpm.astype(bool)
+        mask[indx] = cls.bitmask.turn_on(mask[indx], 'BPM')
+
+        # Cosmic rays
+        indx = crmask.astype(bool)
+        mask[indx] = cls.bitmask.turn_on(mask[indx], 'CR')
+
+        # Saturated pixels
+        indx = sciimg >= saturation
+        mask[indx] = cls.bitmask.turn_on(mask[indx], 'SATURATION')
+
+        # Minimum counts
+        indx = sciimg <= mincounts
+        mask[indx] = cls.bitmask.turn_on(mask[indx], 'MINCOUNTS')
+
+        # Undefined counts
+        indx = np.invert(np.isfinite(sciimg))
+        mask[indx] = cls.bitmask.turn_on(mask[indx], 'IS_NAN')
+
+        # Bad inverse variance values
+        indx = np.invert(sciivar > 0.0)
+        mask[indx] = cls.bitmask.turn_on(mask[indx], 'IVAR0')
+
+        # Undefined inverse variances
+        indx = np.invert(np.isfinite(sciivar))
+        mask[indx] = cls.bitmask.turn_on(mask[indx], 'IVAR_NAN')
+
+        if slitmask is not None:
+            indx = slitmask == -1
+            mask[indx] = cls.bitmask.turn_on(mask[indx], 'OFFSLITS')
+
+        return mask
+
+    @classmethod
+    def update_mask_cr(cls, mask_old, crmask_new):
+
+        # Unset the CR bit from all places where it was set
+        CR_old = (cls.bitmask.unpack(mask_old, flag='CR'))[0]
+        mask_new = np.copy(mask_old)
+        mask_new[CR_old] = cls.bitmask.turn_off(mask_new[CR_old], 'CR')
+        # Now set the CR bit using the new crmask
+        indx = crmask_new.astype(bool)
+        mask_new[indx] = cls.bitmask.turn_on(mask_new[indx], 'CR')
+        return mask_new
+
+
+    # Do we still need this function?
+    @classmethod
+    def update_mask_slitmask(cls, mask_old, slitmask):
+
+        # Pixels excluded from any slit.
+        mask_new = np.copy(mask_old)
+        indx = slitmask == -1
+        mask_new[indx] = cls.bitmask.turn_on(mask_new[indx], 'OFFSLITS')
+        return mask_new
+
+    @classmethod
+    def read_stack(cls, files, bias, pixel_flat, bpm, det, proc_par, spectrograph, illum_flat=None, reject_cr=False,
+                   binning=None):
+        """  Utility function for reading in image stacks using ProcessImages
+        Parameters
+            file_list:
+            bias:
+            pixel_flat:
+            bpm:
+            illum_flat:
+        Returns:
+        """
+        nfiles = len(files)
+        for ifile in range(nfiles):
+            this_proc = ProcessImages(spectrograph, [files[ifile]], det=det, par=proc_par)
+            # TODO I think trim should be hard wired, and am not letting it be a free parameter
+            sciimg = this_proc.process(bias_subtract=bias,pixel_flat=pixel_flat, illum_flat=illum_flat, bpm=bpm,
+                                       apply_gain=True, trim=True)
+            # Allocate the images
+            if ifile == 0:
+                # numpy is row major so stacking will be fastest with nfiles as the first dimensions
+                shape = (nfiles, sciimg.shape[0],sciimg.shape[1])
+                sciimg_stack  = np.zeros(shape)
+                sciivar_stack = np.zeros(shape)
+                rn2img_stack  = np.zeros(shape)
+                crmask_stack  = np.zeros(shape,dtype=bool)
+                mask_stack  = np.zeros(shape,this_proc.bitmask.minimum_dtype(asuint=True))
+
+            # Construct raw variance image
+            rawvarframe = this_proc.build_rawvarframe(trim=True)
+            # Mask cosmic rays
+            sciivar_stack[ifile,:,:] =  utils.calc_ivar(rawvarframe)
+            if reject_cr:
+                crmask_stack[ifile,:,:] = this_proc.build_crmask(sciimg, proc_par, det, spectrograph,
+                                                                 ivar=sciivar_stack[ifile,:,:], binning=binning)
+            sciimg_stack[ifile,:,:] = sciimg
+            # Build read noise squared image
+            rn2img_stack[ifile,:,:] = this_proc.build_rn2img()
+            # Final mask for this image
+            mask_stack[ifile,:,:] = this_proc.build_mask(sciimg, sciivar_stack[ifile,:,:], crmask_stack[ifile,:,:],
+                                                         bpm, saturation = spectrograph.detector[det - 1]['saturation'],
+                                                         mincounts = spectrograph.detector[det - 1]['mincounts'])
+
+        return sciimg_stack, sciivar_stack, rn2img_stack, crmask_stack, mask_stack
+
     def show(self, attr='stack', idx=None, display='ginga'):
         """
         Show an image
@@ -610,6 +753,9 @@ class ProcessImages(object):
             txt = txt[:-2]+']'  # Trim the trailing comma
         txt += '>'
         return txt
+
+
+
 
 
 # TODO Add a function here that just reads in a fits file given a filename. Guess the instrument from the headers.

--- a/pypeit/processimages.py
+++ b/pypeit/processimages.py
@@ -199,15 +199,13 @@ class ProcessImages(object):
             self.headers.append(head)
         # Get the data sections
         self.datasec, one_indexed, include_end, transpose \
-                = self.spectrograph.get_image_section(self.file_list[0], self.det,
-                                                      section='datasec')
+            = self.spectrograph.get_image_section(self.file_list[0], self.det,section='datasec')
         self.datasec = [ parse.sec2slice(sec, one_indexed=one_indexed,
                                            include_end=include_end, require_dim=2,
                                            transpose=transpose) for sec in self.datasec ]
         # Get the overscan sections
-        self.oscansec, one_indexed, include_end, transpose \
-                = self.spectrograph.get_image_section(self.file_list[0], self.det,
-                                                      section='oscansec')
+        self.oscansec, one_indexed, include_end, transpose = \
+            self.spectrograph.get_image_section(self.file_list[0], self.det,section='oscansec')
         self.oscansec = [ parse.sec2slice(sec, one_indexed=one_indexed,
                                             include_end=include_end, require_dim=2,
                                             transpose=transpose) for sec in self.oscansec ]

--- a/pypeit/pypeit.py
+++ b/pypeit/pypeit.py
@@ -777,8 +777,6 @@ class Echelle(PypeIt):
     def find_objects(self, image, std=False, ir_redux=False, std_trace=None, snr_trim=False, maskslits=None,
                           show_peaks=False, show_fits=False, show_trace=False, show=False):
 
-        from IPython import embed
-        embed()
         sobjs_obj_init, nobj_init, skymask_pos = \
             self.sciI.find_objects_ech(image, std=std, std_trace=std_trace, snr_trim=snr_trim,
                                    show_peaks = show_peaks, show_fits = show_fits, show_trace = show_trace)

--- a/pypeit/pypeit.py
+++ b/pypeit/pypeit.py
@@ -442,7 +442,7 @@ class PypeIt(object):
         msgs.sciexp = self.sciI
 
         # Process images (includes inverse variance image, rn2 image, and CR mask)
-        sciimg, sciivar, rn2img, mask, crmask = \
+        self.sciimg, self.sciivar, self.rn2img, self.mask, self.crmask = \
             self.sciI.proc(self.caliBrate.msbias, self.caliBrate.mspixflatnrm,
                            self.caliBrate.msbpm, illum_flat=self.caliBrate.msillumflat,
                            show=self.show)
@@ -450,39 +450,41 @@ class PypeIt(object):
         self.maskslits = self.caliBrate.maskslits.copy()
         # Do one iteration of object finding, and sky subtract to get initial sky model
         self.sobjs_obj, self.nobj, skymask_init = \
-            self.find_objects(sciimg, std=self.std_redux, ir_redux=self.ir_redux, std_trace=std_trace, snr_trim=False,
-                              maskslits=self.maskslits)
+            self.find_objects(self.sciimg, std=self.std_redux, ir_redux=self.ir_redux,
+                              std_trace=std_trace, snr_trim=False,maskslits=self.maskslits,
+                              show = (not self.std_redux))
 
         # Global sky subtraction, first pass. Uses skymask from object finding step above
-        initial_sky = \
+        self.initial_sky = \
             self.sciI.global_skysub(self.caliBrate.tilts_dict['tilts'], skymask=skymask_init,
                                     std=self.std_redux, maskslits=self.maskslits, show=self.show)
 
         if not self.std_redux:
             # Object finding, second pass on frame *with* sky subtraction. Show here if requested
             self.sobjs_obj, self.nobj, self.skymask = \
-                self.find_objects(sciimg - initial_sky, std=self.std_redux, ir_redux=self.ir_redux, std_trace=std_trace, snr_trim=True,
-                maskslits=self.maskslits,show_peaks=self.show)
+                self.find_objects(self.sciimg - self.initial_sky, std=self.std_redux, ir_redux=self.ir_redux,
+                                  std_trace=std_trace, snr_trim=True,
+                                  maskslits=self.maskslits,show=self.show)
 
         # If there are objects, do 2nd round of global_skysub, local_skysub_extract, flexure, geo_motion
         if self.nobj > 0:
             if not self.std_redux:
                 # Global sky subtraction second pass. Uses skymask from object finding
-                global_sky = self.sciI.global_skysub(self.caliBrate.tilts_dict['tilts'],
+                self.global_sky = self.sciI.global_skysub(self.caliBrate.tilts_dict['tilts'],
                                                      skymask=self.skymask, maskslits=self.maskslits, show=self.show)
-            skymodel, objmodel, ivarmodel, outmask, sobjs = \
+            self.skymodel, self.objmodel, self.ivarmodel, self.outmask, self.sobjs = \
                 self.sciI.local_skysub_extract(self.sobjs_obj, self.caliBrate.mswave, model_noise=(not self.ir_redux),
                                                std = self.std_redux,maskslits=self.maskslits, show_profile=self.show,
                                                show=self.show)
 
             # Purge out the negative objects if this was a near-IR reduction
             if self.ir_redux:
-                sobjs.purge_neg()
+                self.sobjs.purge_neg()
 
             # Flexure correction if this is not a standard star
             if not self.std_redux:
-                self.flexure_correct(sobjs, self.maskslits)
-            vel_corr = self.helio_correct(sobjs, self.maskslits, frames[0], self.obstime)
+                self.flexure_correct(self.sobjs, self.maskslits)
+            vel_corr = self.helio_correct(self.sobjs, self.maskslits, frames[0], self.obstime)
 
         else:
             # Print status message
@@ -492,17 +494,17 @@ class PypeIt(object):
                 msgs_string += '{0:s}'.format(self.fitstbl['filename'][iframe]) + msgs.newline()
             msgs.warn(msgs_string)
             # set to first pass global sky
-            skymodel = initial_sky
+            skymodel = self.initial_sky
             objmodel = np.zeros_like(sciimg)
             # Set to sciivar. Could create a model but what is the point?
-            ivarmodel = np.copy(sciivar)
+            ivarmodel = np.copy(self.sciivar)
             # Set to inmask in case on objects were found
-            outmask = self.sciI.mask
+            outmask = self.mask
             # empty specobjs object from object finding
             sobjs = self.sobjs_obj
             vel_corr = None
 
-        return sciimg, sciivar, skymodel, objmodel, ivarmodel, outmask, sobjs, vel_corr
+        return self.sciimg, self.sciivar, self.skymodel, self.objmodel, self.ivarmodel, self.outmask, self.sobjs, vel_corr
 
     def find_objects(self, image, std=False, ir_redux=False, std_trace=None, snr_trim=False, maskslits=None,
                           show_peaks=False, show_fits=False, show_trace=False, show=False):
@@ -673,6 +675,9 @@ class MultiSlit(PypeIt):
         else:
             skymask = skymask_pos
 
+        if show:
+            self.sciI.show('image', image=image*(self.mask == 0), chname='objfind',sobjs=sobjs_obj_init, slits=True)
+
         return sobjs_obj_init, len(sobjs_obj_init), skymask
 
     # TODO: I don't think this function is written yet...
@@ -784,6 +789,10 @@ class Echelle(PypeIt):
             sobjs_obj_init.append_neg(sobjs_obj_init_neg)
         else:
             skymask = skymask_pos
+
+        if show:
+            self.sciI.show('image', image=image*(self.mask == 0), chname='ech_objfind',
+                      sobjs=sobjs_obj_init, slits=True)
 
         return sobjs_obj_init, len(sobjs_obj_init), skymask
 

--- a/pypeit/pypeit.py
+++ b/pypeit/pypeit.py
@@ -777,6 +777,8 @@ class Echelle(PypeIt):
     def find_objects(self, image, std=False, ir_redux=False, std_trace=None, snr_trim=False, maskslits=None,
                           show_peaks=False, show_fits=False, show_trace=False, show=False):
 
+        from IPython import embed
+        embed()
         sobjs_obj_init, nobj_init, skymask_pos = \
             self.sciI.find_objects_ech(image, std=std, std_trace=std_trace, snr_trim=snr_trim,
                                    show_peaks = show_peaks, show_fits = show_fits, show_trace = show_trace)

--- a/pypeit/scienceimage.py
+++ b/pypeit/scienceimage.py
@@ -535,113 +535,9 @@ class ScienceImage(processimages.ProcessImages):
         else: # Otherwise, if self.maskslits exists, use the previously set maskslits
             pass
         return self.maskslits
-    #
-    #
-    # # JFH TODO This stuff should be eventually moved to proc
-    # def proc_old(self, bias, pixel_flat, bpm, illum_flat=None, sigma_clip=False, sigrej=None, maxiters=5, show=False):
-    #     """ Process the image
-    #
-    #     Wrapper to ProcessImages.process()
-    #
-    #     Needed in part to set self.sciframe, although I could kludge it another way..
-    #
-    #     Returns
-    #     -------
-    #     self.sciframe
-    #     self.rawvarframe
-    #     self.crmask
-    #
-    #     """
-    #     # Process
-    #     self.bpm = bpm
-    #     self.bias = bias
-    #     self.pixel_flat = pixel_flat
-    #     self.illum_flat = illum_flat
-    #
-    #     if self.ir_redux:
-    #         if sigma_clip is True:
-    #             msgs.error('You cannot sigma clip with difference imaging as this will reject objects')
-    #         all_files = self.file_list + self.bg_file_list
-    #         cosmics = False # If we are differencing CR reject after we difference for better performance
-    #         # weights account for possibility of differing number of sci and bg images, i.e.
-    #         #  stack = 1/n_sci \Sum sci  - 1/n_bg \Sum bg
-    #         weights = np.hstack((np.ones(self.nsci)/float(self.nsci),-1.0*np.ones(self.nbg)/float(self.nbg)))
-    #     else:
-    #         all_files = self.file_list
-    #         cosmics = True
-    #         weights = np.ones(self.nsci)/float(self.nsci)
-    #
-    #     sciimg_stack, sciivar_stack, rn2img_stack, crmask_stack, mask_stack = \
-    #         self.read_stack(all_files, bias, pixel_flat, bpm, illum_flat, cosmics=cosmics)
-    #     nfiles = len(all_files)
-    #
-    #     # ToDO The bitmask is not being properly propagated here!
-    #     if self.nsci > 1 or self.ir_redux:
-    #         if sigma_clip:
-    #             msgs.error('Sigma clipping is not yet supported')
-    #             if sigrej is None:
-    #             if self.nsci <= 2:
-    #                 sigrej = 100.0  # Irrelevant for only 1 or 2 files, we don't sigma clip below
-    #             elif self.nsci == 3:
-    #                 sigrej = 1.1
-    #             elif self.nsci == 4:
-    #                 sigrej = 1.3
-    #             elif self.nsci == 5:
-    #                 sigrej = 1.6
-    #             elif self.nsci == 6:
-    #                 sigrej = 1.9
-    #             else:
-    #                 sigrej = 2.0
-    #             # sigma clip if we have enough images
-    #             if self.nsci > 2: # cannot sigma clipo for <= 2 images
-    #                 ## TODO THis is not tested!!
-    #                 # JFH ToDO Should we be sigma clipping here at all? What if the two background frames are not
-    #                 # at the same location, this then causes problems?
-    #                 # mask_stack > 0 is a masked value. numpy masked arrays are True for masked (bad) values
-    #                 data = np.ma.MaskedArray(sciimg_stack, (mask_stack > 0))
-    #                 sigclip = stats.SigmaClip(sigma=sigrej, maxiters=maxiters,cenfunc='median')
-    #                 data_clipped = sigclip(data, axis=0, masked=True)
-    #                 outmask_stack = np.invert(data_clipped.mask) # outmask = True are good values
-    #         else:
-    #             outmask_stack = (mask_stack == 0)  # outmask = True are good values
-    #
-    #             var_stack = utils.calc_ivar(sciivar_stack)
-    #             weights_stack = np.einsum('i,ijk->ijk',weights,outmask_stack)
-    #             weights_sum = np.sum(weights_stack, axis=0)
-    #             # Masked everwhere nused == 0
-    #             self.crmask = np.sum(crmask_stack,axis=0) == nfiles # Was everywhere a CR
-    #             self.sciimg = np.sum(sciimg_stack*weights_stack,axis=0)/(weights_sum + (weights_sum == 0.0))
-    #             varfinal = np.sum(var_stack*weights_stack**2,axis=0)/(weights_sum + (weights_sum == 0.0))**2
-    #             self.sciivar = utils.calc_ivar(varfinal)
-    #             self.rn2img = np.sum(rn2img_stack*weights_stack**2,axis=0)/(weights_sum + (weights_sum == 0.0))**2
-    #             # ToDO If I new how to add the bits, this is what I would do do create the mask. For now
-    #             # we simply create the mask again using the stacked images and the stacked mask
-    #             #nused = np.sum(outmask_stack,axis=0)
-    #             #self.mask = (nused == 0) * np.sum(mask_stack, axis=0)
-    #             self.mask = self._build_mask(self.sciimg, self.sciivar, self.crmask, saturation=self.saturation,
-    #                                          mincounts=(not self.ir_redux))
-    #     else:
-    #         self.mask  = mask_stack[0,:,:]
-    #         self.crmask = crmask_stack[0,:,:]
-    #         self.sciimg = sciimg_stack[0,:,:]
-    #         self.sciivar = sciivar_stack[0,:,:]
-    #         self.rn2img = rn2img_stack[0,:,:]
-    #
-    #     # For an IR reduction we build the CR mask after differencing
-    #     if self.ir_redux:
-    #         self.crmask = self.build_crmask(self.sciimg, ivar=self.sciivar)
-    #         self.mask = self._update_mask_cr(self.mask, self.crmask)
-    #
-    #     # Toggle the OFFSLIT bit at the very end
-    #     self.mask = self._update_mask_slitmask(self.mask, self.slitmask)
-    #
-    #     # Show the science image if an interactive run, only show the crmask
-    #     if show:
-    #         # Only mask the CRs in this image
-    #         self.show('image', image=self.sciimg*(self.crmask == 0), chname='sciimg')
-    #
-    #     return self.sciimg, self.sciivar, self.rn2img, self.mask, self.crmask
 
+
+    # JFH TODO This stuff should be eventually moved to processimages?
     def proc(self, bias, pixel_flat, bpm, illum_flat=None, reject_cr=True, sigma_clip=False, sigrej=None,
              maxiters=5,show=False):
 
@@ -710,7 +606,6 @@ class ScienceImage(processimages.ProcessImages):
         return sciimg, sciivar, rn2img, mask, crmask
 
 
-    # JFH TODO This stuff should be eventually moved to proc
     def proc_diff(self, file_list, bg_file_list, reject_cr = True,sigma_clip=False, sigrej=None, maxiters=5):
         """ Process the image
 

--- a/pypeit/scienceimage.py
+++ b/pypeit/scienceimage.py
@@ -592,9 +592,12 @@ class ScienceImage(processimages.ProcessImages):
             sci_list = [sciimg_stack]
             var_stack = utils.calc_ivar(sciivar_stack)
             var_list = [var_stack, rn2img_stack]
-            sciimg, sciivar, rn2img, outmask, nused = procimg.weighted_combine(
+            sci_list_out, var_list_out, outmask, nused = procimg.weighted_combine(
                 weights, sci_list, var_list, (mask_stack == 0),
                 sigma_clip=sigma_clip, sigma_clip_stack = sciimg_stack, sigrej=sigrej, maxiters=maxiters)
+            sciimg = sci_list_out[0]
+            sciivar = utils.calc_ivar(var_list_out[0])
+            rn2img = var_list_out[1]
             # assumes everything masked in the outmask is a CR in the individual images
             crmask = np.invert(outmask)
             # Create a mask for this image now

--- a/pypeit/scienceimage.py
+++ b/pypeit/scienceimage.py
@@ -589,9 +589,12 @@ class ScienceImage(processimages.ProcessImages):
 
         # ToDO The bitmask is not being properly propagated here!
         if nsci > 1:
-            sciimg, sciivar, rn2img, outmask = procimg.weighted_combine(
-                weights, sciimg_stack, sciivar_stack, rn2img_stack, (mask_stack == 0),
-                sigma_clip=sigma_clip, sigrej=sigrej, maxiters=maxiters)
+            sci_list = [sciimg_stack]
+            var_stack = utils.calc_ivar(sciivar_stack)
+            var_list = [var_stack, rn2img_stack]
+            sciimg, sciivar, rn2img, outmask, nused = procimg.weighted_combine(
+                weights, sci_list, var_list, (mask_stack == 0),
+                sigma_clip=sigma_clip, sigma_clip_stack = sciimg_stack, sigrej=sigrej, maxiters=maxiters)
             # assumes everything masked in the outmask is a CR in the individual images
             crmask = np.invert(outmask)
             # Create a mask for this image now

--- a/pypeit/scripts/show_twod.py
+++ b/pypeit/scripts/show_twod.py
@@ -17,7 +17,7 @@ import argparse
 from astropy.table import Table
 from pypeit import ginga
 from pypeit.spectrographs import util
-from pypeit.scienceimage import ScienceImageBitMask as bitmask
+from pypeit.processimages import ProcessImagesBitMask as bitmask
 
 def parser(options=None):
 

--- a/pypeit/spectrographs/gemini_gnirs.py
+++ b/pypeit/spectrographs/gemini_gnirs.py
@@ -117,6 +117,11 @@ class GeminiGNIRSSpectrograph(spectrograph.Spectrograph):
         par['calibrations']['traceframe']['exprng'] = [None, 30]
         par['calibrations']['standardframe']['exprng'] = [None, 30]
         par['scienceframe']['exprng'] = [30, None]
+
+        # Do not bias subtract
+        par['scienceframe']['useframe'] ='none'
+
+
         return par
 
     def check_headers(self, headers):

--- a/pypeit/spectrographs/gemini_gnirs.py
+++ b/pypeit/spectrographs/gemini_gnirs.py
@@ -117,10 +117,10 @@ class GeminiGNIRSSpectrograph(spectrograph.Spectrograph):
         par['scienceframe']['exprng'] = [30, None]
 
         # Do not bias subtract
-        par['scienceframe']['useframe'] ='none'
+        par['scienceframe']['useframe'] ='overscan'
         # This is a hack for now until we can specify for each image type what to do. Bias currently
         # controls everything
-        par['calibrations']['biasframe']['useframe'] = 'none'
+        par['calibrations']['biasframe']['useframe'] = 'overscan'
 
 
 

--- a/pypeit/spectrographs/gemini_gnirs.py
+++ b/pypeit/spectrographs/gemini_gnirs.py
@@ -68,8 +68,6 @@ class GeminiGNIRSSpectrograph(spectrograph.Spectrograph):
         par['calibrations']['pixelflatframe']['number'] = 5
         par['calibrations']['traceframe']['number'] = 5
         par['calibrations']['arcframe']['number'] = 1
-        # Bias
-        par['calibrations']['biasframe']['useframe'] = 'overscan'
 
         # Slits
         par['calibrations']['slits']['sigdetect'] = 220.
@@ -120,6 +118,10 @@ class GeminiGNIRSSpectrograph(spectrograph.Spectrograph):
 
         # Do not bias subtract
         par['scienceframe']['useframe'] ='none'
+        # This is a hack for now until we can specify for each image type what to do. Bias currently
+        # controls everything
+        par['calibrations']['biasframe']['useframe'] = 'none'
+
 
 
         return par

--- a/pypeit/spectrographs/gemini_gnirs.py
+++ b/pypeit/spectrographs/gemini_gnirs.py
@@ -70,7 +70,7 @@ class GeminiGNIRSSpectrograph(spectrograph.Spectrograph):
         par['calibrations']['arcframe']['number'] = 1
 
         # Slits
-        par['calibrations']['slits']['sigdetect'] = 220.
+        par['calibrations']['slits']['sigdetect'] = 50.
         par['calibrations']['slits']['polyorder'] = 5
         par['calibrations']['slits']['maxshift'] = 0.5
 
@@ -291,7 +291,7 @@ class GeminiGNIRSSpectrograph(spectrograph.Spectrograph):
 
         nslits = tslits_dict['lcen'].shape[1]
         if nslits != self.norders:
-            msgs.error('There is a problem with your slit bounadries. You have nslits={:d} orders, whereas NIR has norders={:d}'.format(nslits,self.norders))
+            msgs.error('There is a problem with your slit bounadries. You have nslits={:d} orders, whereas GNIRS has norders={:d}'.format(nslits,self.norders))
         # These are the order boundaries determined by eye by JFH. 2025 is used as the maximum as the upper bit is not illuminated
         order_max = [1022,1022,1022,1022,1022,1022]
         order_min = [512,280, 0, 0, 0, 0]

--- a/pypeit/spectrographs/keck_nires.py
+++ b/pypeit/spectrographs/keck_nires.py
@@ -101,6 +101,8 @@ class KeckNIRESSpectrograph(spectrograph.Spectrograph):
 
         par['scienceframe']['process']['sigclip'] = 20.0
         par['scienceframe']['process']['satpix'] ='nothing'
+        # Do not bias subtract
+        par['scienceframe']['useframe'] ='none'
 
         # Set the default exposure time ranges for the frame typing
         par['calibrations']['standardframe']['exprng'] = [None, 20]

--- a/pypeit/spectrographs/keck_nires.py
+++ b/pypeit/spectrographs/keck_nires.py
@@ -64,8 +64,6 @@ class KeckNIRESSpectrograph(spectrograph.Spectrograph):
         par['calibrations']['pixelflatframe']['number'] = 5
         par['calibrations']['traceframe']['number'] = 5
         par['calibrations']['arcframe']['number'] = 1
-        # Bias
-        par['calibrations']['biasframe']['useframe'] = 'none'
         # Wavelengths
         # 1D wavelength solution
         par['calibrations']['wavelengths']['rms_threshold'] = 0.20 #0.20  # Might be grating dependent..
@@ -101,8 +99,15 @@ class KeckNIRESSpectrograph(spectrograph.Spectrograph):
 
         par['scienceframe']['process']['sigclip'] = 20.0
         par['scienceframe']['process']['satpix'] ='nothing'
+
         # Do not bias subtract
         par['scienceframe']['useframe'] ='none'
+        # This is a hack for now until we can specify for each image type what to do. Bias currently
+        # controls everything
+        par['calibrations']['biasframe']['useframe'] = 'none'
+
+
+
 
         # Set the default exposure time ranges for the frame typing
         par['calibrations']['standardframe']['exprng'] = [None, 20]

--- a/pypeit/spectrographs/keck_nires.py
+++ b/pypeit/spectrographs/keck_nires.py
@@ -101,10 +101,10 @@ class KeckNIRESSpectrograph(spectrograph.Spectrograph):
         par['scienceframe']['process']['satpix'] ='nothing'
 
         # Do not bias subtract
-        par['scienceframe']['useframe'] ='none'
+        par['scienceframe']['useframe'] ='overscan'
         # This is a hack for now until we can specify for each image type what to do. Bias currently
         # controls everything
-        par['calibrations']['biasframe']['useframe'] = 'none'
+        par['calibrations']['biasframe']['useframe'] = 'overscan'
 
 
 

--- a/pypeit/spectrographs/vlt_xshooter.py
+++ b/pypeit/spectrographs/vlt_xshooter.py
@@ -227,8 +227,12 @@ class VLTXShooterNIRSpectrograph(VLTXShooterSpectrograph):
         par['flexure'] = pypeitpar.FlexurePar()
         par['scienceframe']['process']['sigclip'] = 20.0
         par['scienceframe']['process']['satpix'] ='nothing'
+
         # Do not bias subtract
-        par['scienceframe']['useframe'] = 'none'
+        par['scienceframe']['useframe'] ='none'
+        # This is a hack for now until we can specify for each image type what to do. Bias currently
+        # controls everything
+        par['calibrations']['biasframe']['useframe'] = 'none'
 
         return par
 

--- a/pypeit/spectrographs/vlt_xshooter.py
+++ b/pypeit/spectrographs/vlt_xshooter.py
@@ -217,10 +217,18 @@ class VLTXShooterNIRSpectrograph(VLTXShooterSpectrograph):
         par['calibrations']['wavelengths']['ech_norder_coeff'] = 5
         par['calibrations']['wavelengths']['ech_sigrej'] = 3.0
 
+        # Flats
+        par['calibrations']['flatfield']['illumflatten'] = False
+        par['calibrations']['flatfield']['tweak_slits_thresh'] = 0.90
+        par['calibrations']['flatfield']['tweak_slits_maxfrac'] = 0.10
+
+
         # Always correct for flexure, starting with default parameters
         par['flexure'] = pypeitpar.FlexurePar()
         par['scienceframe']['process']['sigclip'] = 20.0
         par['scienceframe']['process']['satpix'] ='nothing'
+        # Do not bias subtract
+        par['scienceframe']['useframe'] = 'none'
 
         return par
 

--- a/pypeit/spectrographs/vlt_xshooter.py
+++ b/pypeit/spectrographs/vlt_xshooter.py
@@ -229,10 +229,10 @@ class VLTXShooterNIRSpectrograph(VLTXShooterSpectrograph):
         par['scienceframe']['process']['satpix'] ='nothing'
 
         # Do not bias subtract
-        par['scienceframe']['useframe'] ='none'
+        par['scienceframe']['useframe'] ='overscan'
         # This is a hack for now until we can specify for each image type what to do. Bias currently
         # controls everything
-        par['calibrations']['biasframe']['useframe'] = 'none'
+        par['calibrations']['biasframe']['useframe'] = 'overscan'
 
         return par
 


### PR DESCRIPTION
This PR implements the following changes: 

-- fixes bugs present in the near-IR difference imaging when just two images were used. It also moves image processing functionality from the Scienceimage class to Processimages. 

-- implemented optimal breakpoint determination using the pixel sampling from the spectral tilts. 

-- Added several new core routines to procimg that are meant to implement 2d rectification and coadding. 

I'm not completely happy with the way ProcessImages is organized as per the first point above. All the relevant methods been made class methods, because I need to run them without an instantiation of the class sometimes. Part of the problem is that processimages is relatively rigidly constructed, and does not give me the flexibility to do the image processing needed on image stacks. Anyway, this is a step in the right direction. 

@profxj you can take a look at the codes and let me know if you think the proc, proc_sci, and proc_diff routines in the Scienceimage class should also be moved. These would need to be class methods though and take a file list. If you can think of a better organization please suggest one. 

