### PR TITLE
LRIS quick fix

### DIFF
--- a/pypeit/core/parse.py
+++ b/pypeit/core/parse.py
@@ -762,7 +762,9 @@ def sec2slice(subarray, one_indexed=False, include_end=False, require_dim=None, 
                 tslices = parse_sec2slice('[:10,10:]', transpose=True)
 
         binning (:obj:`str`, optional):
-            The image binning.  The `subarray` string is always expected to be for an unbinned image.  This binning keyword is used to adjust the slice for an image that is binned.  The string must be a comma-separated list of number providing the binning along the relevant axis.
+            The image binning.  The `subarray` string is always expected to be for an *unbinned* image.
+            This binning keyword is used to adjust the slice for an image that is binned.
+            The string must be a comma-separated list of number providing the binning along the relevant axis.
 
     Returns:
         tuple: A tuple of slice objects, one per dimension of the

--- a/pypeit/processimages.py
+++ b/pypeit/processimages.py
@@ -324,10 +324,10 @@ class ProcessImages(object):
                 datasec, one_indexed, include_end, transpose \
                         = self.spectrograph.get_image_section(inp=self.files[i], det=self.det,
                                                               section='datasec')
-            self.datasec[i] = [ parse.sec2slice(sec, one_indexed=one_indexed,
+            self.datasec[i] = [parse.sec2slice(sec, one_indexed=one_indexed,
                                                 include_end=include_end, require_dim=2,
                                                 transpose=transpose, binning=self.binning[i])
-                                    for sec in datasec ]
+                                    for sec in datasec]
             # Get the overscan sections, one section per amplifier
             try:
                 oscansec, one_indexed, include_end, transpose \
@@ -337,10 +337,11 @@ class ProcessImages(object):
                 oscansec, one_indexed, include_end, transpose \
                         = self.spectrograph.get_image_section(inp=self.files[i], det=self.det,
                                                               section='oscansec')
-            self.oscansec[i] = [ parse.sec2slice(sec, one_indexed=one_indexed,
+            # Parse, including handling binning
+            self.oscansec[i] = [parse.sec2slice(sec, one_indexed=one_indexed,
                                                  include_end=include_end, require_dim=2,
                                                  transpose=transpose, binning=self.binning[i])
-                                    for sec in oscansec ]
+                                    for sec in oscansec]
         # Include step
         self.steps.append(inspect.stack()[0][3])
 

--- a/pypeit/spectrographs/keck_lris.py
+++ b/pypeit/spectrographs/keck_lris.py
@@ -236,6 +236,7 @@ class KeckLRISSpectrograph(spectrograph.Spectrograph):
         else:
             raise ValueError('Unrecognized keyword: {0}'.format(section))
 
+    '''
     def get_datasec_img(self, filename, det=1, force=True):
         """
         Create an image identifying the amplifier used to read each pixel.
@@ -274,6 +275,7 @@ class KeckLRISSpectrograph(spectrograph.Spectrograph):
                 # Assign the amplifier
                 self.datasec_img[datasec] = i+1
         return self.datasec_img
+    '''
 
     def get_image_shape(self, filename=None, det=None, **null_kwargs):
         """
@@ -707,6 +709,7 @@ def read_lris(raw_file, det=None, TRIM=False):
     header : FITS header
     sections : list
       List of datasec, oscansec, ampsec sections
+      datasec, oscansec needs to be for an *unbinned* image as per standard convention
     """
 
     # Check for file; allow for extra .gz, etc. suffix
@@ -824,8 +827,8 @@ def read_lris(raw_file, det=None, TRIM=False):
             nydata = buf[1]
             xs = n_ext*precol + kk*nxdata #(x1-xmin)/xbin
             xe = xs + nxdata
-            # Data section
-            section = '[{:d}:{:d},{:d}:{:d}]'.format(preline,nydata-postline, xs, xe)  # Eliminate lines
+            #section = '[{:d}:{:d},{:d}:{:d}]'.format(preline,nydata-postline, xs, xe)  # Eliminate lines
+            section = '[:,{:d}:{:d}]'.format(xs*xbin, xe*xbin)  # Eliminate lines
             dsec.append(section)
             #print('data',xs,xe)
             array[xs:xe, :] = data   # Include postlines
@@ -835,7 +838,7 @@ def read_lris(raw_file, det=None, TRIM=False):
             nxpost = buf[0]
             xs = nx - n_ext*postpix + kk*postpix
             xe = xs + nxpost 
-            section = '[:,{:d}:{:d}]'.format(xs, xe)
+            section = '[:,{:d}:{:d}]'.format(xs*xbin, xe*xbin)
             osec.append(section)
             '''
             if keyword_set(VERBOSITY) then begin

--- a/pypeit/traceslits.py
+++ b/pypeit/traceslits.py
@@ -121,6 +121,7 @@ class TraceSlits(masterframe.MasterFrame):
         # from_master_files() classmethod below?  Changed it to match
         # the rest of the MasterFrame children.
 
+
         # Required parameters (but can be None)
         self.mstrace = mstrace
 #        self.pixlocn = pixlocn


### PR DESCRIPTION
Quick fix in LRIS data reader to correct the `datasec`
and `oscansec` attribs to be properly independent of 
binining.

This fixes the current crash on the `master` for the
longslit mode (which uses overscan subtraction).