### PR TITLE
Minor changes to get 2-d coadds working again in develop.

### DIFF
--- a/pypeit/core/coadd2d.py
+++ b/pypeit/core/coadd2d.py
@@ -24,6 +24,7 @@ from pypeit import processimages
 from pypeit.core import load, coadd, pixels
 from pypeit.core import parse
 from pypeit.spectrographs import util
+import IPython
 
 
 def get_brightest_obj(specobjs_list, echelle=True):
@@ -785,7 +786,8 @@ def extract_coadd2d(stack_dict, master_dir, samp_fact = 1.0,ir_redux=False, par=
     tslits_dict_psuedo = dict(slit_left=slit_left, slit_righ=slit_righ, slitcen=slitcen,
                               nspec=nspec_psuedo, nspat=nspat_psuedo, pad=0,
                               nslits = nslits, binspectral=1, binspatial=1, spectrograph=spectrograph.spectrograph,
-                              spec_min=spec_min1, spec_max=spec_max1)
+                              spec_min=spec_min1, spec_max=spec_max1,
+                              maskslits=np.zeros(slit_left.shape[1], dtype=np.bool))
 
     slitmask_psuedo = pixels.tslits2mask(tslits_dict_psuedo)
     # This is a kludge to deal with cases where bad wavelengths result in large regions where the slit is poorly sampled,

--- a/pypeit/reduce.py
+++ b/pypeit/reduce.py
@@ -9,8 +9,7 @@ from abc import ABCMeta
 
 from pypeit import ginga, utils, msgs, processimages, specobjs
 from pypeit.core import skysub, extract, trace_slits, pixels, wave
-
-from IPython import embed
+import IPython
 
 class Reduce(object):
     """

--- a/pypeit/spectrographs/gemini_gnirs.py
+++ b/pypeit/spectrographs/gemini_gnirs.py
@@ -228,10 +228,12 @@ class GeminiGNIRSSpectrograph(spectrograph.Spectrograph):
 
         # Check
         if np.abs(order_spat_pos[iorder] - slit_spat_pos) > 0.05:
-            msgs.error("Bad echelle format for MagE or you have discovered one of the bluest 3 orders!")
-
-        # Return
-        return orders[iorder]
+            msgs.warn("Bad echelle format for GNIRS or you are performing a 2-d coadd with different order locations."
+                      "Returning order vector with the same number of orders you requested")
+            iorder = np.arange(slit_spat_pos.size)
+            return orders[iorder]
+        else:
+            return orders[iorder]
 
 
     def slit_minmax(self, nslits, binspectral=1):
@@ -296,11 +298,11 @@ class GeminiGNIRSSpectrograph(spectrograph.Spectrograph):
     def loglam_minmax(self):
         return np.log10(7000), np.log10(26000)
 
-    def wavegrid(self, binning=None, midpoint=False):
+    def wavegrid(self, binning=None, samp_fact=1.0, midpoint=False):
 
         # Define the grid for GNIRS
         logmin, logmax = self.loglam_minmax
-        loglam_grid = wvutils.wavegrid(logmin, logmax, self.dloglam)
+        loglam_grid = wvutils.wavegrid(logmin, logmax, self.dloglam, samp_fact=samp_fact)
         if midpoint:
             loglam_grid = loglam_grid + self.dloglam/2.0
         return np.power(10.0,loglam_grid)

--- a/pypeit/spectrographs/keck_nires.py
+++ b/pypeit/spectrographs/keck_nires.py
@@ -254,10 +254,12 @@ class KeckNIRESSpectrograph(spectrograph.Spectrograph):
 
         # Check
         if np.abs(order_spat_pos[iorder] - slit_spat_pos) > 0.05:
-            msgs.error("Bad echelle input for VLT X-Shooter VIS")
-
-        # Return
-        return orders[iorder]
+            msgs.warn("Bad echelle format for Keck-NIRES or you are performing a 2-d coadd with different order locations."
+                      "Returning order vector with the same number of orders you requested")
+            iorder = np.arange(slit_spat_pos.size)
+            return orders[iorder]
+        else:
+            return orders[iorder]
 
 
     def order_platescale(self, order_vec, binning=None):

--- a/pypeit/spectrographs/magellan_mage.py
+++ b/pypeit/spectrographs/magellan_mage.py
@@ -288,12 +288,16 @@ class MagellanMAGESpectrograph(spectrograph.Spectrograph):
         # Find closest
         iorder = np.argmin(np.abs(slit_spat_pos-order_spat_pos))
 
+
         # Check
         if np.abs(order_spat_pos[iorder] - slit_spat_pos) > 0.05:
-            msgs.error("Bad echelle format for MagE or you have discovered one of the bluest 3 orders!")
+            msgs.warn("Bad echelle format for Magellan-MAGE or you are performing a 2-d coadd with different order locations."
+                      "Returning order vector with the same number of orders you requested")
+            iorder = np.arange(slit_spat_pos.size)
+            return orders[iorder]
+        else:
+            return orders[iorder]
 
-        # Return
-        return orders[iorder]
 
 
     def order_platescale(self, order_vec, binning=None):

--- a/pypeit/spectrographs/vlt_xshooter.py
+++ b/pypeit/spectrographs/vlt_xshooter.py
@@ -348,10 +348,13 @@ class VLTXShooterNIRSpectrograph(VLTXShooterSpectrograph):
 
         # Check
         if np.abs(order_spat_pos[iorder] - slit_spat_pos) > 0.05:
-            msgs.error("Bad echelle input for VLT X-Shooter VIS")
+            msgs.warn("Bad echelle format for VLT-XSHOOTER or you are performing a 2-d coadd with different order locations."
+                      "Returning order vector with the same number of orders you requested")
+            iorder = np.arange(slit_spat_pos.size)
+            return orders[iorder]
+        else:
+            return orders[iorder]
 
-        # Return
-        return orders[iorder]
 
     def order_platescale(self, order_vec, binning=None):
         """
