### PR TITLE
minor change to grab binning info from header

### DIFF
--- a/pypeit/spectrographs/vlt_xshooter.py
+++ b/pypeit/spectrographs/vlt_xshooter.py
@@ -75,8 +75,14 @@ class VLTXShooterSpectrograph(spectrograph.Spectrograph):
 
     def compound_meta(self, headarr, meta_key):
         if meta_key == 'binning':
-            binspatial = headarr[0]['HIERARCH ESO DET WIN1 BINX']
-            binspec = headarr[0]['HIERARCH ESO DET WIN1 BINY']
+            try:
+                binspatial = headarr[0]['HIERARCH ESO DET WIN1 BINX']
+            except:
+                binspatial = 1
+            try:
+                binspec = headarr[0]['HIERARCH ESO DET WIN1 BINY']
+            except:
+                binspec = 1
             binning = parse.binning2string(binspec, binspatial)
             return binning
         elif meta_key in ['ra', 'dec']:

--- a/pypeit/spectrographs/vlt_xshooter.py
+++ b/pypeit/spectrographs/vlt_xshooter.py
@@ -75,13 +75,13 @@ class VLTXShooterSpectrograph(spectrograph.Spectrograph):
 
     def compound_meta(self, headarr, meta_key):
         if meta_key == 'binning':
-            try:
+            if 'HIERARCH ESO DET WIN1 BINX' in headarr[0]:
                 binspatial = headarr[0]['HIERARCH ESO DET WIN1 BINX']
-            except:
+            else:
                 binspatial = 1
-            try:
+            if 'HIERARCH ESO DET WIN1 BINY' in headarr[0]:
                 binspec = headarr[0]['HIERARCH ESO DET WIN1 BINY']
-            except:
+            else:
                 binspec = 1
             binning = parse.binning2string(binspec, binspatial)
             return binning


### PR DESCRIPTION
This is a small PR that solve a problem in pypeit_setup for XSHOOTER.

Basically, in the header of NIR frames the keywords HIERARCH ESO DET WIN1 BINY and HIERARCH ESO DET WIN1 BINX are not present, causing pypeit_setup to crash while trying to sort the different files. The try/except conditions solve this problem.

Given that this is quick fix than have no impacts on other part of the code I am submitting it here, but if you think is better to correct this in the dev branch I can just change it.
