### PR TITLE
Bias test hotfix

### DIFF
--- a/pypeit/images/combineimage.py
+++ b/pypeit/images/combineimage.py
@@ -174,7 +174,6 @@ class CombineImage(object):
                 print(msgs.indent() + strout.format(os.path.split(file)[1], " ".join(lampstat[ff].split("_"))))
             print(msgs.indent() + '-'*maxlen + "  " + '-'*maxlmp)
             embed(header='')
-            msgs.error("Unable to combine frames with different lamp status")
 
         # Coadd them
         weights = np.ones(nimages)/float(nimages)

--- a/pypeit/images/combineimage.py
+++ b/pypeit/images/combineimage.py
@@ -173,6 +173,7 @@ class CombineImage(object):
             for ff, file in enumerate(self.files):
                 print(msgs.indent() + strout.format(os.path.split(file)[1], " ".join(lampstat[ff].split("_"))))
             print(msgs.indent() + '-'*maxlen + "  " + '-'*maxlmp)
+            embed(header='')
             msgs.error("Unable to combine frames with different lamp status")
 
         # Coadd them

--- a/pypeit/tests/test_biasframe.py
+++ b/pypeit/tests/test_biasframe.py
@@ -30,8 +30,11 @@ def deimos_flat_files():
 @pytest.fixture
 @dev_suite_required
 def kast_blue_bias_files():
-    kast_blue_bias_files = glob.glob(os.path.join(os.getenv('PYPEIT_DEV'), 'RAW_DATA',
+    kast_blue_files = glob.glob(os.path.join(os.getenv('PYPEIT_DEV'), 'RAW_DATA',
                                                   'shane_kast_blue', '600_4310_d55', 'b1?.fits*'))
+    kast_blue_files.sort()
+    # Trim to bias
+    kast_blue_bias_files = kast_blue_files[5:]
     return kast_blue_bias_files
 
 @dev_suite_required
@@ -41,7 +44,7 @@ def test_instantiate(kast_blue_bias_files):
     assert bias_frame0.nfiles == 0
     #
     bias_frame1 = biasframe.BiasFrame(shane_kast_blue, files=kast_blue_bias_files)
-    assert bias_frame1.nfiles == 10
+    assert bias_frame1.nfiles == 5
 
 @dev_suite_required
 def test_process(kast_blue_bias_files):


### PR DESCRIPTION
The previous test was mixing bias and other calibration frames.

Now restricted to only bias.

Passing:

(base) profx> py.test test_biasframe.py 
============================= test session starts ==============================
platform linux -- Python 3.7.3, pytest-5.3.5, py-1.8.1, pluggy-0.13.0
rootdir: /data/Projects/Python/PypeIt
plugins: cov-2.7.1, hypothesis-5.6.0, remotedata-0.3.1, astropy-header-0.1.2, openfiles-0.4.0, arraydiff-0.3, doctestplus-0.4.0
collected 4 items                                                              

test_biasframe.py ....                                                   [100%]

=============================== warnings summary ===============================
/home/xavier/Projects/anaconda3/lib/python3.7/site-packages/pkg_resources/__init__.py:1146
/home/xavier/Projects/anaconda3/lib/python3.7/site-packages/pkg_resources/__init__.py:1146
/home/xavier/Projects/anaconda3/lib/python3.7/site-packages/pkg_resources/__init__.py:1146
   DeprecationWarning: Use of .. or absolute path in a resource path is not allowed and will raise exceptions in a future release. (__init__.py:1146)

pypeit/tests/test_biasframe.py::test_io
pypeit/tests/test_biasframe.py::test_run_and_master
   VerifyWarning: Card is too long, comment will be truncated. (card.py:1003)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
======================== 4 passed, 5 warnings in 11.18s ========================