### PR TITLE
HolyGrail hotfix

### DIFF
--- a/pypeit/calibrations.py
+++ b/pypeit/calibrations.py
@@ -819,7 +819,10 @@ class Calibrations(object):
         # Return existing data
         if self._cached('wavecalib', self.master_key_dict['arc']):
             self.wv_calib = self.calib_dict[self.master_key_dict['arc']]['wavecalib']
-            self.slits.mask_wvcalib(self.wv_calib)
+            try:
+                self.slits.mask_wvcalib(self.wv_calib)
+            except:
+                embed(header='825 of header')
             return self.wv_calib
 
         # No wavelength calibration requested
@@ -844,7 +847,10 @@ class Calibrations(object):
         if os.path.isfile(masterframe_name) and self.reuse_masters:
             # Load from disk
             self.wv_calib = self.waveCalib.load(masterframe_name)
-            self.slits.mask_wvcalib(self.wv_calib)
+            try:
+                self.slits.mask_wvcalib(self.wv_calib)
+            except:
+                embed(header='853 of calibrations')
         else:
             self.wv_calib = self.waveCalib.run(skip_QA=(not self.write_qa))
             # Save to Masters

--- a/pypeit/calibrations.py
+++ b/pypeit/calibrations.py
@@ -819,10 +819,7 @@ class Calibrations(object):
         # Return existing data
         if self._cached('wavecalib', self.master_key_dict['arc']):
             self.wv_calib = self.calib_dict[self.master_key_dict['arc']]['wavecalib']
-            try:
-                self.slits.mask_wvcalib(self.wv_calib)
-            except:
-                embed(header='825 of header')
+            self.slits.mask_wvcalib(self.wv_calib)
             return self.wv_calib
 
         # No wavelength calibration requested
@@ -847,10 +844,7 @@ class Calibrations(object):
         if os.path.isfile(masterframe_name) and self.reuse_masters:
             # Load from disk
             self.wv_calib = self.waveCalib.load(masterframe_name)
-            try:
-                self.slits.mask_wvcalib(self.wv_calib)
-            except:
-                embed(header='853 of calibrations')
+            self.slits.mask_wvcalib(self.wv_calib)
         else:
             self.wv_calib = self.waveCalib.run(skip_QA=(not self.write_qa))
             # Save to Masters

--- a/pypeit/core/wavecal/autoid.py
+++ b/pypeit/core/wavecal/autoid.py
@@ -1496,6 +1496,7 @@ class HolyGrail:
         for slit in range(self._nslit):
             msgs.info("Working on slit: {}".format(slit))
             if slit not in self._ok_mask:
+                self._all_final_fit[str(slit)] = {}
                 continue
             # TODO Pass in all the possible params for detect_lines to arc_lines_from_spec, and update the parset
             # Detect lines, and decide which tcent to use
@@ -1601,6 +1602,7 @@ class HolyGrail:
         self._det_stro = {}
         for slit in range(self._nslit):
             if slit not in self._ok_mask:
+                self._all_final_fit[str(slit)] = {}
                 continue
             # Detect lines, and decide which tcent to use
             self._all_tcent, self._all_ecent, self._cut_tcent, self._icut, _ =\

--- a/pypeit/core/wavecal/autoid.py
+++ b/pypeit/core/wavecal/autoid.py
@@ -1189,6 +1189,7 @@ class ArchiveReid:
         for slit in range(self.nslits):
             # ToDO should we still be populating wave_calib with an empty dict here?
             if slit not in self.ok_mask:
+                self.wv_calib[str(slit)] = None
                 continue
             msgs.info('Reidentifying and fitting slit # {0:d}/{1:d}'.format(slit,self.nslits-1))
             # If this is a fixed format echelle, arxiv has exactly the same orders as the data and so
@@ -1211,7 +1212,7 @@ class ArchiveReid:
                            debug_reid=self.debug_reid)
             # Check if an acceptable reidentification solution was found
             if not self.all_patt_dict[str(slit)]['acceptable']:
-                self.wv_calib[str(slit)] = {}
+                self.wv_calib[str(slit)] = None
                 self.bad_slits = np.append(self.bad_slits, slit)
                 continue
 
@@ -1225,7 +1226,7 @@ class ArchiveReid:
             # Did the fit succeed?
             if final_fit is None:
                 # This pattern wasn't good enough
-                self.wv_calib[str(slit)] = {}
+                self.wv_calib[str(slit)] = None
                 self.bad_slits = np.append(self.bad_slits, slit)
                 continue
             # Is the RMS below the threshold?
@@ -1496,7 +1497,7 @@ class HolyGrail:
         for slit in range(self._nslit):
             msgs.info("Working on slit: {}".format(slit))
             if slit not in self._ok_mask:
-                self._all_final_fit[str(slit)] = {}
+                self._all_final_fit[str(slit)] = None
                 continue
             # TODO Pass in all the possible params for detect_lines to arc_lines_from_spec, and update the parset
             # Detect lines, and decide which tcent to use

--- a/pypeit/slittrace.py
+++ b/pypeit/slittrace.py
@@ -623,8 +623,8 @@ class SlitTraceSet(datamodel.DataContainer):
         #    if wv_calib[str(spat_id)] is None:
         #        self.mask[kk] = self.bitmask.turn_on(self.mask[kk], 'BADWVCALIB')
         for islit in range(self.nslits):
-            if wv_calib[str(self.slitord_id[islit])] is None:
-                self.mask[islit] = self.bitmask.turn_on(self.mask[islit], 'BADWVCALIB')
+            if wv_calib[str(self.slitord_id[islit])] is None or len(wv_calib[str(self.slitord_id[islit])]) == 0:
+                    self.mask[islit] = self.bitmask.turn_on(self.mask[islit], 'BADWVCALIB')
 
     def mask_wavetilts(self, waveTilts):
         """

--- a/pypeit/wavecalib.py
+++ b/pypeit/wavecalib.py
@@ -255,7 +255,6 @@ class WaveCalib(object):
         for idx in range(self.slits.nslits):
             if str(idx) in final_fit.keys():
                 self.wv_calib[str(self.slits.slitord_id[idx])] = final_fit.pop(str(idx))
-                #self.wv_calib[str(self.slits.spat_id[idx])] = final_fit.pop(str(idx))
 
         # Update mask
         self.update_wvmask()


### PR DESCRIPTION
The wavelength algorithms must now generate an entry
for every slit, bad or good.

I guess this wasn't caught by the Dev Suite because none
of the HolyGrail entries have a short slit. 