### PR TITLE
Customizing for small slits and bright standards

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,7 +16,7 @@
 - Add find_trim_edge and std_prof_nsigma parameters
 - A bit of tuning for MagE
 - Fixes for Echelle in fluxspec
--
+
 
 0.10.1 (22 May 2019)
 --------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,10 @@
 - Started notes on how to generate a new spectrograph in PypeIt
 - Refactoring of reduce to take a ScienceImage object for the images and the mask
 - Updates to many spectrograph files to put datasec, oscansec in the raw frame
+- Add find_trim_edge and std_prof_nsigma parameters
+- A bit of tuning for MagE
+- Fixes for Echelle in fluxspec
+-
 
 0.10.1 (22 May 2019)
 --------------------

--- a/doc/fluxing.rst
+++ b/doc/fluxing.rst
@@ -49,6 +49,7 @@ To flux one or more spec1d files, generate a `flux read`, e.g.::
 
 The first entry of each row is the spec1d file to be fluxed
 and the second provides the output filename.
+One separates the two entries by *a single space*!
 
 .. _fluxspec-script:
 

--- a/doc/mage.rst
+++ b/doc/mage.rst
@@ -1,7 +1,7 @@
 .. highlight:: rest
 
 *************
-Magellan MagE
+Magellan Mage
 *************
 
 
@@ -9,18 +9,22 @@ Overview
 ========
 
 This file summarizes several instrument specific
-settings that are related to the Magellan/MagE spectrograph.
+settings that are related to Magellan/Mage.
 
 
-Limitations
+Short slits
 ===========
 
