### PR TITLE
Fixing a bug.

### DIFF
--- a/pypeit/core/coadd1d.py
+++ b/pypeit/core/coadd1d.py
@@ -1273,7 +1273,6 @@ def compute_stack(wave_grid, waves, fluxes, ivars, masks, weights):
     fluxes_flat = fluxes[ubermask].flatten()
     ivars_flat = ivars[ubermask].flatten()
     vars_flat = utils.inverse(ivars_flat)
-    #weights_flat = np.float64(weights[ubermask].flatten())
     weights_flat = weights[ubermask].flatten()
 
     # Counts how many pixels in each wavelength bin
@@ -2078,6 +2077,7 @@ def combspec(waves, fluxes, ivars, masks, sn_smooth_npix,
               spectrum on wave_stack wavelength grid. True=Good.
     '''
 
+    # We cast to float64 because of a bug in np.histogram
     waves = np.float64(waves)
     fluxes = np.float64(fluxes)
     ivars = np.float64(ivars)

--- a/pypeit/core/coadd1d.py
+++ b/pypeit/core/coadd1d.py
@@ -1273,7 +1273,8 @@ def compute_stack(wave_grid, waves, fluxes, ivars, masks, weights):
     fluxes_flat = fluxes[ubermask].flatten()
     ivars_flat = ivars[ubermask].flatten()
     vars_flat = utils.inverse(ivars_flat)
-    weights_flat = np.float64(weights[ubermask].flatten())
+    #weights_flat = np.float64(weights[ubermask].flatten())
+    weights_flat = weights[ubermask].flatten()
 
     # Counts how many pixels in each wavelength bin
     nused, wave_edges = np.histogram(waves_flat,bins=wave_grid,density=False)
@@ -2077,6 +2078,9 @@ def combspec(waves, fluxes, ivars, masks, sn_smooth_npix,
               spectrum on wave_stack wavelength grid. True=Good.
     '''
 
+    waves = np.float64(waves)
+    fluxes = np.float64(fluxes)
+    ivars = np.float64(ivars)
 
     # Generate a giant wave_grid
     wave_grid, _, _ = get_wave_grid(waves, masks = masks, wave_method=wave_method, wave_grid_min=wave_grid_min,

--- a/pypeit/core/coadd1d.py
+++ b/pypeit/core/coadd1d.py
@@ -1273,7 +1273,7 @@ def compute_stack(wave_grid, waves, fluxes, ivars, masks, weights):
     fluxes_flat = fluxes[ubermask].flatten()
     ivars_flat = ivars[ubermask].flatten()
     vars_flat = utils.inverse(ivars_flat)
-    weights_flat = weights[ubermask].flatten()
+    weights_flat = np.float64(weights[ubermask].flatten())
 
     # Counts how many pixels in each wavelength bin
     nused, wave_edges = np.histogram(waves_flat,bins=wave_grid,density=False)


### PR DESCRIPTION
Previous version: After coadding spectra by using combspec in coadd1d.py, wavelengths were unexpectedly shifted.
New version: Wavelengths are not artificially shifted (as it should be).
Reason for the bug: Precision in weights_flat in compute_stack was not enough high.
Modification: Weights_flat set to float64 type (instead of float32).
Attached: An example of a coadded spectrum with shifted wavelengths (flux vs wavelength) before the changes in the code. In this example two identical spectra (in blue) were coadded. The coadded spectrum is shown in black. After the changes in the code, the blue and black line overlap, as expected.  
![example](https://user-images.githubusercontent.com/22138925/71541722-414df680-2912-11ea-83af-f5a43a3a941e.png)

