### PR TITLE
Refactoring rawdatasec_img and BPM

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,10 @@
 - Revamped 2-d coadding routines and introduced 2-d coadding of MultiSlit data
 - Improved ginga plotting routines.
 - Fixed bug associated with astropy.stats.sigma_clipped_stats when astropy.stats.mad_std is used.
+- Break apart LRIS and DEIMOS image reading from section parsing
+- Refactor BPM generation
+- Merge raw_image loading with datasec_img and oscansec_img generation
+- Sync datasec_img to image in ProcessRawImage
 
 0.11.0 (22 Jun 2019)
 --------------------

--- a/pypeit/calibrations.py
+++ b/pypeit/calibrations.py
@@ -445,6 +445,8 @@ class Calibrations(object):
 
         # Build the data-section image
         sci_image_file = self.fitstbl.frame_paths(self.frame)
+
+        '''
         rdsec_img = self.spectrograph.get_rawdatasec_img(sci_image_file, det=self.det)
 
         # Instantiate the shape here, based on the shape of the science
@@ -453,9 +455,11 @@ class Calibrations(object):
         trim = procimg.trim_frame(rdsec_img, rdsec_img < 1)
         orient = self.spectrograph.orient_image(trim, self.det)
         self.shape = orient.shape
+        '''
 
         # Build it
-        self.msbpm = self.spectrograph.bpm(shape=self.shape, filename=sci_image_file, det=self.det)
+        self.msbpm = self.spectrograph.bpm(sci_image_file, self.det)
+        self.shape = self.msbpm.shape
 
         # Record it
         self._update_cache('bpm', 'bpm', self.msbpm)

--- a/pypeit/calibrations.py
+++ b/pypeit/calibrations.py
@@ -446,17 +446,6 @@ class Calibrations(object):
         # Build the data-section image
         sci_image_file = self.fitstbl.frame_paths(self.frame)
 
-        '''
-        rdsec_img = self.spectrograph.get_rawdatasec_img(sci_image_file, det=self.det)
-
-        # Instantiate the shape here, based on the shape of the science
-        # image. This is the shape of most calibrations, although we are
-        # allowing for arcs of different shape because of X-shooter etc.
-        trim = procimg.trim_frame(rdsec_img, rdsec_img < 1)
-        orient = self.spectrograph.orient_image(trim, self.det)
-        self.shape = orient.shape
-        '''
-
         # Build it
         self.msbpm = self.spectrograph.bpm(sci_image_file, self.det)
         self.shape = self.msbpm.shape

--- a/pypeit/core/arc.py
+++ b/pypeit/core/arc.py
@@ -432,60 +432,40 @@ def resize_spec(spec_from, nspec_to):
     return spec_to
 
 
+def get_censpec(slit_cen, slitmask, arcimg, gpm=None, box_rad=3.0,
+                nonlinear_counts=1e10):
+    """
+    Extract a boxcar spectrum down the center of the slit
 
-def get_censpec(slit_cen, slitmask, arcimg, inmask = None, box_rad = 3.0, xfrac = 0.5, nonlinear_counts=1e10):
+    Args:
+        slit_cen (np.ndarray):
+            Trace down the center of the slit
+        slitmask (np.ndarray):
+        arcimg (np.ndarray):
+            Image to extract the arc from. This should be an arcimage or perhaps a frame with night sky lines.
+        gpm (np.ndarray, optional):
+            Input mask image with same shape as arcimg. Convention True = good and False = bad. The default is None.
+        box_rad (float, optional):
+            Size of boxcar window in pixels (as a floating point number) in the spatial direction used to extract the arc.
+        nonlinear_counts (float, optional):
+            Values exceeding this input value are masked as bad
 
-    """Extract a spectrum down
-
-
-    Parameters
-    ----------
-    slit_left:  float ndarray
-        Left boundary of slit/order to be extracted (given as floating pt pixels). This a 1-d array with shape (nspec, 1)
-        or (nspec)
-
-    slit_righ:  float ndarray
-        Left boundary of slit/order to be extracted (given as floating pt pixels). This a 1-d array with shape (nspec, 1)
-        or (nspec)
-
-
-    slitpix:  float  ndarray
-        Mask image specifying the pixels which lie on the slit/order to search for objects on. This is created by
-        traceslits in the tslits_dict, and has the convention that each slit/order has an integer index starting with one.
-        Locations with zeros are not on slits/orders.
-
-    arcimg:  float ndarray
-        Image to extract the arc from. This should be an arcimage or perhaps a frame with night sky lines.
-
-    Optional Parameters
-    ----------
-    inmask: boolean ndararay
-         Input mask image with same shape as arcimg. Convention True = good and False = bad. The default is None.
-
-    box_rad: float, [default = 3.0]
-        Size of boxcar window in pixels (as a floating point number) in the spatial direction used to extract the arc.
-
-    xfrac: float [default = 0.5]
-        Fraction location along the slit to extract the arc. The default is at the midpoint of the slit which is 0.5,
-        but this can be adjusted to an off center location.
-
-    Returns
-    -------
-    :func:`tuple`
-         A tuple containing the (arc_spec, maskslit)
+    Returns:
+        tuple:
+            A tuple containing the (arc_spec, maskslit)
 
             arc_spec: float ndarray with shape (nspec, nslits)
                 Array containing the extracted arc spectrum for each slit.
 
             maskslit: int ndarray with shape (nslits)
                output mask indicating whether a slit is good or bad. 0 = good, 1 = bad.
-     """
 
-    if inmask is None:
-        inmask = slitmask > -1
+    """
+    if gpm is None:
+        gpm = slitmask > -1
 
     # Mask saturated parts of the arc image for the extraction
-    inmask = inmask & (arcimg < nonlinear_counts)
+    gpm = gpm & (arcimg < nonlinear_counts)
 
     nslits = slit_cen.shape[1]
     (nspec, nspat) = arcimg.shape