-Tested on the reddest 12 orders and 1x1 and 2x2 binning.
+There are several issues related to the very short
+slits of Magellan/Mage  (34 pixels or 10" unbinned).
 
-Calibrations
-============
+Find Objects
+------------
 
-The following are the recommended way to take
-calibrations (especially flat fields) for MagE.
+To have enough slit to 'properly' find objects,
+we restrict the find_trim_edge parameter, i.e.::
 
-TO BE FILLED IN
+    par['scienceimage']['find_trim_edge'] = (4,4)    # Slit is too short to trim 5,5 especially with 2x binning
+
+For spatial binning, we recommend you to further reduce
+this by the binning factor.

--- a/pypeit/core/extract.py
+++ b/pypeit/core/extract.py
@@ -1483,7 +1483,7 @@ def objfind(image, thismask, slit_left, slit_righ, inmask=None, fwhm=3.0,
 
     slit_spat_pos = (np.interp(slit_spec_pos, spec_vec, slit_left), np.interp(slit_spec_pos, spec_vec, slit_righ))
 
-    ximg, edgmask = pixels.ximg_and_edgemask(slit_left, slit_righ, thismask, trim_edg = trim_edg)
+    ximg, edgmask = pixels.ximg_and_edgemask(slit_left, slit_righ, thismask, trim_edg=trim_edg)
 
     # If a mask was not passed in, create it
     if inmask is None:
@@ -1505,6 +1505,8 @@ def objfind(image, thismask, slit_left, slit_righ, inmask=None, fwhm=3.0,
     flux_mean_med = np.median(flux_mean[smash_mask])
     flux_mean[np.invert(smash_mask)] = 0.0
     if (nsamp < 9.0*fwhm):
+        # This may lead to many negative fluxsub values..
+        # TODO: Calculate flux_mean_med by avoiding the peak
         fluxsub = flux_mean - flux_mean_med
     else:
         kernel_size= int(np.ceil(bg_smth*fwhm) // 2 * 2 + 1) # This ensure kernel_size is odd
@@ -1523,7 +1525,7 @@ def objfind(image, thismask, slit_left, slit_righ, inmask=None, fwhm=3.0,
 
     cont, cont_mask = arc.iter_continuum(fluxconv, inmask=smash_mask, fwhm=fwhm,
                                          cont_frac_fwhm=2.0, sigthresh=sig_thresh,
-                                         sigrej=2.0, cont_samp=3,npoly=1, cont_mask_neg=True)
+                                         sigrej=2.0, cont_samp=3,npoly=1, cont_mask_neg=True)#, debug=debug)
     # TODO this is experimental, but I'm removing the linear continuum fit
     fluxconv_cont = fluxconv - cont
 
@@ -1581,6 +1583,7 @@ def objfind(image, thismask, slit_left, slit_righ, inmask=None, fwhm=3.0,
         # Possible thresholds    [significance,  fraction of brightest, absolute]
         threshvec = np.array([sig_thresh*sigma, peak_thresh*ypeak.max(), abs_thresh])
         threshold = threshvec.max()
+        #embed(header='1584 of extract')
         if threshvec.argmax() == 0:
             msgs.info('Used SIGNIFICANCE threshold: sig_thresh = {:3.1f}'.format(sig_thresh) +
                       ' * sigma = {:5.2f}'.format(sigma))

--- a/pypeit/core/extract.py
+++ b/pypeit/core/extract.py
@@ -1525,7 +1525,7 @@ def objfind(image, thismask, slit_left, slit_righ, inmask=None, fwhm=3.0,
 
     cont, cont_mask = arc.iter_continuum(fluxconv, inmask=smash_mask, fwhm=fwhm,
                                          cont_frac_fwhm=2.0, sigthresh=sig_thresh,
-                                         sigrej=2.0, cont_samp=3,npoly=1, cont_mask_neg=True)#, debug=debug)
+                                         sigrej=2.0, cont_samp=3,npoly=1, cont_mask_neg=True)
     # TODO this is experimental, but I'm removing the linear continuum fit
     fluxconv_cont = fluxconv - cont
 
@@ -1583,7 +1583,6 @@ def objfind(image, thismask, slit_left, slit_righ, inmask=None, fwhm=3.0,
         # Possible thresholds    [significance,  fraction of brightest, absolute]
         threshvec = np.array([sig_thresh*sigma, peak_thresh*ypeak.max(), abs_thresh])
         threshold = threshvec.max()
-        #embed(header='1584 of extract')
         if threshvec.argmax() == 0:
             msgs.info('Used SIGNIFICANCE threshold: sig_thresh = {:3.1f}'.format(sig_thresh) +
                       ' * sigma = {:5.2f}'.format(sigma))

--- a/pypeit/core/skysub.py
+++ b/pypeit/core/skysub.py
@@ -618,7 +618,7 @@ def local_skysub_extract(sciimg, sciivar, tilts, waveimg, global_sky, rn2_img, t
     if std is True:
         chi2_sigrej = 100.0
         #sigrej_ceil = 1e10
-        sigrej = 25.0
+        sigrej = 50.0  # 25 wasn't enough for MagE 2x2 binning (probably undersampled)
     else:
         chi2_sigrej = 6.0
         #sigrej_ceil = 10.0

--- a/pypeit/debugger.py
+++ b/pypeit/debugger.py
@@ -11,8 +11,6 @@ except ImportError:  # Ginga is not yet required
     pass
 else:
     from pypeit.ginga import clear_canvas
-# Moved to the top and changed to only import set_trace
-from pdb import set_trace
 
 # ADD-ONs from xastropy
 def plot1d(*args, **kwargs):

--- a/pypeit/fluxspec.py
+++ b/pypeit/fluxspec.py
@@ -15,14 +15,10 @@ from pypeit import msgs
 from pypeit.core import flux
 from pypeit.core import load
 from pypeit.core import save
-from pypeit import utils
-from pypeit import masterframe
 from pypeit import specobjs
-
-from pypeit.spectrographs.util import load_spectrograph
-from pypeit.par.pypeitpar import TelescopePar
-
 from pypeit import debugger
+
+from IPython import embed
 
 class FluxSpec(object):
     """Class to guide fluxing
@@ -283,7 +279,14 @@ class FluxSpec(object):
         #mag_func = utils.func_val(self.sens_dict['c'], wave, self.sens_dict['func'])
         #sens = 10.0**(0.4*mag_func)
         # Plot
-        debugger.plot1d(self.sens_dict['wave'], self.sens_dict['sensfunc'], xlbl='Wavelength', ylbl='Sensitivity Function')
+        if self.spectrograph.pypeline == 'Echelle':
+            for iord in range(len(self.std)):
+                sord = str(iord)
+                debugger.plot1d(self.sens_dict[sord]['wave'],
+                                self.sens_dict[sord]['sensfunc'],
+                                xlbl='Wavelength', ylbl='Sensitivity Function')
+        else:
+            debugger.plot1d(self.sens_dict['wave'], self.sens_dict['sensfunc'], xlbl='Wavelength', ylbl='Sensitivity Function')
 
     def write_science(self, outfile):
         """
@@ -362,7 +365,7 @@ class MultiSlit(FluxSpec):
 
         self.sens_dict = {}
         try:
-            this_wave = self.std.optimal['WAVE_GRID']
+            this_wave = self.std.boxcar['WAVE_GRID']
         except KeyError:
             this_wave = self.std.optimal['WAVE']
         sens_dict_long = flux.generate_sensfunc(this_wave,
@@ -444,22 +447,27 @@ class Echelle(FluxSpec):
             return None
 
         ext_final = fits.getheader(self.par['std_file'], -1)
-        norder = ext_final['ECHORDER'] + 1
+        #norder = ext_final['ECHORDER'] + 1
+        norder = len(self.std)
 
         self.sens_dict = {}
         for iord in range(norder):
-            std_specobjs, std_header = load.load_specobjs(self.par['std_file'], order=iord)
-            std_idx = flux.find_standard(std_specobjs)
-            std = std_specobjs[std_idx]
+            #std_specobjs, std_header = load.load_specobjs(self.par['std_file'], order=iord)
+            #embed(header='447 of fluxspec')
+            #std_idx = flux.find_standard(std_specobjs)
+            std = self.std[iord] #std_specobjs[std_idx]
+
+            # THIS IS A CRAZY KLUDGE....
             try:
                 wavemask = std.optimal['WAVE_GRID'] > 0.0 #*units.AA
             except KeyError:
-                wavemask = std.optimal['WAVE'] > 1000.0 * units.AA
-                this_wave = std.optimal['WAVE'][wavemask]
+                wavemask = std.boxcar['WAVE'] > 1000.0 * units.AA
+                this_wave = std.boxcar['WAVE'][wavemask]
             else:
                 this_wave = std.optimal['WAVE_GRID'][wavemask]
 
-            counts, ivar = std.optimal['COUNTS'][wavemask], std.optimal['COUNTS_IVAR'][wavemask]
+            #counts, ivar = std.optimal['COUNTS'][wavemask], std.optimal['COUNTS_IVAR'][wavemask]
+            counts, ivar = std.boxcar['COUNTS'][wavemask], std.boxcar['COUNTS_IVAR'][wavemask]
             sens_dict_iord = flux.generate_sensfunc(this_wave, counts, ivar,
                                                     float(self.std_header['AIRMASS']),
                                                     self.std_header['EXPTIME'],
@@ -473,8 +481,7 @@ class Echelle(FluxSpec):
                                                     poly_norder=self.poly_norder,
                                                     polycorrect=self.polycorrect, debug=self.debug)
             sens_dict_iord['ech_orderindx'] = iord
-            self.sens_dict[str(iord)] = sens_dict_iord
-        ## add some keys to be saved into primary header in masterframe
+            self.sens_dict[str(iord)] = sens_dict_iord  # THIS SHOULD BE THE PHYSICAL ORDER!
         for key in ['wave_max', 'exptime', 'airmass', 'std_file', 'std_ra', 'std_dec',
                     'std_name', 'cal_file']:
             try:

--- a/pypeit/fluxspec.py
+++ b/pypeit/fluxspec.py
@@ -364,10 +364,7 @@ class MultiSlit(FluxSpec):
             return None
 
         self.sens_dict = {}
-        try:
-            this_wave = self.std.boxcar['WAVE_GRID']
-        except KeyError:
-            this_wave = self.std.optimal['WAVE']
+        this_wave = self.std.optimal['WAVE']
         sens_dict_long = flux.generate_sensfunc(this_wave,
                                                self.std.optimal['COUNTS'],
                                                self.std.optimal['COUNTS_IVAR'],

--- a/pypeit/par/pypeitpar.py
+++ b/pypeit/par/pypeitpar.py
@@ -1687,6 +1687,7 @@ class ScienceImagePar(ParSet):
 
     def __init__(self, bspline_spacing=None, boxcar_radius=None, trace_npoly=None,
                  global_sky_std=None, sig_thresh=None, maxnumber=None, sn_gauss=None,
+                 find_trim_edge=None, std_prof_nsigma=None,
                  model_full_slit=None, no_poly=None, manual=None, sky_sigrej=None):
 
         # Grab the parameter names and values from the function
@@ -1719,6 +1720,9 @@ class ScienceImagePar(ParSet):
         dtypes['sky_sigrej'] = float
         descr['sky_sigrej'] = 'Rejection parameter for local sky subtraction'
 
+        # TODO: Consider adding a parameter for trim_edg for skysub+object model
+
+        # Boxcar Parameters
         defaults['boxcar_radius'] = 1.5
         dtypes['boxcar_radius'] = [int, float]
         descr['boxcar_radius'] = 'Boxcar radius in arcseconds used for boxcar extraction'
@@ -1727,7 +1731,10 @@ class ScienceImagePar(ParSet):
         dtypes['trace_npoly'] = int
         descr['trace_npoly'] = 'Order of legendre polynomial fits to object traces.'
 
-        defaults['global_sky_std'] = True
+        defaults['std_prof_nsigma'] = 30.
+        dtypes['std_prof_nsigma'] = float
+        descr['std_prof_nsigma'] = 'prof_nsigma parameter for Standard star extraction.  Prevents undesired rejection.'
+
         dtypes['global_sky_std'] = bool
         descr['global_sky_std'] = 'Global sky subtraction will be performed on standard stars. This should be turned' \
                                   'off for example for near-IR reductions with narrow slits, since bright standards can' \
@@ -1742,6 +1749,10 @@ class ScienceImagePar(ParSet):
         dtypes['maxnumber'] = int
         descr['maxnumber'] = 'Maximum number of objects to extract in a science frame.  Use ' \
                              'None for no limit.'
+
+        defaults['find_trim_edge'] = [5,5]
+        dtypes['find_trim_edge'] = list
+        descr['find_trim_edge'] = 'Trim the slit by this number of pixels left/right before finding objects'
 
         defaults['sn_gauss'] = 4.0
         dtypes['sn_gauss'] = [int, float]
@@ -1777,6 +1788,7 @@ class ScienceImagePar(ParSet):
         #ToDO change to updated param list
         parkeys = ['bspline_spacing', 'boxcar_radius', 'trace_npoly', 'global_sky_std',
                    'sig_thresh', 'maxnumber', 'sn_gauss', 'model_full_slit', 'no_poly', 'manual',
+                   'find_trim_edge', 'std_prof_nsigma',
                    'sky_sigrej']
         kwargs = {}
         for pk in parkeys:

--- a/pypeit/pypeit.py
+++ b/pypeit/pypeit.py
@@ -555,7 +555,6 @@ class PypeIt(object):
         msgs.sciexp = self.sciI
 
         # Process images (includes inverse variance image, rn2 image, and CR mask)
-        #self.sciimg, self.sciivar, self.rn2img, self.mask, self.crmask = \
         self.sciImg = self.sciI.proc(self.caliBrate.msbias, self.caliBrate.mspixelflat.copy(),
                            self.caliBrate.msbpm, illum_flat=self.caliBrate.msillumflat,
                            show=self.show)
@@ -577,6 +576,7 @@ class PypeIt(object):
                                     std_trace=std_trace, maskslits=self.maskslits,
                                     show=self.show & (not self.std_redux),
                                     manual_extract_dict=manual_extract_dict)
+        #embed(header='579 of pyepit')
 
         # Global sky subtraction, first pass. Uses skymask from object finding step above
         self.initial_sky = \
@@ -590,6 +590,10 @@ class PypeIt(object):
                                   std_trace=std_trace,maskslits=self.maskslits,show=self.show,
                                         manual_extract_dict=manual_extract_dict,
                                         skysub_img=self.initial_sky)
+        else:
+            # For standard stars
+            for iobj in self.sobjs_obj:
+                iobj.prof_nsigma = self.par['scienceimage']['std_prof_nsigma']
 
         # If there are objects, do 2nd round of global_skysub, local_skysub_extract, flexure, geo_motion
         if self.nobj > 0:

--- a/pypeit/reduce.py
+++ b/pypeit/reduce.py
@@ -603,6 +603,7 @@ class MultiSlit(Reduce):
                                 sig_thresh=sig_thresh, hand_extract_dict=manual_extract_dict,
                                 specobj_dict=specobj_dict, show_peaks=show_peaks,
                                 show_fits=show_fits, show_trace=show_trace,
+                                trim_edg=self.redux_par['find_trim_edge'],
                                 qa_title=qa_title, nperslit=self.redux_par['maxnumber'])
             sobjs.add_sobj(sobjs_slit)
 
@@ -734,6 +735,7 @@ class Echelle(Reduce):
                                 plate_scale=plate_scale, std_trace=std_trace,
                                 specobj_dict=specobj_dict,sig_thresh=sig_thresh,
                                 show_peaks=show_peaks, show_fits=show_fits,
+                                trim_edg=self.redux_par['find_trim_edge'],
                                 show_trace=show_trace, debug=debug)
 
         # Steps

--- a/pypeit/scripts/flux_spec.py
+++ b/pypeit/scripts/flux_spec.py
@@ -91,8 +91,9 @@ def main(args, unit_test=False):
     import numpy as np
 
     from pypeit import fluxspec
-    from pypeit.core import flux
     from pypeit.par import pypeitpar
+
+    from IPython import embed
 
 
     # Load the file

--- a/pypeit/spectrographs/magellan_mage.py
+++ b/pypeit/spectrographs/magellan_mage.py
@@ -100,6 +100,7 @@ class MagellanMAGESpectrograph(spectrograph.Spectrograph):
         par['calibrations']['slits']['sigdetect'] = 10.  # Tough to get the bluest orders
         # Scienceimage default parameters
         par['scienceimage'] = pypeitpar.ScienceImagePar()
+        par['scienceimage']['find_trim_edge'] = [4,4]    # Slit is too short to trim 5,5 especially with 2x binning
         # Always flux calibrate, starting with default parameters
         par['fluxcalib'] = pypeitpar.FluxCalibrationPar()
         # Do not correct for flexure
@@ -308,10 +309,8 @@ class MagellanMAGESpectrograph(spectrograph.Spectrograph):
             np.ndarray: Platescale
 
         """
-        # MAGE has no binning, but for an instrument with binning we would do this
-        #binspatial, binspectral = parse.parse_binning(binning)
         norders = len(order_vec)
         binspatial, binspec = parse.parse_binning(binning)
-        return np.full(norders, 0.15*binspatial)
+        return np.full(norders, 0.30*binspatial)
 
 


### PR DESCRIPTION
A small set of updates to get 2x2 binning with MagE to reduce 
and flux.  Includes a number of "bug fixes" to `fluxspec`. 
Here are the main changes:

- Add find_trim_edge and std_prof_nsigma parameters
- A bit of tuning for MagE
- Fixes for Echelle in fluxspec