### PR TITLE
Hotfix for saving and reusing masters in memory

### DIFF
--- a/pypeit/__init__.py
+++ b/pypeit/__init__.py
@@ -45,6 +45,6 @@ warnings.simplefilter('ignore')
 # TODO: Need some way of selectively doing this.  Once you import
 # pypeit, this affects the behavior of pyplot for *anything* else you
 # plot in a given session.
-from matplotlib import pyplot
-pyplot.switch_backend('agg')
+#from matplotlib import pyplot
+#pyplot.switch_backend('agg')
 

--- a/pypeit/calibrations.py
+++ b/pypeit/calibrations.py
@@ -457,8 +457,8 @@ class Calibrations(object):
                                           det=self.det)
 
         # Return already generated data
-        if self._cached('pixelflat', self.master_key_dict['flat']) and \
-                self._cached('illumflat', self.master_key_dict['flat']):
+        if self._cached('pixelflat', self.master_key_dict['flat']) \
+                and self._cached('illumflat', self.master_key_dict['flat']):
             self.mspixelflat = self.calib_dict[self.master_key_dict['flat']]['pixelflat']
             self.msillumflat = self.calib_dict[self.master_key_dict['flat']]['illumflat']
             return self.mspixelflat, self.msillumflat
@@ -717,7 +717,8 @@ class Calibrations(object):
             msgs.error('Arc master key not set.  First run get_arc.')
 
         # Return existing data
-        if self._cached('wavecalib', self.master_key_dict['arc']):
+        if self._cached('wavecalib', self.master_key_dict['arc']) \
+                and self._cached('wvmask', self.master_key_dict['arc']):
             self.wv_calib = self.calib_dict[self.master_key_dict['arc']]['wavecalib']
             self.wv_maskslits = self.calib_dict[self.master_key_dict['arc']]['wvmask']
             self.maskslits += self.wv_maskslits
@@ -791,7 +792,8 @@ class Calibrations(object):
             msgs.error('Arc master key not set.  First run get_arc.')
         
         # Return existing data
-        if self._cached('tilts_dict', self.master_key_dict['arc']):
+        if self._cached('tilts_dict', self.master_key_dict['arc']) \
+                and self._cached('wtmask', self.master_key_dict['arc']):
             self.tilts_dict = self.calib_dict[self.master_key_dict['arc']]['tilts_dict']
             self.wt_maskslits = self.calib_dict[self.master_key_dict['arc']]['wtmask']
             self.maskslits += self.wt_maskslits

--- a/pypeit/pypeit.py
+++ b/pypeit/pypeit.py
@@ -268,6 +268,7 @@ class PypeIt(object):
 
             # Reduce all the standard frames, loop on unique comb_id
             u_combid_std= np.unique(self.fitstbl['comb_id'][grp_standards])
+
             for j, comb_id in enumerate(u_combid_std):
                 frames = np.where(self.fitstbl['comb_id'] == comb_id)[0]
                 bg_frames = np.where(self.fitstbl['bkg_id'] == comb_id)[0]
@@ -308,7 +309,6 @@ class PypeIt(object):
 
         # Finish
         self.print_end_time()
-
 
     # This is a static method to allow for use in coadding script 
     @staticmethod

--- a/pypeit/tests/test_calibrations.py
+++ b/pypeit/tests/test_calibrations.py
@@ -192,16 +192,37 @@ def test_reuse(multi_caliBrate_reuse):
 
     os.makedirs(multi_caliBrate_reuse.master_dir)
 
-    # Perform the calibrations
+    # Perform the calibrations and check that the data are correctly
+    # stored in memory
     multi_caliBrate_reuse.shape = (2048,350)
     multi_caliBrate_reuse.get_bpm()
-    multi_caliBrate_reuse.msbias = 'overscan'
+    assert list(multi_caliBrate_reuse.calib_dict.keys()) == ['A_1_01'], 'Incorrect master key'
+    assert list(multi_caliBrate_reuse.calib_dict['A_1_01'].keys()) == ['bpm'], \
+                'Incorrect list of master types in memory'
     msarc = multi_caliBrate_reuse.get_arc()
+    assert list(multi_caliBrate_reuse.calib_dict['A_1_01'].keys()) == ['bpm', 'arc'], \
+                'Incorrect list of master types in memory'
     multi_caliBrate_reuse.get_slits(write_qa=False)
+    assert list(multi_caliBrate_reuse.calib_dict['A_1_01'].keys()) == ['bpm', 'arc', 'trace'], \
+                'Incorrect list of master types in memory'
     multi_caliBrate_reuse.get_wv_calib()
+    assert list(multi_caliBrate_reuse.calib_dict['A_1_01'].keys()) \
+                == ['bpm', 'arc', 'trace', 'wavecalib', 'wvmask'], \
+                'Incorrect list of master types in memory'
     multi_caliBrate_reuse.get_tilts()
+    assert list(multi_caliBrate_reuse.calib_dict['A_1_01'].keys()) \
+                == ['bpm', 'arc', 'trace', 'wavecalib', 'wvmask', 'tilts_dict', 'wtmask'], \
+                'Incorrect list of master types in memory'
     multi_caliBrate_reuse.get_flats()
+    assert list(multi_caliBrate_reuse.calib_dict['A_1_01'].keys()) \
+                == ['bpm', 'arc', 'trace', 'wavecalib', 'wvmask', 'tilts_dict', 'wtmask',
+                    'pixelflat', 'illumflat'], \
+                'Incorrect list of master types in memory'
     mswave = multi_caliBrate_reuse.get_wave()
+    assert list(multi_caliBrate_reuse.calib_dict['A_1_01'].keys()) \
+                == ['bpm', 'arc', 'trace', 'wavecalib', 'wvmask', 'tilts_dict', 'wtmask',
+                    'pixelflat', 'illumflat', 'wave'], \
+                'Incorrect list of master types in memory'
     assert mswave.shape == (2048,350)
 
     # Reset
@@ -217,7 +238,7 @@ def test_reuse(multi_caliBrate_reuse):
     assert 'arc' not in multi_caliBrate_reuse.master_key_dict.keys(), \
             'arc master key should not be defined yet'
     _msarc = multi_caliBrate_reuse.get_arc()
-    assert multi_caliBrate_reuse._check_cache('arc',
+    assert multi_caliBrate_reuse._cached('arc',
                     multi_caliBrate_reuse.master_key_dict['arc']), 'Should find cached data.'
     assert os.path.isfile(multi_caliBrate_reuse.arcImage.file_path), \
             'Should find master file.'


### PR DESCRIPTION
The `calib_dict` object wasn't being setup correctly in `Calibrations`.