### PR TITLE
Show2dspec hotfix

### DIFF
--- a/pypeit/ginga.py
+++ b/pypeit/ginga.py
@@ -3,6 +3,7 @@
 import os
 import numpy as np
 import time
+import IPython
 
 import subprocess
 

--- a/pypeit/scripts/show_2dspec.py
+++ b/pypeit/scripts/show_2dspec.py
@@ -115,9 +115,8 @@ def main(args):
     # Get waveimg
     mdir = head0['PYPMFDIR']+'/'
     if not os.path.exists(mdir):
-        mdir_base = os.path.basename(os.path.dirname(mdir)) + '/'
-        IPython.embed()
-        msgs.warn('Master file dir: {0} does not exist. Using ./{1}'.format(mdir, mdir_base))
+        mdir_base = os.path.join(os.getcwd(), os.path.basename(os.path.dirname(mdir)))
+        msgs.warn('Master file dir: {0} does not exist. Using {1}'.format(mdir, mdir_base))
         mdir=mdir_base
 
     trace_key = '{0}_{1:02d}'.format(head0['TRACMKEY'], args.det)

--- a/pypeit/scripts/show_2dspec.py
+++ b/pypeit/scripts/show_2dspec.py
@@ -116,6 +116,7 @@ def main(args):
     mdir = head0['PYPMFDIR']+'/'
     if not os.path.exists(mdir):
         mdir_base = os.path.basename(os.path.dirname(mdir)) + '/'
+        IPython.embed()
         msgs.warn('Master file dir: {0} does not exist. Using ./{1}'.format(mdir, mdir_base))
         mdir=mdir_base
 


### PR DESCRIPTION
There was a bug in the show2dspec script. If the data has been moved, such that the masterfile path has changed, the code defaults to assuming masters are in ./Masters. However, this breaks the waveimg functionality we added to ginga, because ginga seems to stupidly require absolute file paths. This is now fixed. It is a one line change. 