### PR TITLE
Hotfix to remove a sort command causing pypeit_setup failures

### DIFF
--- a/pypeit/metadata.py
+++ b/pypeit/metadata.py
@@ -1476,7 +1476,8 @@ class PypeItMetaData:
             ff.write('Setup {:s}\n'.format(setup))
             ff.write(yaml.dump(utils.yamlify(cfg)))
             ff.write('#---------------------------------------------------------\n')
-            subtbl.sort(['mjd']) # JFH added this line so that the output reads like a log file
+            #subtbl.sort(['mjd']) # JFH added this line so that the output reads like a log file
+            # JXP -- This incurs a bug for all instruments with bad headers or things like XShooter
             subtbl.write(ff, format='ascii.fixed_width')
         ff.write('##end\n')
         ff.close()


### PR DESCRIPTION
Introduced by JFH