### PR TITLE
Add dispangle as a configuration key for shane_kast_red

### DIFF
--- a/pypeit/spectrographs/shane_kast.py
+++ b/pypeit/spectrographs/shane_kast.py
@@ -374,7 +374,7 @@ class ShaneKastRedSpectrograph(ShaneKastSpectrograph):
 
         # Required
         self.meta['dispname'] = dict(ext=0, card='GRATNG_N')
-        self.meta['dispangle'] = dict(ext=0, card='GRTILT_P', rtol=5.)
+        self.meta['dispangle'] = dict(ext=0, card='GRTILT_P', rtol=2e-4)
         # Additional (for config)
 
     def configuration_keys(self):

--- a/pypeit/spectrographs/shane_kast.py
+++ b/pypeit/spectrographs/shane_kast.py
@@ -374,9 +374,25 @@ class ShaneKastRedSpectrograph(ShaneKastSpectrograph):
 
         # Required
         self.meta['dispname'] = dict(ext=0, card='GRATNG_N')
-        self.meta['dispangle'] = dict(ext=0, card='GRTILT_P')
+        self.meta['dispangle'] = dict(ext=0, card='GRTILT_P', rtol=5.)
         # Additional (for config)
 
+    def configuration_keys(self):
+        """
+        Return the metadata keys that defines a unique instrument
+        configuration.
+
+        This list is used by :class:`pypeit.metadata.PypeItMetaData` to
+        identify the unique configurations among the list of frames read
+        for a given reduction.
+
+        Returns:
+
+            list: List of keywords of data pulled from meta
+        """
+        cfg_keys = super(ShaneKastRedSpectrograph, self).configuration_keys()
+        # Add grating tilt
+        return cfg_keys+['dispangle']
 
 class ShaneKastRedRetSpectrograph(ShaneKastSpectrograph):
     """


### PR DESCRIPTION
As titled.

Existing tests don't touch these lines of codes, i.e. no need to run the Dev suite.

I have, however, confirmed by running `pypeit_setup` that this works as intended.