@@ -579,10 +582,12 @@ class VLTXShooterVISSpectrograph(VLTXShooterSpectrograph):
 
         # Check
         if np.abs(order_spat_pos[iorder] - slit_spat_pos) > 0.05:
-            msgs.error("Bad echelle input for VLT X-Shooter VIS")
-
-        # Return
-        return orders[iorder]
+            msgs.warn("Bad echelle format for VLT-XSHOOTER or you are performing a 2-d coadd with different order locations."
+                      "Returning order vector with the same number of orders you requested")
+            iorder = np.arange(slit_spat_pos.size)
+            return orders[iorder]
+        else:
+            return orders[iorder]
 
     def order_platescale(self, order_vec, binning=None):
         """

--- a/pypeit/waveimage.py
+++ b/pypeit/waveimage.py
@@ -15,8 +15,7 @@ from pypeit.masterframe import MasterFrame
 from pypeit import ginga
 from pypeit.core import pixels
 from pypeit.core import trace_slits
-
-from IPython import embed
+import IPython
 
 class WaveImage(MasterFrame):
     """
@@ -62,7 +61,13 @@ class WaveImage(MasterFrame):
         self.tslits_dict = tslits_dict
         self.tilts = tilts
         self.wv_calib = wv_calib
-        self.slitmask = pixels.tslits2mask(self.tslits_dict) if tslits_dict is not None else None
+        if tslits_dict is not None:
+            self.slitmask = pixels.tslits2mask(self.tslits_dict)
+            self.slit_spat_pos = trace_slits.slit_spat_pos(self.tslits_dict)
+        else:
+            self.slitmask = None
+            self.slit_spat_pos = None
+
         # TODO: only echelle is ever used.  Do we need to keep the whole
         # thing?
         self.par = wv_calib['par'] if wv_calib is not None else None
@@ -70,7 +75,6 @@ class WaveImage(MasterFrame):
         self.maskslits = maskslits
 
         # For echelle order, primarily
-        self.slit_spat_pos = trace_slits.slit_spat_pos(self.tslits_dict)
 
         # List to hold ouptut from inspect about what module create the image?
         self.steps = []


### PR DESCRIPTION
This is a very minor hot fix PR to get 2d coadds working again in the develop branch. The main change is that the slit2order functions in the fixed format echelle spectrograph files now return something sensible if the slit positions are not at their expected locations on the detector. Since the 2-d coadds remap the slits to new locations there is no other way to get the list of orders. The other fixes are minor and allow the pseudo master files to be written. 