### PR TITLE
Pixel and illumination flats

### DIFF
--- a/doc/flat_fielding.rst
+++ b/doc/flat_fielding.rst
@@ -130,11 +130,10 @@ at least one of the data files in the
 :doc:`pypeit_file` :ref:`pypeit_file:Data Block` must
 be labelled as *illumflat*.
 
-Last, and **most confusing**, at present the code
-
-- Cannot process separate sets of *illumflat* and *pixelflat* images
-  and will take the former if both are provided.
-- the *illumflat* images must be the same as the *trace* images
+In some cases, it may be desirable to use a different set of
+frames for the pixel and illumination corrections. This is
+supported, but we recommend that you set the *trace* frames
+to be the same as the *illumflat* frames.
 
 Feed a PixelFlat
 ----------------

--- a/pypeit/calibrations.py
+++ b/pypeit/calibrations.py
@@ -505,8 +505,6 @@ class Calibrations(object):
             self.slits.mask_flats(self.flatimages)
             return self.flatimages
 
-
-        # TODO -- Allow for separate pixelflat and illumflat images
         # Generate the image
         illum_flat, pix_flat = None, None
         # Check if the image files are the same
@@ -526,7 +524,7 @@ class Calibrations(object):
         if pix_flat is None and illum_flat is not None:
             # Assign the pixel flat to be the stacked flat
             pix_flat = illum_flat
-            illum_flat = None # we only have one flat, so use the same image for pixel and illum flat.
+            illum_flat = None  # we only have one flat, so use the same image for pixel and illum flat.
 
         # Check if one should be used and not the other
         if pix_flat is not None:

--- a/pypeit/flatfield.py
+++ b/pypeit/flatfield.py
@@ -208,9 +208,16 @@ class FlatImages(datamodel.DataContainer):
         show_flats(self.pixelflat, illumflat, self.procflat, self.flat_model,
                    wcs_match=wcs_match, slits=slits)
 
+
 class FlatField(object):
     """
     Builds pixel-level flat-field and the illumination flat-field.
+    rawpixflatimg *must* be provided. If rawillumflatimg is None,
+    the illumination and pixel-level corrections will be derived
+    from rawpixflatimg. If rawillumflatimg is a PypeItImage, the
+    illumination correction will be performed with the illumflat
+    and the pixel-level corrections will be derived from the
+    rawpixflatimg frame.
 
     For the primary methods, see :func:`run`.
 


### PR DESCRIPTION
This PR allows separate `pixelflat` and `illumflat` to be specified. The logic ensures that if the pixelflat and illumflat files are the same, then the flatfield calculation is only performed once. Otherwise, the illumflat is derived first, followed by the pixelflat. The msillumflat is set to be the illumination profile of the pixel flat, while the bsplines are stored to generate the illumination profile