### PR TITLE
Bugs in pypeit_coadd_1dspec

### DIFF
--- a/pypeit/core/coadd.py
+++ b/pypeit/core/coadd.py
@@ -1319,10 +1319,10 @@ def order_phot_scale(spectra, phot_scale_dicts, nsig=3.0, niter=5, debug=False):
 def order_median_scale(wave, wave_mask, fluxes_in, ivar_in, sigrej=3.0, nsig=3.0, niter=5, num_min_pixels=21, min_overlap_pix=21, overlapfrac=0.03, min_overlap_frac=0.03, max_rescale_percent=50.0, sn_min=1.0, SN_MIN_MEDSCALE=1.0, debug=False):
 
     #### HOTFIX
-    sigrej=nsig
-    min_overlap_frac = overlapfrac
-    min_overlap_pix = num_min_pixels
-    sn_min = SN_MIN_MEDSCALE
+    sigrej=nsig ####
+    min_overlap_frac = overlapfrac ####
+    min_overlap_pix = num_min_pixels ####
+    sn_min = SN_MIN_MEDSCALE ####
     '''
     Scale different orders using the median of overlap regions. It starts from the reddest order, i.e. scale H to K,
       and then scale J to H+K, etc.
@@ -1449,7 +1449,6 @@ def merge_order(spectra, wave_grid, spectrograph, files, extract='OPT', ordersca
     """
 
     ## Scaling different orders
-    orderscale = 'None' #### BECAUSE IT'S CURRENTLY BROKEN
     if orderscale == 'photometry':
         # Only tested on NIRES.
         if phot_scale_dicts is not None:
@@ -1590,12 +1589,12 @@ def ech_coadd(files,spectrograph,objids=None,extract='OPT',flux=True,giantcoadd=
         msgs.info('Coadding {:} spectra.'.format(nfile))
         fname = files[0]
         ext_final = fits.getheader(fname, -1)
-        nam = spectrograph.spectrograph
-        if (nam=='vlt_xshooter_vis'):
-            norder = ext_final['ECHORDER'] - 1 ### HOTFIX FOR XSHOOTER-VIS
+        nam = spectrograph.spectrograph     ### HOTFIX FOR XSHOOTER
+        if (nam=='vlt_xshooter_vis'): 
+            norder = ext_final['ECHORDER'] - 1
         elif (nam=='vlt_xshooter_nir'):
             norder = 16
-        else:
+        else: 
             norder = ext_final['ECHORDER'] + 1 
         msgs.info('spectrum {:s} has {:d} orders'.format(fname, norder))
         if norder <= 1:

--- a/pypeit/core/load.py
+++ b/pypeit/core/load.py
@@ -166,7 +166,6 @@ def load_spec_order(fname,spectrograph,objid=None,order=None,extract='OPT',flux=
         objid = 0
     if order is None:
         msgs.error('Please specify which order you want to load')
-    msgs.info("Info received: objid {:s}, order {:f}".format(objid, order))
 
     # read extension name into a list
     primary_header = fits.getheader(fname, 0)
@@ -181,18 +180,19 @@ def load_spec_order(fname,spectrograph,objid=None,order=None,extract='OPT',flux=
     extname = extnameroot.replace('OBJ0001', objid)
     extname = extname.replace('ORDER0000', 'ORDER' + ordername)
 
-    nam = spectrograph.spectrograph  
+    nam = spectrograph.spectrograph   ### HOTFIX FOR XSHOOTER
     if (nam=='vlt_xshooter_vis'):
-        exten = order + 1 ### HOTFIX FOR XSHOOTER
+        exten = order + 1
+        msgs.info("Loading extension number {:f}".format(exten))
     if (nam=='vlt_xshooter_nir'):
         exten = order + 1 
+        msgs.info("Loading extension number {:f}".format(exten))
     else:
         try:
             exten = extnames.index(extname) + 1
             msgs.info("Loading extension {:s} of spectrum {:s}".format(extname, fname))
         except:
             msgs.error("Spectrum {:s} does not contain {:s} extension".format(fname, extname))
-    msgs.info("Loading extension number {:f}".format(exten))
     spectrum = load_1dspec(fname, exten=exten, extract=extract, flux=flux)
     # Polish a bit -- Deal with NAN, inf, and *very* large values that will exceed
     #   the floating point precision of float32 for var which is sig**2 (i.e. 1e38)
@@ -235,12 +235,10 @@ def ech_load_spec(files, spectrograph,objid=None,order=None,extract='OPT',flux=T
 
     fname = files[0]
     ext_final = fits.getheader(fname, -1)
-    #norder = ext_final['ECHORDER'] + 1  
-    #msgs.info('spectrograph is {:s}, {:s}'.format(spectrograph.telescope['name'], spectrograph.spectrograph))
 
-    nam = spectrograph.spectrograph  
+    nam = spectrograph.spectrograph  ### HOTFIX FOR XSHOOTER
     if (nam=='vlt_xshooter_vis'):
-        norder = ext_final['ECHORDER'] - 1 ### HOTFIX FOR XSHOOTER
+        norder = ext_final['ECHORDER'] - 1 
     elif (nam=='vlt_xshooter_nir'):
         norder = 16
     else:


### PR DESCRIPTION
Hi all,

I have been using Pypeit to reduce X-Shooter spectra and have identified two bugs affecting the pypeit_coadd_1dspec routine. One of them is X-Shooter specific.

In the file core/coadd.py, there are multiple contradicting usages of functions with extra or missing arguments, e.g. line 1490
`write_to_disk(spec1d_final, outfile)`
while the definition requires, line 1069:
`def write_to_disk(spectrograph, gdfiles, spec1d, outfile):`
This currently prevents pypeit_coadd_1dspec from working out-of-the-box on a fresh install.

Second, the change in numbering of orders and extensions in X-Shooter spectra since version 0.9 has cause the core/load.py function to read in the incorrect extensions and to mis-count the number of extensions present (since they are now numbered backwards). I have implemented somewhat horrible hotfixes to make things work again, e.g.:
   

    if (nam=='vlt_xshooter_vis'):

        nam = spectrograph.spectrograph 
        norder = ext_final['ECHORDER'] - 1 

    elif (nam=='vlt_xshooter_nir'):

        norder = 16

    else:

        norder = ext_final['ECHORDER'] + 1  `

While these changes most likely don't live up to the formatting standards of the rest of the code, I thought submitting a pull request would be a more illustrative way to show the issues. These are the minimal required changes to make pypeit_coadd_1dspec function on X-Shooter inputs.