@@ -498,12 +478,12 @@ def get_censpec(slit_cen, slitmask, arcimg, inmask = None, box_rad = 3.0, xfrac 
         msgs.info("Extracting an approximate arc spectrum at the centre of slit {:d}".format(islit))
         # Create a mask for the pixels that will contribue to the arc
         slit_img = np.outer(slit_cen[:,islit], np.ones(nspat))  # central trace replicated spatially
-        arcmask = (slitmask > -1) & inmask & (spat_img > (slit_img - box_rad)) & (spat_img < (slit_img + box_rad))
+        arcmask = (slitmask > -1) & gpm & (spat_img > (slit_img - box_rad)) & (spat_img < (slit_img + box_rad))
         # Trimming the image makes this much faster
         left = np.fmax(spat_img[arcmask].min() - 4,0)
         righ = np.fmin(spat_img[arcmask].max() + 5,nspat)
-        this_mean, this_med, this_sig = stats.sigma_clipped_stats(arcimg[:,left:righ], mask=np.invert(arcmask[:,left:righ])
-                                                            , sigma=3.0, axis=1)
+        this_mean, this_med, this_sig = stats.sigma_clipped_stats(
+            arcimg[:,left:righ], mask=np.invert(arcmask[:,left:righ]), sigma=3.0, axis=1)
         imask = np.isnan(this_med)
         this_med[imask]=0.0
         arc_spec[:,islit] = this_med

--- a/pypeit/core/procimg.py
+++ b/pypeit/core/procimg.py
@@ -237,7 +237,7 @@ def grow_masked(img, grow, growval):
     return _img
 
 
-def gain_frame(amp_img, gain, trim=True):
+def gain_frame(amp_img, gain, trim=False):
     """
     Generate an image with the gain for each pixel.
 
@@ -249,7 +249,7 @@ def gain_frame(amp_img, gain, trim=True):
             List of amplifier gain values.  Must be that the gain for
             amplifier 1 is provided by `gain[0]`, etc.
         trim (:obj:`bool`, optional):
-            Trim the overscan section from the image.
+            Trim; not recommended
 
     Returns:
         `numpy.ndarray`: Image with the gain for each pixel.

--- a/pypeit/core/procimg.py
+++ b/pypeit/core/procimg.py
@@ -328,7 +328,7 @@ def subtract_overscan(rawframe, datasec_img, oscansec_img,
     Subtract overscan
 
     Args:
-        frame (:obj:`numpy.ndarray`):
+        rawframe (:obj:`numpy.ndarray`):
             Frame from which to subtract overscan
         numamplifiers (int):
             Number of amplifiers for this detector.

--- a/pypeit/images/processrawimage.py
+++ b/pypeit/images/processrawimage.py
@@ -61,7 +61,7 @@ class ProcessRawImage(pypeitimage.PypeItImage):
         self.hdu = None
 
         # Load -- This also initializes rawdatasec_img and oscansec_img
-        self.rawdatasec_img, self.oscansec_img = self.load_rawframe()
+        self.load_rawframe()
 
         # All possible processing steps
         #  Note these have to match the method names below

--- a/pypeit/images/processrawimage.py
+++ b/pypeit/images/processrawimage.py
@@ -252,15 +252,14 @@ class ProcessRawImage(pypeitimage.PypeItImage):
 
         """
         # Load
-        #self.image, self.hdu, \
-        #    = self.spectrograph.load_raw_frame(self.filename, det=self.det)
-        self.hdu, self.image, self.exptime, self.datasec_img, self.oscansec_img = self.spectrograph.load_raw(
-            self.filename, self.det)
+        self.image, self.hdu, \
+            = self.spectrograph.load_raw_frame(self.filename, det=self.det)
+        self.exptime, self.datasec_img, self.oscansec_img, self.binning_raw \
+            = self.spectrograph.load_raw_extras(self.hdu, self.det)
 
         self.head0 = self.hdu[0].header
         # Shape
         self.orig_shape = self.image.shape
-
 
     def orient(self, force=False):
         """

--- a/pypeit/images/pypeitimage.py
+++ b/pypeit/images/pypeitimage.py
@@ -19,6 +19,8 @@ class PypeItImage(object):
 
     Attributes:
         image (np.ndarray):
+        datasec_img (np.ndarray):
+            Used for the amplifiers
         head0 (astropy.io.fits.Header):
         orig_shape (tuple):
         binning_raw (tuple):  Binning in the raw image orientaion (NAXIS1, NAXIS2)
@@ -35,6 +37,7 @@ class PypeItImage(object):
 
         # Attributes
         self.image = None
+        self.datasec_img = None
         self.head0 = None           # Image header
         self.orig_shape = None       # Shape of the image when loaded
         self.binning_raw = None     # Binning in the raw image orientation;  e.g. bin_1, bin_2 (for NAXIS1, NAXIS2)

--- a/pypeit/metadata.py
+++ b/pypeit/metadata.py
@@ -291,8 +291,7 @@ class PypeItMetaData:
 
             # Grab Meta
             for meta_key in self.spectrograph.meta.keys():
-                value = self.spectrograph.get_meta_value(ifile, meta_key, headarr=headarr,
-                                                         required=strict, usr_row=usr_row,
+                value = self.spectrograph.get_meta_value(headarr, meta_key, required=strict, usr_row=usr_row,
                                         ignore_bad_header=self.par['rdx']['ignore_bad_headers'])
                 data[meta_key].append(value)
             msgs.info('Added metadata for {0}'.format(os.path.split(ifile)[1]))

--- a/pypeit/spectrographs/gemini_gmos.py
+++ b/pypeit/spectrographs/gemini_gmos.py
@@ -326,7 +326,7 @@ class GeminiGMOSSHamSpectrograph(GeminiGMOSSpectrograph):
         ]
         self.numhead = 13
 
-    def bpm(self, shape=None, filename=None, det=None, **null_kwargs):
+    def bpm(self, filename, det, shape=None):
         """ Generate a BPM
 
         Parameters
@@ -341,7 +341,7 @@ class GeminiGMOSSHamSpectrograph(GeminiGMOSSpectrograph):
 
         """
         # Get the empty bpm: force is always True
-        self.empty_bpm(shape=shape, filename=filename, det=det)
+        bpm_img = self.empty_bpm(filename, det, shape=shape)
 
         if det == 1:
             msgs.info("Using hard-coded BPM for det=1 on GMOSs")
@@ -355,7 +355,7 @@ class GeminiGMOSSHamSpectrograph(GeminiGMOSSpectrograph):
             # Apply the mask
             xbin = int(binning.split(' ')[0])
             badc = 616//xbin
-            self.bpm_img[badc,:] = 1
+            bpm_img[badc,:] = 1
         elif det == 2:
             msgs.info("Using hard-coded BPM for det=2 on GMOSs")
 
@@ -370,10 +370,10 @@ class GeminiGMOSSHamSpectrograph(GeminiGMOSSpectrograph):
                 embed()
             # Up high
             badr = (898*2)//xbin # Transposed
-            self.bpm_img[badr:badr+(8*2)//xbin,:] = 1
+            bpm_img[badr:badr+(8*2)//xbin,:] = 1
             # Down low
             badr = (161*2)//xbin # Transposed
-            self.bpm_img[badr,:] = 1
+            bpm_img[badr,:] = 1
         elif det == 3:
             msgs.info("Using hard-coded BPM for det=3 on GMOSs")
 
@@ -387,9 +387,9 @@ class GeminiGMOSSHamSpectrograph(GeminiGMOSSpectrograph):
             if xbin != 2:
                 embed()
             badr = (281*2)//xbin # Transposed
-            self.bpm_img[badr:badr+(2*2)//xbin,:] = 1
+            bpm_img[badr:badr+(2*2)//xbin,:] = 1
 
-        return self.bpm_img
+        return bpm_img
 
 
 

--- a/pypeit/spectrographs/gemini_gnirs.py
+++ b/pypeit/spectrographs/gemini_gnirs.py
@@ -251,7 +251,7 @@ class GeminiGNIRSSpectrograph(spectrograph.Spectrograph):
         return np.power(10.0,loglam_grid)
 
 
-    def bpm(self, shape=None, filename=None, det=None, **null_kwargs):
+    def bpm(self, filename, det, shape=None):
         """
         Override parent bpm function with BPM specific to X-Shooter VIS.
 
@@ -271,12 +271,12 @@ class GeminiGNIRSSpectrograph(spectrograph.Spectrograph):
 
         """
         msgs.info("Custom bad pixel mask for GNIRS")
-        self.empty_bpm(shape=shape, filename=filename, det=det)
+        bpm_img = self.empty_bpm(filename, det, shape=shape)
         if det == 1:
-            self.bpm_img[:, :20] = 1.
-            self.bpm_img[:, 1000:] = 1.
+            bpm_img[:, :20] = 1.
+            bpm_img[:, 1000:] = 1.
 
-        return self.bpm_img
+        return bpm_img
 
 
 

--- a/pypeit/spectrographs/keck_deimos.py
+++ b/pypeit/spectrographs/keck_deimos.py
@@ -422,17 +422,7 @@ class KeckDEIMOSSpectrograph(spectrograph.Spectrograph):
         Return a string representation of a slice defining a section of
         the detector image.
 
-        Overwrites base class function to use :func:`read_deimos` to get
-        the image sections.
-
-        .. todo ::
-            - It is really ineffiecient.  Can we parse
-              :func:`read_deimos` into something that can give you the
-              image section directly?
-
-        This is done separately for the data section and the overscan
-        section in case one is defined as a header keyword and the other
-        is defined directly.
+        Overwrites base class function
 
         Args:
             inp (:obj:`str`, `astropy.io.fits.Header`_, optional):
@@ -872,6 +862,19 @@ class DEIMOSDetectorMap(DetectorMap):
 
 
 def deimos_image_sections(inp, det):
+    """
+    Parse the image for the raw image shape and data sections
+
+    Args:
+        inp (str or `astropy.io.fits.HDUList`_ object):
+        det (int):
+
+    Returns:
+        tuple:
+            shape, dsec, osec, ext_items
+            ext_items is a large tuple of bits and pieces for other methods
+                ext_items = hdu, chips, postpix, image
+    """
     # Check for file; allow for extra .gz, etc. suffix
     if isinstance(inp, str):
         fil = glob.glob(inp + '*')
@@ -1028,15 +1031,13 @@ def indexing(itt, postpix, det=None):
 def deimos_read_1chip(hdu,chipno):
     """ Read one of the DEIMOS detectors
 
-    Parameters
-    ----------
-    hdu : HDUList
-    chipno : int
+    Args:
+        hdu (astropy.io.fits.HDUList):
+        chipno (int):
 
-    Returns
-    -------
-    data : ndarray
-    oscan : ndarray
+    Returns:
+        np.ndarray, np.ndarray:
+            data, oscan
     """
 
     # Extract datasec from header

--- a/pypeit/spectrographs/keck_deimos.py
+++ b/pypeit/spectrographs/keck_deimos.py
@@ -255,20 +255,22 @@ class KeckDEIMOSSpectrograph(spectrograph.Spectrograph):
         par = self.default_pypeit_par() if inp_par is None else inp_par
         # TODO: Should we allow the user to override these?
 
+        headarr = self.get_headarr(scifile)
+
         # Templates
-        if self.get_meta_value(scifile, 'dispname') == '600ZD':
+        if self.get_meta_value(headarr, 'dispname') == '600ZD':
             par['calibrations']['wavelengths']['method'] = 'full_template'
             par['calibrations']['wavelengths']['reid_arxiv'] = 'keck_deimos_600.fits'
             par['calibrations']['wavelengths']['lamps'] += ['CdI', 'ZnI', 'HgI']
-        elif self.get_meta_value(scifile, 'dispname') == '830G':
+        elif self.get_meta_value(headarr, 'dispname') == '830G':
             par['calibrations']['wavelengths']['method'] = 'full_template'
             par['calibrations']['wavelengths']['reid_arxiv'] = 'keck_deimos_830G.fits'
-        elif self.get_meta_value(scifile, 'dispname') == '1200G':
+        elif self.get_meta_value(headarr, 'dispname') == '1200G':
             par['calibrations']['wavelengths']['method'] = 'full_template'
             par['calibrations']['wavelengths']['reid_arxiv'] = 'keck_deimos_1200G.fits'
 
         # FWHM
-        binning = parse.parse_binning(self.get_meta_value(scifile, 'binning'))
+        binning = parse.parse_binning(self.get_meta_value(headarr, 'binning'))
         par['calibrations']['wavelengths']['fwhm'] = 6.0 / binning[1]
 
         # Return
@@ -466,23 +468,19 @@ class KeckDEIMOSSpectrograph(spectrograph.Spectrograph):
         else:
             raise ValueError('Unrecognized keyword: {0}'.format(section))
 
-    def get_raw_image_shape(self, filename=None, det=None, **null_kwargs):
+    def get_raw_image_shape(self, hdulist, det=None, **null_kwargs):
         """
         Overrides :class:`Spectrograph.get_image_shape` for LRIS images.
 
         Must always provide a file.
         """
-        # Cannot be determined without file
-        if filename is None:
-            raise ValueError('Must provide a file to determine the shape of an LRIS image.')
-
-        # Use a file
+        # Do it
         self._check_detector()
-        shape, datasec, oscansec, _ = deimos_image_sections(filename, det)
+        shape, datasec, oscansec, _ = deimos_image_sections(hdulist, det)
         self.naxis = shape
         return self.naxis
 
-    def bpm(self, shape=None, filename=None, det=None, **null_kwargs):
+    def bpm(self, filename, det):
         """
         Override parent bpm function with BPM specific to DEIMOS.
 
@@ -501,49 +499,49 @@ class KeckDEIMOSSpectrograph(spectrograph.Spectrograph):
           0 = ok; 1 = Mask
 
         """
-        self.empty_bpm(shape=shape, filename=filename, det=det)
+        bpm_img = self.empty_bpm(filename, det)
         if det == 1:
-            self.bpm_img[:,1052:1054] = 1
+            bpm_img[:,1052:1054] = 1
         elif det == 2:
-            self.bpm_img[:,0:4] = 1
-            self.bpm_img[:,376:381] = 1
-            self.bpm_img[:,489] = 1
-            self.bpm_img[:,1333:1335] = 1
-            self.bpm_img[:,2047] = 1
+            bpm_img[:,0:4] = 1
+            bpm_img[:,376:381] = 1
+            bpm_img[:,489] = 1
+            bpm_img[:,1333:1335] = 1
+            bpm_img[:,2047] = 1
         elif det == 3:
-            self.bpm_img[:,0:4] = 1
-            self.bpm_img[:,221] = 1
-            self.bpm_img[:,260] = 1
-            self.bpm_img[:,366] = 1
-            self.bpm_img[:,816:819] = 1
-            self.bpm_img[:,851] = 1
-            self.bpm_img[:,940] = 1
-            self.bpm_img[:,1167] = 1
-            self.bpm_img[:,1280] = 1
-            self.bpm_img[:,1301:1303] = 1
-            self.bpm_img[:,1744:1747] = 1
-            self.bpm_img[:,-4:] = 1
+            bpm_img[:,0:4] = 1
+            bpm_img[:,221] = 1
+            bpm_img[:,260] = 1
+            bpm_img[:,366] = 1
+            bpm_img[:,816:819] = 1
+            bpm_img[:,851] = 1
+            bpm_img[:,940] = 1
+            bpm_img[:,1167] = 1
+            bpm_img[:,1280] = 1
+            bpm_img[:,1301:1303] = 1
+            bpm_img[:,1744:1747] = 1
+            bpm_img[:,-4:] = 1
         elif det == 4:
-            self.bpm_img[:,0:4] = 1
-            self.bpm_img[:,47] = 1
-            self.bpm_img[:,744] = 1
-            self.bpm_img[:,790:792] = 1
-            self.bpm_img[:,997:999] = 1
+            bpm_img[:,0:4] = 1
+            bpm_img[:,47] = 1
+            bpm_img[:,744] = 1
+            bpm_img[:,790:792] = 1
+            bpm_img[:,997:999] = 1
         elif det == 5:
-            self.bpm_img[:,25:27] = 1
-            self.bpm_img[:,128:130] = 1
-            self.bpm_img[:,1535:1539] = 1
+            bpm_img[:,25:27] = 1
+            bpm_img[:,128:130] = 1
+            bpm_img[:,1535:1539] = 1
         elif det == 7:
-            self.bpm_img[:,426:428] = 1
-            self.bpm_img[:,676] = 1
-            self.bpm_img[:,1176:1178] = 1
+            bpm_img[:,426:428] = 1
+            bpm_img[:,676] = 1
+            bpm_img[:,1176:1178] = 1
         elif det == 8:
-            self.bpm_img[:,440] = 1
-            self.bpm_img[:,509:513] = 1
-            self.bpm_img[:,806] = 1
-            self.bpm_img[:,931:934] = 1
+            bpm_img[:,440] = 1
+            bpm_img[:,509:513] = 1
+            bpm_img[:,806] = 1
+            bpm_img[:,931:934] = 1
 
-        return self.bpm_img
+        return bpm_img
 
     def get_slitmask(self, filename):
         hdu = fits.open(filename)
@@ -931,13 +929,14 @@ def deimos_image_sections(inp, det):
         shape = image.shape
     else:
         image = None
-        head = hdu[chips[0]].header
-        shape = (head['NAXIS2'], head['NAXIS1'])
+        head = hdu[chips[0]+1].header
+        shape = (head['NAXIS2'], head['NAXIS1']-precol)  # We don't load up the precol
 
     # Pack up a few items for use elsewhere
     ext_items = hdu, chips, postpix, image
     # Return
     return shape, dsec, osec, ext_items
+
 
 def read_deimos(raw_file, det=None):
     """

--- a/pypeit/spectrographs/keck_deimos.py
+++ b/pypeit/spectrographs/keck_deimos.py
@@ -470,7 +470,7 @@ class KeckDEIMOSSpectrograph(spectrograph.Spectrograph):
         self.naxis = shape
         return self.naxis
 
-    def bpm(self, filename, det):
+    def bpm(self, filename, det, shape=None):
         """
         Override parent bpm function with BPM specific to DEIMOS.
 
@@ -489,7 +489,7 @@ class KeckDEIMOSSpectrograph(spectrograph.Spectrograph):
           0 = ok; 1 = Mask
 
         """
-        bpm_img = self.empty_bpm(filename, det)
+        bpm_img = self.empty_bpm(filename, det, shape=shape)
         if det == 1:
             bpm_img[:,1052:1054] = 1
         elif det == 2:

--- a/pypeit/spectrographs/keck_lris.py
+++ b/pypeit/spectrographs/keck_lris.py
@@ -394,7 +394,7 @@ class KeckLRISBSpectrograph(KeckLRISSpectrograph):
         # Add the name of the dispersing element
         self.meta['dispname'] = dict(ext=0, card='GRISNAME')
 
-    def bpm(self, filename, det):
+    def bpm(self, filename, det, shape=None):
         """ Generate a BPM
 
         Args:
@@ -406,7 +406,7 @@ class KeckLRISBSpectrograph(KeckLRISSpectrograph):
 
         """
         # Get the empty bpm: force is always True
-        bpm_img = self.empty_bpm(filename, det)
+        bpm_img = self.empty_bpm(filename, det, shape=shape)
 
         # Only defined for det=1
         if det == 1:
@@ -614,7 +614,7 @@ class KeckLRISRSpectrograph(KeckLRISSpectrograph):
         # Add grating tilt
         return cfg_keys+['dispangle']
 
-    def bpm(self, filename, det):
+    def bpm(self, filename, det, shape=None):
         """ Generate a BPM
 
         Args:
@@ -626,7 +626,7 @@ class KeckLRISRSpectrograph(KeckLRISSpectrograph):
 
         """
         # Get the empty bpm: force is always True
-        bpm_img = self.empty_bpm(filename, det)
+        bpm_img = self.empty_bpm(filename, det, shape=shape)
         
         # Only defined for det=2
         if det == 2:

--- a/pypeit/spectrographs/keck_lris.py
+++ b/pypeit/spectrographs/keck_lris.py
@@ -207,7 +207,7 @@ class KeckLRISSpectrograph(spectrograph.Spectrograph):
         is defined directly.
 
         Args:
-            inp (:obj:`str`, `astropy.io.fits.Header`_, optional):
+            inp (:obj:`str`, hdulist):
                 String providing the file name to read, or the relevant
                 header object.  Default is None, meaning that the
                 detector attribute must provide the image section
@@ -230,11 +230,9 @@ class KeckLRISSpectrograph(spectrograph.Spectrograph):
         """
         # Read the file
         if inp is None:
-            msgs.error('Must provide Keck LRIS file to get image section.')
-        elif not os.path.isfile(inp):
-            msgs.error('File {0} does not exist!'.format(inp))
+            msgs.error('Must provide Keck LRIS file or hdulist to get image section.')
         # Read em
-        shape, datasec, oscansec, _ = lris_image_sections(raw_file=inp, det=det)
+        shape, datasec, oscansec, _ = lris_image_sections(inp, det=det)
         #_, _, secs = read_lris(inp, det)
         if section == 'datasec':
             return datasec, False, False
@@ -841,7 +839,7 @@ def lris_parse_extensions(hdu, det):
     return hdu, n_ext, preline, postline, nx, ny, xbin, ybin, precol, postpix, xcol, order[det_idx]
 
 
-def lris_image_sections(raw_file, det):
+def lris_image_sections(inp, det):
     """
 
     Args:
@@ -852,11 +850,14 @@ def lris_image_sections(raw_file, det):
         tuple, list, list:  shape, datasecs, oscansecs
 
     """
+    if isinstance(inp, str):
+        hdu = fits.open(inp)
+    else:
+        hdu = inp
 
-    hdu = fits.open(raw_file)
     ext_items = lris_parse_extensions(hdu, det)
     # Unpack for usage
-    hdu, n_ext, preline, postline, nx,  ny, xbin, ybin, precol, postpix, xcol, order = ext_items
+    _, n_ext, preline, postline, nx,  ny, xbin, ybin, precol, postpix, xcol, order = ext_items
 
     shape = (ny, nx)
 

--- a/pypeit/spectrographs/keck_lris.py
+++ b/pypeit/spectrographs/keck_lris.py
@@ -396,31 +396,26 @@ class KeckLRISBSpectrograph(KeckLRISSpectrograph):
         # Add the name of the dispersing element
         self.meta['dispname'] = dict(ext=0, card='GRISNAME')
 
-    def bpm(self, shape=None, filename=None, det=None, **null_kwargs):
+    def bpm(self, filename, det):
         """ Generate a BPM
 
-        Parameters
-        ----------
-        shape : tuple, REQUIRED
-        filename : str,
-        det : int, REQUIRED
-        **null_kwargs:
-           Captured and never used
+        Args:
+            filename (str):
+            det (int):
 
-        Returns
-        -------
-        badpix : ndarray
+        Returns:
+            np.ndarray:
 
         """
         # Get the empty bpm: force is always True
-        self.empty_bpm(shape=shape, filename=filename, det=det)
+        bpm_img = self.empty_bpm(filename, det)
 
         # Only defined for det=1
         if det == 1:
             msgs.info("Using hard-coded BPM for det=1 on LRISb")
-            self.bpm_img[:,:3] = 1
+            bpm_img[:,:3] = 1
 
-        return self.bpm_img
+        return bpm_img
 
 
 class KeckLRISRSpectrograph(KeckLRISSpectrograph):
@@ -621,24 +616,19 @@ class KeckLRISRSpectrograph(KeckLRISSpectrograph):
         # Add grating tilt
         return cfg_keys+['dispangle']
 
-    def bpm(self, shape=None, filename=None, det=None, **null_kwargs):
+    def bpm(self, filename, det):
         """ Generate a BPM
 
-        Parameters
-        ----------
-        shape : tuple, REQUIRED
-        filename : str, REQUIRED for binning
-        det : int, REQUIRED
-        **null_kwargs:
-           Captured and never used
+        Args:
+            filename (str):
+            det (int):
 
-        Returns
-        -------
-        badpix : ndarray
+        Returns:
+            np.ndarray
 
         """
         # Get the empty bpm: force is always True
-        self.empty_bpm(shape=shape, filename=filename, det=det)
+        bpm_img = self.empty_bpm(filename, det)
         
         # Only defined for det=2
         if det == 2:
@@ -652,9 +642,9 @@ class KeckLRISRSpectrograph(KeckLRISSpectrograph):
             # Apply the mask
             xbin = int(binning.split(',')[0])
             badc = 16//xbin
-            self.bpm_img[:, 0:badc] = 1
+            bpm_img[:, 0:badc] = 1
 
-        return self.bpm_img
+        return bpm_img
 
 
 class KeckLRISRLSpectrograph(KeckLRISRSpectrograph):

--- a/pypeit/spectrographs/keck_nires.py
+++ b/pypeit/spectrographs/keck_nires.py
@@ -159,7 +159,7 @@ class KeckNIRESSpectrograph(spectrograph.Spectrograph):
         return (fitstbl['idname'] == 'object') \
                         & framematch.check_frame_exptime(fitstbl['exptime'], exprng)
 
-    def bpm(self, shape=None, filename=None, det=None, **null_kwargs):
+    def bpm(self, filename, det, shape=None):
         """
         Override parent bpm function with BPM specific to X-Shooter VIS.
 
@@ -179,12 +179,12 @@ class KeckNIRESSpectrograph(spectrograph.Spectrograph):
 
         """
         msgs.info("Custom bad pixel mask for NIRES")
-        self.empty_bpm(shape=shape, filename=filename, det=det)
+        bpm_img = self.empty_bpm(filename, det, shape=shape)
         if det == 1:
-            self.bpm_img[:, :20] = 1.
-            self.bpm_img[:, 1000:] = 1.
+            bpm_img[:, :20] = 1.
+            bpm_img[:, 1000:] = 1.
 
-        return self.bpm_img
+        return bpm_img
 
 
 

--- a/pypeit/spectrographs/keck_nirspec.py
+++ b/pypeit/spectrographs/keck_nirspec.py
@@ -244,7 +244,7 @@ class KeckNIRSPECSpectrograph(spectrograph.Spectrograph):
         raise ValueError('No implementation for status = {0}'.format(status))
 
     # TODO: This function is unstable to shape...
-    def bpm(self, shape=None, **null_kwargs):
+    def bpm(self, filename, det):
         """ Generate a BPM
         Parameters
         ----------
@@ -253,15 +253,13 @@ class KeckNIRSPECSpectrograph(spectrograph.Spectrograph):
         -------
         badpix : ndarray
         """
-        if shape is None:
-            raise ValueError('Must provide shape for Keck NIRSPEC bpm.')
+        bpm_img = self.empty_bpm(filename, det)
         # Edges of the detector are junk
         msgs.info("Custom bad pixel mask for NIRSPEC")
-        self.bpm_img = np.zeros(shape, dtype=np.int8)
-        self.bpm_img[:, :20] = 1.
-        self.bpm_img[:, 1000:] = 1.
+        bpm_img[:, :20] = 1.
+        bpm_img[:, 1000:] = 1.
 
-        return self.bpm_img
+        return bpm_img
 
 class KeckNIRSPECLowSpectrograph(KeckNIRSPECSpectrograph):
     """

--- a/pypeit/spectrographs/magellan_mage.py
+++ b/pypeit/spectrographs/magellan_mage.py
@@ -183,7 +183,7 @@ class MagellanMAGESpectrograph(spectrograph.Spectrograph):
             return (fitstbl['idname'] == 'Object') \
                         & framematch.check_frame_exptime(fitstbl['exptime'], exprng)
 
-    def bpm(self, shape=None, filename=None, det=None, **null_kwargs):
+    def bpm(self, filename, det, shape=None):
         """
         Override parent bpm function with BPM specific to X-Shooter VIS.
 
@@ -203,16 +203,16 @@ class MagellanMAGESpectrograph(spectrograph.Spectrograph):
 
         """
         msgs.info("Custom bad pixel mask for MAGE")
-        self.empty_bpm(shape=shape, filename=filename, det=det)
+        bpm_img = self.empty_bpm(filename, det, shape=shape)
         # Get the binning
         hdu = fits.open(filename)
         binspatial, binspec = parse.parse_binning(hdu[0].header['BINNING'])
         hdu.close()
         # Do it
-        self.bpm_img[:, :10//binspatial] = 1.
-        self.bpm_img[:, 1020//binspatial:] = 1.
+        bpm_img[:, :10//binspatial] = 1.
+        bpm_img[:, 1020//binspatial:] = 1.
         # Return
-        return self.bpm_img
+        return bpm_img
 
     @staticmethod
     def slitmask(tslits_dict, pad=None, binning=None):

--- a/pypeit/spectrographs/mmt_binospec.py
+++ b/pypeit/spectrographs/mmt_binospec.py
@@ -453,67 +453,6 @@ class MMTBINOSPECSpectrograph(spectrograph.Spectrograph):
     # provided it will fail.  Provide a function like in keck_lris.py
     # that forces a file to be provided?
 
-    def bpm(self, filename=None, det=None, **null_kwargs):
-        """
-        Override parent bpm function with BPM specific to DEIMOS.
-
-        .. todo::
-            Allow for binning changes.
-
-        Parameters
-        ----------
-        det : int, REQUIRED
-        **null_kwargs:
-            Captured and never used
-
-        Returns
-        -------
-        bpix : ndarray
-          0 = ok; 1 = Mask
-
-        """
-        self.empty_bpm(filename=filename, det=det)
-        if det == 1:
-            self.bpm_img[:, 1052:1054] = 1
-        elif det == 2:
-            self.bpm_img[:, 0:4] = 1
-            self.bpm_img[:, 376:381] = 1
-            self.bpm_img[:, 489] = 1
-            self.bpm_img[:, 1333:1335] = 1
-            self.bpm_img[:, 2047] = 1
-        elif det == 3:
-            self.bpm_img[:, 221] = 1
-            self.bpm_img[:, 260] = 1
-            self.bpm_img[:, 366] = 1
-            self.bpm_img[:, 816:819] = 1
-            self.bpm_img[:, 851] = 1
-            self.bpm_img[:, 940] = 1
-            self.bpm_img[:, 1167] = 1
-            self.bpm_img[:, 1280] = 1
-            self.bpm_img[:, 1301:1303] = 1
-            self.bpm_img[:, 1744:1747] = 1
-        elif det == 4:
-            self.bpm_img[:, 0:4] = 1
-            self.bpm_img[:, 47] = 1
-            self.bpm_img[:, 744] = 1
-            self.bpm_img[:, 790:792] = 1
-            self.bpm_img[:, 997:999] = 1
-        elif det == 5:
-            self.bpm_img[:, 25:27] = 1
-            self.bpm_img[:, 128:130] = 1
-            self.bpm_img[:, 1535:1539] = 1
-        elif det == 7:
-            self.bpm_img[:, 426:428] = 1
-            self.bpm_img[:, 676] = 1
-            self.bpm_img[:, 1176:1178] = 1
-        elif det == 8:
-            self.bpm_img[:, 440] = 1
-            self.bpm_img[:, 509:513] = 1
-            self.bpm_img[:, 806] = 1
-            self.bpm_img[:, 931:934] = 1
-
-        return self.bpm_img
-
     def get_slitmask(self, filename):
         hdu = fits.open(filename)
         corners = np.array([hdu['BluSlits'].data['slitX1'],

--- a/pypeit/spectrographs/spectrograph.py
+++ b/pypeit/spectrographs/spectrograph.py
@@ -260,31 +260,6 @@ class Spectrograph(object):
         """
         return self.detector[det-1]['specaxis'] == 1
 
-    '''
-    def load_raw_img_hdu(self, raw_file, dataext=0, **null_kwargs):
-        """
-        Generic raw image reader
-
-        Args:
-            raw_file (:obj:`str`):
-                File to read.
-            dataext (:obj:`str`, :obj:`int`, optional):
-                Fits extension with the image data.
-            headext (:obj:`str`, :obj:`int`, optional):
-                Fits extension with the header data to return.
-            **null_kwargs:
-              Captured and never used
-
-        Returns:
-            Returns an `numpy.ndarray`_ with the image data and
-            the `astropy.io.fits.HDUList`_ object with the image and HDU,
-            respectively.
-        """
-        # Open and go
-        hdu = fits.open(raw_file)
-        return hdu[dataext].data, hdu
-    '''
-
     def get_image_section(self, hdulist, det, section):
         """
         Return a string representation of a slice defining a section of
@@ -300,14 +275,11 @@ class Spectrograph(object):
         is defined directly.
         
         Args:
-            hdulist (:obj:`str`, `astropy.io.fits.Header`_, optional):
-                String providing the file name to read, or the relevant
-                header object.  Default is None, meaning that the
-                detector attribute must provide the image section
-                itself, not the header keyword.
-            det (:obj:`int`, optional):
+            hdulist (`astropy.io.fits.Header`_):
+                Header list of the image
+            det (:obj:`int`):
                 1-indexed detector number.
-            section (:obj:`str`, optional):
+            section (:obj:`str`):
                 The section to return.  Should be either 'datasec' or
                 'oscansec', according to the
                 :class:`pypeitpar.DetectorPar` keywords.
@@ -330,21 +302,6 @@ class Spectrograph(object):
 
         # Get the data section
         hdr = hdulist[self.detector[det-1]['dataext']].header
-        '''
-        try:
-            # Parse inp
-            if inp is None:
-                # Force the call to the except block
-                raise KeyError
-            elif isinstance(inp, str):
-                hdu = fits.open(inp)
-                hdr = hdu[self.detector[det-1]['dataext']].header
-            elif isinstance(inp, fits.Header):
-                hdr = inp
-            else:
-                msgs.error('Input must be a filename or a fits.Header object.')
-
-        '''
         # Try using the image sections as header keywords
         try:
             image_sections = [ hdr[key] for key in self.detector[det-1][section] ]
@@ -364,45 +321,7 @@ class Spectrograph(object):
         return image_sections, one_indexed, include_last
 
     '''
-    def get_rawdatasec_img(self, filename, det, force=True):
-        """
-        Return the *raw* datasec image, i.e. in the load-from-disk orientation, etc.
-
-        Args:
-            filename:
-            det:
-            force:
-
-        Returns:
-
-        """
-        if self.rawdatasec_img is None or force:
-            return self.get_pixel_img(filename, 'datasec', det)
-        return self.rawdatasec_img
-
-    def get_oscansec_img(self, filename, det, force=True):
-        """
-        Generate the oscansec image
-
-        Args:
-            filename (str):
-                Filename
-            det (int):
-                Detector index
-            force (bool, optional):
-                Force the code to remake the image.
-                Might need to do this in cases where binning varies
-                between calibrations and science images.
-
-        Returns:
-
-        """
-        if self.oscansec_img is None or force:
-            return self.get_pixel_img(filename, 'oscansec', det)
-        return self.oscansec_img
-    '''
-
-    '''
+    # THIS WILL PROBABLY NEED TO COME BACK
     def get_datasec_img(self, filename, det):
         """
         Generate and return the datasec image in the PypeIt reference

--- a/pypeit/spectrographs/spectrograph.py
+++ b/pypeit/spectrographs/spectrograph.py
@@ -159,6 +159,30 @@ class Spectrograph(object):
             if not isinstance(d, pypeitpar.DetectorPar):
                 raise TypeError('Detector parameters must be specified using DetectorPar.')
 
+    def load_raw(self, raw_file, det):
+
+        # First the raw image
+        raw_img, hdu = self.load_raw_frame(raw_file, det)
+
+        # Binning
+        headarr = self.get_headarr(hdu)
+        binning = self.get_meta_value(headarr, 'binning')
+        if self.detector[det-1]['specaxis'] == 1:
+            binning_raw = (',').join(binning.split(',')[::-1])
+        else:
+            binning_raw = binning
+
+        # Exposure time
+        exptime = self.get_meta_value(headarr, 'exptime')
+
+        # Rawdatasec, oscansec images
+        rawdatasec_img = self.get_pixel_img(hdu, det, 'datasec', binning_raw)
+        oscansec_img = self.get_pixel_img(hdu, det, 'oscansec', binning_raw)
+
+        # Return it all
+        return hdu, raw_img, exptime, rawdatasec_img, oscansec_img
+
+
     def load_raw_frame(self, raw_file, det=1):
         r"""
         Load the image and header for an exposure taken with this
@@ -208,11 +232,6 @@ class Spectrograph(object):
 
         hdu = fits.open(raw_file)
         raw_img = hdu[self.detector[det-1]['dataext']].data
-        '''
-        # Load the raw image
-        raw_img, hdu = self.load_raw_img_hdu(raw_file, dataext=self.detector[det-1]['dataext'],
-                                                det=det)
-        '''
         # Turn to float
         img = raw_img.astype(float)
 
@@ -260,7 +279,7 @@ class Spectrograph(object):
         return hdu[dataext].data, hdu
     '''
 
-    def get_image_section(self, inp=None, det=1, section='datasec'):
+    def get_image_section(self, hdulist, det, section):
         """
         Return a string representation of a slice defining a section of
         the detector image.
@@ -275,7 +294,7 @@ class Spectrograph(object):
         is defined directly.
         
         Args:
-            inp (:obj:`str`, `astropy.io.fits.Header`_, optional):
+            hdulist (:obj:`str`, `astropy.io.fits.Header`_, optional):
                 String providing the file name to read, or the relevant
                 header object.  Default is None, meaning that the
                 detector attribute must provide the image section
@@ -304,6 +323,8 @@ class Spectrograph(object):
         self._check_detector()
 
         # Get the data section
+        hdr = hdulist[self.detector[det-1]['dataext']].header
+        '''
         try:
             # Parse inp
             if inp is None:
@@ -317,7 +338,9 @@ class Spectrograph(object):
             else:
                 msgs.error('Input must be a filename or a fits.Header object.')
 
-            # Try using the image sections as header keywords
+        '''
+        # Try using the image sections as header keywords
+        try:
             image_sections = [ hdr[key] for key in self.detector[det-1][section] ]
         except KeyError:
             # Expect a KeyError to be thrown if the section defined by
@@ -332,18 +355,9 @@ class Spectrograph(object):
         include_last = True
         #transpose = self.detector[det-1]['specaxis'] == 0
 
-        return image_sections, one_indexed, include_last#, transpose
+        return image_sections, one_indexed, include_last
 
-        # Re-order so that the section is always returned as
-        # (spec,spat).  NOTE: This is different from load_raw_frame
-        # because of the added flip performed by just reading the image
-        # data.
-        #if self.detector[det-1]['specaxis'] == 0:
-        #    image_sections = ['[{0}]'.format(','.join(s.strip('[]').split(',')[::-1]))
-        #                        for s in image_sections]
-        #
-        #return image_sections, one_indexed, include_last
-
+    '''
     def get_rawdatasec_img(self, filename, det, force=True):
         """
         Return the *raw* datasec image, i.e. in the load-from-disk orientation, etc.
@@ -380,7 +394,9 @@ class Spectrograph(object):
         if self.oscansec_img is None or force:
             return self.get_pixel_img(filename, 'oscansec', det)
         return self.oscansec_img
+    '''
 
+    '''
     def get_datasec_img(self, filename, det):
         """
         Generate and return the datasec image in the PypeIt reference
@@ -396,8 +412,9 @@ class Spectrograph(object):
         dimg = self.orient_image(rdimg, det)
         # Return
         return dimg
+    '''
 
-    def get_pixel_img(self, filename, section, det):
+    def get_pixel_img(self, hdulist, det, section, binning_raw):
         """
         Create an image identifying the amplifier used to read each pixel.
         This is in the *raw* data format
@@ -435,12 +452,13 @@ class Spectrograph(object):
         # Check the detector is defined
         self._check_detector()
         # Get the image shape
-        raw_naxis = self.get_raw_image_shape(filename, det=det)
+        #raw_naxis = self.get_raw_image_shape(filename, det=det)
+        #binning_raw = self.get_meta_value(filename, 'binning')
 
-        binning_raw = self.get_meta_value(filename, 'binning')
+        raw_naxis = self.get_raw_image_shape(hdulist, det=det)
 
         data_sections, one_indexed, include_end \
-                    = self.get_image_section(filename, det, section=section)
+                    = self.get_image_section(hdulist, det, section=section)
 
         # Initialize the image (0 means no amplifier)
         pix_img = np.zeros(raw_naxis, dtype=int)
@@ -448,17 +466,13 @@ class Spectrograph(object):
             # Convert the data section from a string to a slice
             datasec = parse.sec2slice(data_sections[i], one_indexed=one_indexed,
                                       include_end=include_end, require_dim=2,
-                                      binning=binning_raw) #transpose=transpose,
+                                      binning=binning_raw)
             # Assign the amplifier
-            #self.datasec_img[datasec] = i+1
             pix_img[datasec] = i+1
 
         return pix_img
 
-    # TODO: There *has* to be a better way to do this.  We're reading a
-    # file just to get the size of the image, likely when the image has
-    # already been read (likely multiple times).
-    def get_raw_image_shape(self, filename, det=None):
+    def get_raw_image_shape(self, hdulist, det=None):
         """
         Get the *untrimmed* shape of the image data for a given detector using a
         file.  :attr:`detector` must be defined.
@@ -471,7 +485,7 @@ class Spectrograph(object):
         used.
         
         Args:
-            filename (:obj:`str`, optional):
+            hdulist (:obj:`str`, optional):
                 Name of the fits file with the header to use.
             det (:obj:`int`, optional):
                 1-indexed number of the detector.  Default is None.  If
@@ -492,8 +506,8 @@ class Spectrograph(object):
         """
         # Use a file
         self._check_detector()
-        hdu = fits.open(filename)
-        header = hdu[self.detector[det-1]['dataext']].header
+        #hdu = fits.open(filename)
+        header = hdulist[self.detector[det-1]['dataext']].header
         shape = (header['NAXIS2'], header['NAXIS1'])  # Usual Python vs. the world
         return shape
 
@@ -659,16 +673,13 @@ class Spectrograph(object):
         """
         self.meta = {}
 
-    # TODO: Change this so that it uses one argument for ifile or
-    # headarray? ala, get_image_section, etc?
-    def get_meta_value(self, ifile, meta_key, headarr=None, required=False, ignore_bad_header=False,
-                       usr_row=None):
+    def get_meta_value(self, inp, meta_key, required=False, ignore_bad_header=False, usr_row=None):
         """
         Return meta data from a given file (or its array of headers)
 
         Args:
-            ifile: str or None
-              Input filename
+            inp (str or list):
+              Input filename or headarr list
             meta_key: str or list of str
             headarr: list, optional
               List of headers
@@ -683,14 +694,16 @@ class Spectrograph(object):
             value: value or list of values
 
         """
-        if headarr is None:
-            headarr = self.get_headarr(ifile)
+        if isinstance(inp, str):
+            headarr = self.get_headarr(inp)
+        else:
+            headarr = inp
 
         # Loop?
         if isinstance(meta_key, list):
             values = []
             for mdict in meta_key:
-                values.append(self.get_meta_value(mdict, headarr=headarr, required=required))
+                values.append(self.get_meta_value(headarr, mdict, required=required))
             #
             return values
 
@@ -734,8 +747,8 @@ class Spectrograph(object):
                     if kerror:
                         msgs.error('Required meta "{:s}" did not load!  You may have a corrupt header'.format(meta_key))
                 else:
-                    msgs.warn("Required card {:s} missing from your header of {:s}.  Proceeding with risk..".format(
-                        self.meta[meta_key]['card'], ifile))
+                    msgs.warn("Required card {:s} missing from your header.  Proceeding with risk..".format(
+                        self.meta[meta_key]['card']))
             return None
 
         # Deal with dtype (DO THIS HERE OR IN METADATA?  I'M TORN)
@@ -778,13 +791,13 @@ class Spectrograph(object):
             if key not in self.meta_data_model.keys():
                 msgs.error("Meta data {:s} not in meta_data_model".format(key))
 
-    def get_headarr(self, filename, strict=True):
+    def get_headarr(self, inp, strict=True):
         """
         Read the header data from all the extensions in the file.
 
         Args:
-            filename (:obj:`str`):
-                Name of the file to read.
+            inp (:obj:`str` or hdulist):
+                Name of the file to read or the hdulist
             strict (:obj:`bool`, optional):
                 Function will fault if :func:`fits.getheader` fails to
                 read any of the headers.  Set to False to report a
@@ -796,19 +809,19 @@ class Spectrograph(object):
         """
         # Faster to open the whole file and then assign the headers,
         # particularly for gzipped files (e.g., DEIMOS)
-        try:
-            hdu = fits.open(filename)
-        except:
-            if strict:
-                msgs.error('Problem opening {0}.'.format(filename))
-            else:
-                msgs.warn('Problem opening {0}.'.format(filename) + msgs.newline()
-                          + 'Proceeding, but should consider removing this file!')
-                return ['None']*self.numhead
-        return [ hdu[k].header for k in range(self.numhead) ]
-
-#    def get_match_criteria(self):
-#        msgs.error("You need match criteria for your spectrograph.")
+        if isinstance(inp, str):
+            try:
+                hdu = fits.open(inp)
+            except:
+                if strict:
+                    msgs.error('Problem opening {0}.'.format(inp))
+                else:
+                    msgs.warn('Problem opening {0}.'.format(inp) + msgs.newline()
+                              + 'Proceeding, but should consider removing this file!')
+                    return ['None']*self.numhead
+        else:
+            hdu = inp
+            return [hdu[k].header for k in range(self.numhead)]
 
     def check_frame_type(self, ftype, fitstbl, exprng=None):
         raise NotImplementedError('Frame typing not defined for {0}.'.format(self.spectrograph))

--- a/pypeit/spectrographs/spectrograph.py
+++ b/pypeit/spectrographs/spectrograph.py
@@ -107,19 +107,28 @@ class Spectrograph(object):
     def default_pypeit_par():
         return pypeitpar.PypeItPar()
 
-    def nonlinear_counts(self, det=1):
+    def nonlinear_counts(self, det, datasec_img=None):
         """
         Return the counts at which the detector response becomes
         non-linear.
 
         Args:
-            det (:obj:`int`, optional):
+            det (:obj:`int`):
                 1-indexed detector number.
         
         Returns:
-            float: Counts at which detector response becomes nonlinear.
+            float or np.ndarray:
+                Counts at which detector response becomes nonlinear.
+                If datasec_img is provided, an image with the same shape
+                is returned with the gain accounted for
         """
-        return self.detector[det-1]['saturation']*self.detector[det-1]['nonlinear']
+        nonlinear_counts = self.detector[det-1]['saturation']*self.detector[det-1]['nonlinear']
+        # Generate an image, applying the gain?
+        if datasec_img is not None:
+            gain = np.atleast_1d(self.detector[det-1]['gain']).tolist()
+            nonlinear_counts = nonlinear_counts * procimg.gain_frame(datasec_img, gain)
+        # Return
+        return nonlinear_counts
 
     def config_specific_par(self, scifile, inp_par=None):
         """

--- a/pypeit/spectrographs/spectrograph.py
+++ b/pypeit/spectrographs/spectrograph.py
@@ -46,7 +46,7 @@ from pypeit.par import pypeitpar
 from pypeit.core import pixels
 from pypeit.metadata import PypeItMetaData
 
-from pypeit import debugger
+from IPython import embed
 
 class Spectrograph(object):
     """
@@ -458,7 +458,7 @@ class Spectrograph(object):
     # TODO: There *has* to be a better way to do this.  We're reading a
     # file just to get the size of the image, likely when the image has
     # already been read (likely multiple times).
-    def get_raw_image_shape(self, filename, det=None, force=False):
+    def get_raw_image_shape(self, filename, det=None):
         """
         Get the *untrimmed* shape of the image data for a given detector using a
         file.  :attr:`detector` must be defined.
@@ -478,8 +478,6 @@ class Spectrograph(object):
                 None, the primary extension is used.  Otherwise the
                 internal detector parameters are used to determine the
                 extension to read.
-            force (:obj:`bool`, optional):
-                Force the image shape to be redetermined.
             null_kwargs (dict):
                 Used to catch any extraneous keyword arguments.
         
@@ -494,7 +492,10 @@ class Spectrograph(object):
         """
         # Use a file
         self._check_detector()
-        return (self.load_raw_frame(filename, det=det)[0]).shape
+        hdu = fits.open(filename)
+        header = hdu[self.detector[det-1]['dataext']].header
+        shape = (header['NAXIS2'], header['NAXIS1'])  # Usual Python vs. the world
+        return shape
 
     def header_cards_for_spec(self):
         """

--- a/pypeit/spectrographs/vlt_fors.py
+++ b/pypeit/spectrographs/vlt_fors.py
@@ -273,27 +273,4 @@ class VLTFORS2Spectrograph(VLTFORSSpectrograph):
         #return ['dispname', 'dispangle', 'decker', 'detector']
         return ['dispname', 'dispangle', 'decker', 'detector']
 
-    def bpm(self, shape=None, filename=None, det=None, **null_kwargs):
-        """
-        Override parent bpm function with BPM specific to X-ShooterNIR.
-
-        .. todo::
-            Allow for binning changes.
-
-        Parameters
-        ----------
-        det : int, REQUIRED
-        **null_kwargs:
-            Captured and never used
-
-        Returns
-        -------
-        bpix : ndarray
-          0 = ok; 1 = Mask
-
-        """
-        self.empty_bpm(shape=shape, filename=filename, det=det)
-        return self.bpm_img
-
-
 

--- a/pypeit/spectrographs/vlt_xshooter.py
+++ b/pypeit/spectrographs/vlt_xshooter.py
@@ -273,7 +273,7 @@ class VLTXShooterNIRSpectrograph(VLTXShooterSpectrograph):
         self.meta['decker'] = dict(ext=0, card='HIERARCH ESO INS OPTI5 NAME')
 
 
-    def bpm(self, shape=None, filename=None, det=None, **null_kwargs):
+    def bpm(self, filename, det, shape=None):
         """
         Override parent bpm function with BPM specific to X-ShooterNIR.
 
@@ -293,7 +293,7 @@ class VLTXShooterNIRSpectrograph(VLTXShooterSpectrograph):
 
         """
 
-        self.empty_bpm(shape=shape, filename=filename, det=det)
+        bpm_img = self.empty_bpm(filename, det, shape=shape)
         if det == 1:
             bpm_dir = resource_filename('pypeit', 'data/static_calibs/vlt_xshoooter/')
             try :
@@ -318,9 +318,9 @@ class VLTXShooterNIRSpectrograph(VLTXShooterSpectrograph):
                 bpm_loc = np.array([y_bpm,x_bpm]).T
                 np.savetxt(bpm_dir+'BP_MAP_RP_NIR.dat', bpm_loc, fmt=['%d','%d'])
             finally :
-                self.bpm_img[bpm_loc[:,0].astype(int),bpm_loc[:,1].astype(int)] = 1.
+                bpm_img[bpm_loc[:,0].astype(int),bpm_loc[:,1].astype(int)] = 1.
 
-        return self.bpm_img
+        return bpm_img
 
 
     @property
@@ -559,7 +559,7 @@ class VLTXShooterVISSpectrograph(VLTXShooterSpectrograph):
     def loglam_minmax(self):
         return np.log10(5000.0), np.log10(11000)
 
-    def bpm(self, shape=None, filename=None, det=None, **null_kwargs):
+    def bpm(self, filename, det, shape=None):
         """
         Override parent bpm function with BPM specific to X-Shooter VIS.
 
@@ -578,6 +578,9 @@ class VLTXShooterVISSpectrograph(VLTXShooterSpectrograph):
           0 = ok; 1 = Mask
 
         """
+        bpm_img = self.empty_bpm(filename, det, shape=shape)
+        shape = bpm_img.shape
+        #
         # ToDo Ema: This is just a workaround to deal with
         # different binning. I guess binspatial and binspectral
         # should be passed in.
@@ -590,10 +593,9 @@ class VLTXShooterVISSpectrograph(VLTXShooterSpectrograph):
         else:
             binspatial_bpm=1
 
-        self.empty_bpm(shape=shape, filename=filename, det=det)
         if det == 1:
-            self.bpm_img[2912//binspectral_bpm:,842//binspatial_bpm:844//binspatial_bpm] = 1.
-        return self.bpm_img
+            bpm_img[2912//binspectral_bpm:,842//binspatial_bpm:844//binspatial_bpm] = 1.
+        return bpm_img
 
 
 class VLTXShooterUVBSpectrograph(VLTXShooterSpectrograph):
@@ -718,7 +720,6 @@ class VLTXShooterUVBSpectrograph(VLTXShooterSpectrograph):
         return orders[islit]
 
 
-
     def order_platescale(self, binning = None):
         """
         Returns the plate scale in arcseconds for each order
@@ -747,7 +748,7 @@ class VLTXShooterUVBSpectrograph(VLTXShooterSpectrograph):
         # Right now I just took the average
         return np.full(self.norders, 0.161)*binspatial
 
-    def bpm(self, shape=None, filename=None, det=None, **null_kwargs):
+    def bpm(self, filename, det, shape=None):
         """
         Override parent bpm function with BPM specific to X-Shooter UVB.
 
@@ -766,13 +767,13 @@ class VLTXShooterUVBSpectrograph(VLTXShooterSpectrograph):
           0 = ok; 1 = Mask
 
         """
-        self.empty_bpm(shape=shape, filename=filename, det=det)
+        bpm_img = self.empty_bpm(filename, det, shape=shape)
         if det == 1:
             # TODO: This is for the 1x1 binning it should
             # change for other binning
-            self.bpm_img[:2369,1326:1328] = 1.
+            bpm_img[:2369,1326:1328] = 1.
 
-        return self.bpm_img
+        return bpm_img
 
 
 

--- a/pypeit/tests/test_bpmimage.py
+++ b/pypeit/tests/test_bpmimage.py
@@ -18,7 +18,7 @@ def data_path(filename):
     return os.path.join(data_dir, filename)
 
 
-
+'''
 def test_dummy_image():
     # Simple
     shape=(2048,2048)
@@ -27,6 +27,7 @@ def test_dummy_image():
     assert isinstance(bpm, np.ndarray)
     assert bpm.shape == shape
     assert np.sum(bpm) == 0
+'''
 
 
 @dev_suite_required
@@ -38,12 +39,15 @@ def test_keck_lris_red():
                                 'long_600_7500_d560', 'LR.20160216.05529.fits.gz')
     # Get the shape
     det = 2
+    '''
     rdsec_img = spectrograph.get_rawdatasec_img(example_file, det=det)
     trim = procimg.trim_frame(rdsec_img, rdsec_img < 1)
     orient = spectrograph.orient_image(trim, det)
     shape = orient.shape
+    '''
     # Simple
-    bpm = spectrograph.bpm(shape=shape, filename=example_file, det=det)
+    #bpm = spectrograph.bpm(shape=shape, filename=example_file, det=det)
+    bpm = spectrograph.bpm(example_file, det)
     assert np.sum(bpm) > 0
 
 
@@ -53,12 +57,15 @@ def test_keck_deimos():
     example_file = os.path.join(os.getenv('PYPEIT_DEV'), 'RAW_DATA', 'Keck_DEIMOS', '830G_L_8400',
                                 'd0914_0002.fits.gz')
     # Get the shape
-    det = 2
+    det = 4
+    '''
     rdsec_img = spectrograph.get_rawdatasec_img(example_file, det=det)
     trim = procimg.trim_frame(rdsec_img, rdsec_img < 1)
     orient = spectrograph.orient_image(trim, det)
     shape = orient.shape
+    '''
     # Simple
-    bpm = spectrograph.bpm(shape=shape,det=4)
+    #bpm = spectrograph.bpm(shape=shape,det=4)
+    bpm = spectrograph.bpm(example_file, det)
     assert bpm[0,0] == 1
 

--- a/pypeit/tests/test_load_images.py
+++ b/pypeit/tests/test_load_images.py
@@ -23,8 +23,10 @@ def ProcessImages(specstr, par, files, det=1):
     return calibImage
 
 def grab_img(proc, filename):
-    rdimg = proc.spectrograph.get_rawdatasec_img(filename, proc.det)
-    data_img, slice = procimg.rect_slice_with_mask(proc.image, rdimg)
+    img, hdu = proc.spectrograph.load_raw_frame(filename, proc.det)
+    exptime, rawdatasec_img, oscansec_img, binning_raw = proc.spectrograph.load_raw_extras(hdu, proc.det)
+    #rdimg = proc.spectrograph.get_rawdatasec_img(filename, proc.det)
+    data_img, slice = procimg.rect_slice_with_mask(img, rawdatasec_img)
     return data_img
 
 

--- a/pypeit/tests/test_processimage.py
+++ b/pypeit/tests/test_processimage.py
@@ -42,7 +42,7 @@ def test_instantiate(deimos_flat_files, kast_blue_bias_files):
     deimos_flat = processrawimage.ProcessRawImage(one_file, spectograph, 3, par)
     # Test
     assert isinstance(deimos_flat.image, np.ndarray)
-    assert deimos_flat.rawdatasec_img.shape == (4096, 2128)
+    assert deimos_flat.datasec_img.shape == (4096, 2128)
 
     # Kast blue
     one_file = kast_blue_bias_files[0]

--- a/pypeit/tests/test_scienceimage.py
+++ b/pypeit/tests/test_scienceimage.py
@@ -57,12 +57,12 @@ def test_instantiate_from_one(shane_kast_blue_sci_files):
     """
     Run on a single science frame
     """
+    det = 1
     # Load calibrations
     tslits_dict, mstrace, tilts_dict, pixelflat = load_kast_blue_masters(
         tslits=True, tilts=True, pixflat=True)
-    bpm = kast_blue.empty_bpm(shape=pixelflat.shape)
+    bpm = kast_blue.empty_bpm(shane_kast_blue_sci_files[0], det)
     # Do it
-    det = 1
     sciImg = scienceimage.ScienceImage.from_single_file(kast_blue, det, kast_par['scienceframe']['process'],
                                             bpm, shane_kast_blue_sci_files[0], None, pixelflat)
     # Test
@@ -74,12 +74,12 @@ def test_from_list(shane_kast_blue_sci_files):
     """
     Run on two frames
     """
+    det = 1
     # Load calibrations
     tslits_dict, mstrace, tilts_dict, pixelflat = load_kast_blue_masters(
         tslits=True, tilts=True, pixflat=True)
-    bpm = kast_blue.empty_bpm(shape=pixelflat.shape)
+    bpm = kast_blue.empty_bpm(shane_kast_blue_sci_files[0], det)
     # Do it
-    det = 1
     sciImg = scienceimage.ScienceImage.from_file_list(kast_blue, det, kast_par['scienceframe']['process'],
                                                         bpm, shane_kast_blue_sci_files, None, pixelflat)
     # Test

--- a/pypeit/tests/test_spectrographs.py
+++ b/pypeit/tests/test_spectrographs.py
@@ -24,11 +24,7 @@ def test_keckdeimos():
     det = 2
     data, _ = s.load_raw_frame(example_file, det=det)
     #
-    rdsec_img = s.get_rawdatasec_img(example_file, det=det)
-    trim = procimg.trim_frame(rdsec_img, rdsec_img < 1)
-    orient = s.orient_image(trim, det)
-    shape = orient.shape
-    bpm = s.bpm(shape=shape) # filename=example_file)
+    bpm = s.bpm(example_file, det) #shape=shape) # filename=example_file)
     assert data.shape == (4096,2128)
     assert bpm.shape == (4096,2048)
 
@@ -42,11 +38,7 @@ def test_kecklrisblue():
     det = 2
     data, _ = s.load_raw_frame(example_file, det=det)
     #
-    rdsec_img = s.get_rawdatasec_img(example_file, det=det)
-    trim = procimg.trim_frame(rdsec_img, rdsec_img < 1)
-    orient = s.orient_image(trim, det)
-    shape = orient.shape
-    bpm = s.bpm(shape=shape)
+    bpm = s.bpm(example_file, det) #shape=shape) # filename=example_file)
     assert data.shape == (2048,1154)
     assert bpm.shape == (2048,1024)
 
@@ -60,11 +52,7 @@ def test_kecklrisred():
     det = 1
     data, _ = s.load_raw_frame(example_file, det=det)
     #
-    rdsec_img = s.get_rawdatasec_img(example_file, det=det)
-    trim = procimg.trim_frame(rdsec_img, rdsec_img < 1)
-    orient = s.orient_image(trim, det)
-    shape = orient.shape
-    bpm = s.bpm(shape=shape)
+    bpm = s.bpm(example_file, det) #shape=shape) # filename=example_file)
     assert data.shape == (2068,1110)
     assert bpm.shape == (2048,1024)
 
@@ -82,7 +70,8 @@ def test_kecknirspec():
                                 'NIRSPEC-1', 'NS.20160414.02637.fits.gz')
     assert os.path.isfile(example_file), 'Could not find example file for Keck NIRSPEC read.'
     data, _ = s.load_raw_frame(example_file)
-    bpm = s.bpm(shape=data.shape)
+    det=1
+    bpm = s.bpm(example_file, det)
     assert data.shape == bpm.shape, 'Image and BPM have different shapes!'
 
 
@@ -92,24 +81,28 @@ def test_shanekastblue():
                                 'b1.fits.gz')
     assert os.path.isfile(example_file), 'Could not find example file for Shane Kast blue read.'
     data, _ = s.load_raw_frame(example_file)
-    bpm = s.bpm(shape=data.shape)
-    assert data.shape == bpm.shape, 'Image and BPM have different shapes!'
+    det=1
+    bpm = s.bpm(example_file, det)
+    assert data.shape == (350, 2112)
+    assert bpm.shape == (2048,350)
 
 
 @dev_suite_required
-def test_shanekastred():
-    s = spectrographs.shane_kast.ShaneKastRedSpectrograph()
+def test_shanekastredret():
+    s = spectrographs.shane_kast.ShaneKastRedRetSpectrograph()
     example_file = os.path.join(os.environ['PYPEIT_DEV'], 'RAW_DATA', 'Shane_Kast_red',
                                 '600_7500_d55', 'r112.fits.gz')
     assert os.path.isfile(example_file), 'Could not find example file for Shane Kast red read.'
     data, _ = s.load_raw_frame(example_file)
-    bpm = s.bpm(shape=data.shape)
-    assert data.shape == bpm.shape, 'Image and BPM have different shapes!'
+    det = 1
+    bpm = s.bpm(example_file, det)
+    assert data.shape == (250, 1232)
+    assert bpm.shape == (1200, 250)
 
 
-def test_shanekastredret():
-    spectrographs.shane_kast.ShaneKastRedRetSpectrograph()
-    # TODO: Any Shane Kast Red Ret files to read?
+def test_shanekastred():
+    spectrographs.shane_kast.ShaneKastRedSpectrograph()
+    # TODO: Any Shane Kast Red files to read?
 
 
 def test_tngdolores():
@@ -124,8 +117,10 @@ def test_vltxshooteruvb():
                                 'UVB_1x1', 'XSHOO.2010-04-28T05:34:32.723.fits.gz')
     assert os.path.isfile(example_file), 'Could not find example file for VLT Xshooter UVB read.'
     data, _ = s.load_raw_frame(example_file)
-    bpm = s.bpm(shape=data.shape)
-    assert data.shape == bpm.shape, 'Image and BPM have different shapes!'
+    det = 1
+    bpm = s.bpm(example_file, det)
+    assert data.shape == (3000, 2144)
+    assert bpm.shape == (3000, 2048)
 
 
 @dev_suite_required
@@ -135,8 +130,10 @@ def test_vltxshootervis():
                                 'VIS_1x1', 'XSHOO.2010-04-28T05:34:37.853.fits.gz')
     assert os.path.isfile(example_file), 'Could not find example file for VLT Xshooter VIS read.'
     data, _ = s.load_raw_frame(example_file)
-    bpm = s.bpm(shape=data.shape)
-    assert data.shape == bpm.shape, 'Image and BPM have different shapes!'
+    det = 1
+    bpm = s.bpm(example_file, det)
+    assert data.shape == (4000, 2106)
+    assert bpm.shape == (4000, 2048)
 
 
 @dev_suite_required
@@ -146,18 +143,10 @@ def test_vltxshooternir():
                                 'NIR', 'XSHOO.2016-08-02T08:45:49.494.fits.gz')
     assert os.path.isfile(example_file), 'Could not find example file for VLT Xshooter NIR read.'
     data, _ = s.load_raw_frame(example_file)
-    bpm = s.bpm(shape=data.shape)
-    assert data.shape == bpm.shape, 'Image and BPM have different shapes!'
+    det = 1
+    bpm = s.bpm(example_file, det)
+    assert data.shape == (1100,2048)
+    assert bpm.shape == (2045, 1097)
 
 
-'''
-@dev_suite_required
-def test_whtisisblue():
-    s = spectrographs.wht_isis.WhtIsisBlueSpectrograph()
-    example_file = os.path.join(os.environ['PYPEIT_DEV'], 'RAW_DATA', 'WHT_ISIS_blue',
-                                'long_R300B_d5300', 'r2324566.fit.gz')
-    assert os.path.isfile(example_file), 'Could not find example file for WHT ISIS blue read.'
-    data, _ = s.load_raw_frame(example_file)
-    bpm = s.bpm(shape=data.shape)
-    assert data.shape == bpm.shape, 'Image and BPM have different shapes!'
-'''
+

--- a/pypeit/tests/tstutils.py
+++ b/pypeit/tests/tstutils.py
@@ -205,7 +205,7 @@ def instant_traceslits(mstrace_file, det=None):
     # Instantiate
     spectrograph = load_spectrograph(tslits_dict['spectrograph'])
     par = spectrograph.default_pypeit_par()
-    msbpm = spectrograph.bpm(shape=mstrace.shape, det=det)
+    msbpm = spectrograph.bpm(None, det, shape=mstrace.shape)
     #binning = tslits_dict['binspectral'], tslits_dict['binspatial']
     traceSlits = traceslits.TraceSlits(spectrograph, par['calibrations']['slits'],
                                        msbpm=msbpm)

--- a/pypeit/wavecalib.py
+++ b/pypeit/wavecalib.py
@@ -92,10 +92,6 @@ class WaveCalib(masterframe.MasterFrame):
         # TODO: Build another base class that does these things for both
         # WaveTilts and WaveCalib?
 
-        # Get the non-linear count level
-        self.nonlinear_counts = 1e10 if self.spectrograph is None \
-                                    else self.spectrograph.nonlinear_counts(det=self.det)
-
         # Set the slitmask and slit boundary related attributes that the
         # code needs for execution. This also deals with arcimages that
         # have a different binning then the trace images used to defined
@@ -111,7 +107,7 @@ class WaveCalib(masterframe.MasterFrame):
                                                   self.tslits_dict['slit_left'])
             self.slit_righ = arc.resize_slits2arc(self.shape_arc, self.shape_science,
                                                   self.tslits_dict['slit_righ'])
-            self.slitcen   = arc.resize_slits2arc(self.shape_arc, self.shape_science,
+            self.slitcen = arc.resize_slits2arc(self.shape_arc, self.shape_science,
                                                   self.tslits_dict['slitcen'])
             self.slitmask  = arc.resize_mask2arc(self.shape_arc, self.slitmask_science)
             self.inmask = arc.resize_mask2arc(self.shape_arc, inmask)
@@ -119,6 +115,10 @@ class WaveCalib(masterframe.MasterFrame):
             if self.par['method'] != 'full_template':
                 self.inmask &= self.msarc < self.nonlinear_counts
             self.slit_spat_pos = trace_slits.slit_spat_pos(self.tslits_dict)
+            # Get the non-linear count level
+            self.nonlinear_counts = 1e10 if self.spectrograph is None \
+                else self.spectrograph.nonlinear_counts(self.det)
+
         else:
             self.slitmask_science = None
             self.shape_science = None
@@ -129,7 +129,8 @@ class WaveCalib(masterframe.MasterFrame):
             self.slitcen = None
             self.slitmask = None
             self.inmask = None
-        # --------------------------------------------------------------
+            self.nonlinear_counts = None
+                # --------------------------------------------------------------
 
     def build_wv_calib(self, arccen, method, skip_QA=False):
         """
@@ -280,7 +281,7 @@ class WaveCalib(masterframe.MasterFrame):
 
     # TODO: JFH this method is identical to the code in wavetilts.
     # SHould we make it a separate function?
-    def extract_arcs(self, slitcen, slitmask, msarc, inmask):
+    def extract_arcs(self, slitcen, slitmask, inmask):
         """
         Extract the arcs down each slit/order
 
@@ -303,8 +304,10 @@ class WaveCalib(masterframe.MasterFrame):
         # Do it
         # TODO: Consider *not* passing in nonlinear_counts;  Probably
         # should not mask saturated lines at this stage
-        arccen, arc_maskslit = arc.get_censpec(slitcen, slitmask, msarc, inmask=inmask,
-                                               nonlinear_counts=nonlinear)
+
+        arccen, arc_maskslit = arc.get_censpec(
+            slitcen, slitmask, self.msarc,
+            gpm=inmask, nonlinear_counts=nonlinear)
         # Step
         self.steps.append(inspect.stack()[0][3])
         return arccen, arc_maskslit
@@ -426,8 +429,7 @@ class WaveCalib(masterframe.MasterFrame):
         """
         ###############
         # Extract an arc down each slit
-        self.arccen, self.maskslits = self.extract_arcs(self.slitcen, self.slitmask, self.msarc,
-                                                        self.inmask)
+        self.arccen, self.maskslits = self.extract_arcs(self.slitcen, self.slitmask, self.inmask)
 
         # Fill up the calibrations and generate QA
         self.wv_calib = self.build_wv_calib(self.arccen, self.par['method'], skip_QA=skip_QA)

--- a/pypeit/wavetilts.py
+++ b/pypeit/wavetilts.py
@@ -150,7 +150,7 @@ class WaveTilts(masterframe.MasterFrame):
             ndarray, ndarray:  Extracted arcs
 
         """
-        arccen, arc_maskslit = arc.get_censpec(slitcen, slitmask, msarc, inmask=inmask,
+        arccen, arc_maskslit = arc.get_censpec(slitcen, slitmask, msarc, gpm=inmask,
                                                nonlinear_counts=self.nonlinear_counts)
         # Step
         self.steps.append(inspect.stack()[0][3])


### PR DESCRIPTION
Addresses the age-old annoyance of multiple reads of DEIMOS, LRIS and
other images to determine the `datasec` and other bits and pieces.  Splits
out the image section determination for DEIMOS and LRIS from the previous methods.

Here are the specific CHANGES:

- Break apart LRIS and DEIMOS image reading from section parsing
- Refactor BPM generation
- Merge rawdatasec_img and oscansec_img generation
- Sync `datasec_img` to image in `ProcessRawImage`

I took a hard look at converting calibration images to counts from DNs.
This looks like an arduous road that would even have us rethink what we save
as Masters (all the more so if we generate masks, ivar, etc.).   We should
think carefully about the benefits before addressing items raised repeatedly
in Issues #719 and #740 and elsewhere.

Tests are failing right now, but should be straightforward to fix.
Good old `shane_kast_blue` just ran through fine.