### PR TITLE
I have adjusted these files to allow for the manual addition of objec…

### DIFF
--- a/pypeit/coadd2d.py
+++ b/pypeit/coadd2d.py
@@ -408,7 +408,22 @@ class CoAdd2D(object):
         if show:
             redux.show('image', image=pseudo_dict['imgminsky']*(sciImage.mask == 0), chname = 'imgminsky', slits=True, clear=True)
         # Object finding
-        sobjs_obj, nobj, skymask_init = redux.find_objects(sciImage.image, show_peaks=show_peaks)
+         msgs.warn("added in manual extraction at line 371 in coadd2d.py")
+         man = parcopy['reduce']['extraction']['manual']
+         if man is not None:
+             det = np.zeros_like(man)
+             spec = np.zeros_like(man)
+             spat = np.zeros_like(man)
+             fwhm = np.zeros_like(man)
+             for i in range(len(man)):
+                 det[i],spec[i],spat[i],fwhm[i] = man[i].split(':')
+             mandict = {}
+             mandict['hand_extract_spec'] = np.array(spec,dtype=np.float)
+             mandict['hand_extract_det'] = np.array(det,dtype=np.int)
+             mandict['hand_extract_fwhm'] = np.array(fwhm,dtype=np.float)
+             mandict['hand_extract_spat'] = np.array(spat,dtype=np.float)
+        sobjs_obj, nobj, skymask_init = redux.find_objects(sciImage.image, show_peaks=show_peaks,manual_extract_dict=mandict)
+        #NOTE: added in manual extraction for 2d coadd Christopher SK
         # Local sky-subtraction
         global_sky_pseudo = np.zeros_like(pseudo_dict['imgminsky']) # No global sky for co-adds since we go straight to local
         skymodel_pseudo, objmodel_pseudo, ivarmodel_pseudo, outmask_pseudo, sobjs = redux.local_skysub_extract(

--- a/pypeit/core/gui/object_find.py
+++ b/pypeit/core/gui/object_find.py
@@ -131,9 +131,10 @@ class ObjectTraces:
         """Construct a string that can be placed in the .pypeit file to define new object traces
         """
         strall = ""
+        msgs.warn("Changing order of string to be consistent with code for manual extraction made by Christopher SK at line 133 in object_find.py: _pos_spat <-> _pos_spec")
         for ii in range(self.nobj):
             if self._add_rm[ii] == 1:
-                strall += ",{0:d}:{1:.1f}:{2:.1f}:{3:.1f}".format(self._det[ii], self._pos_spat[ii], self._pos_spec[ii], self._fwhm[ii])
+                strall += ",{0:d}:{1:.1f}:{2:.1f}:{3:.1f}".format(self._det[ii], self._pos_spec[ii], self._pos_spat[ii], self._fwhm[ii])
         strall += "\n"
         return strall[1:]
 
@@ -917,6 +918,10 @@ def initialise(det, frame, left, right, obj_trace, trace_models, sobjs, slit_ids
     mad = np.median(np.abs(frame-med))
     vmin = med-3*mad
     vmax = med+3*mad
+    if mad == 0:
+        #NOTE: Added conditional for cases where mad == 0, Christopher SK
+        vmin = med - 10
+        vmax = med + 10
 
     # Add the main figure axis
     fig, ax = plt.subplots(figsize=(16, 9), facecolor="white")

--- a/pypeit/metadata.py
+++ b/pypeit/metadata.py
@@ -127,6 +127,10 @@ class PypeItMetaData:
         self.configs = None
         self.calib_bitmask = None
 
+        #NOTE: Need to keep track of user objects, not sure if this does that (Christopher SK)
+        msgs.warn("Adding in at 131 in metadata.py")
+        self.usrobjs = self.par['reduce']['extraction']['manual']
+
     def _impose_types(self, columns, types):
         """
         Impose a set of types on certain columns.
@@ -234,19 +238,22 @@ class PypeItMetaData:
         """
 
         # Manual extract
-        if 'manual_extract' not in self.keys():
+        #if 'manual_extract' not in self.keys():
+        #    return None
+        if self.par['reduce']['extraction']['manual'] is None:
             return None
         # Warn me
         if len(frames) > 1:
             msgs.warn("Taking first science frame in stack for manual extraction")
         frame = frames[0]
         # Empty?
-        if self['manual_extract'][frame] == 'None':
-            return None
+        #if self['manual_extract'][frame] == 'None':
+        #    return None
 
         # Parse the input
         manual_extract_dict = {}
-        items = self['manual_extract'][frame].split(',')
+        #items = self['manual_extract'][frame].split(',')
+        items = self.par['reduce']['extraction']['manual']
         dets, spats, specs, fwhms = [], [], [], []
         for item in items:
             numbers = item.split(':')

--- a/pypeit/par/pypeitpar.py
+++ b/pypeit/par/pypeitpar.py
@@ -3007,7 +3007,7 @@ class FindObjPar(ParSet):
     def __init__(self, trace_npoly=None, sig_thresh=None, find_trim_edge=None, find_cont_fit=None,
                  find_npoly_cont=None, find_maxdev=None, find_extrap_npoly=None, maxnumber=None,
                  find_fwhm=None, ech_find_max_snr=None, ech_find_min_snr=None,
-                 ech_find_nabove_min_snr=None, skip_second_find=None):
+                 ech_find_nabove_min_snr=None, skip_second_find=None,manual=None):#NOTE: manual added by Christopher SK. unsure if necessary
         # Grab the parameter names and values from the function
         # arguments
         args, _, _, values = inspect.getargvalues(inspect.currentframe())
@@ -3022,6 +3022,10 @@ class FindObjPar(ParSet):
 
         # Fill out parameter specifications.  Only the values that are
         # *not* None (i.e., the ones that are defined) need to be set
+        defaults['manual'] = None
+        dtypes['manual'] = list
+        descr['manual'] = 'list of manual extraction parameter set'
+
         defaults['trace_npoly'] = 5
         dtypes['trace_npoly'] = int
         descr['trace_npoly'] = 'Order of legendre polynomial fits to object traces.'
@@ -3098,7 +3102,7 @@ class FindObjPar(ParSet):
                    'find_cont_fit', 'find_npoly_cont',
                    'find_extrap_npoly', 'maxnumber',
                    'find_maxdev', 'find_fwhm', 'ech_find_max_snr',
-                   'ech_find_min_snr', 'ech_find_nabove_min_snr', 'skip_second_find']
+                   'ech_find_min_snr', 'ech_find_nabove_min_snr', 'skip_second_find','manual']#NOTE: manual added by Christopher SK
 
         badkeys = numpy.array([pk not in parkeys for pk in k])
         if numpy.any(badkeys):
@@ -3277,7 +3281,7 @@ class ExtractionPar(ParSet):
         descr['use_2dmodel_mask'] = 'Mask pixels rejected during profile fitting when extracting.' \
                              'Turning this off may help with bright emission lines.'
 
-
+        defaults['manual'] = None
         dtypes['manual'] = list
         descr['manual'] = 'List of manual extraction parameter sets'
 
@@ -3305,7 +3309,9 @@ class ExtractionPar(ParSet):
         kwargs = {}
         for pk in parkeys:
             kwargs[pk] = cfg[pk] if pk in k else None
-        kwargs['manual'] = util.get_parset_list(cfg, 'manual', ManualExtractionPar)
+        #kwargs['manual'] = util.get_parset_list(cfg, 'manual', ManualExtractionPar)
+        #NOTE: Removing this deprecated line of code allows the use of manual under ExtractionPar in Pypeit file
+        #Changed by Christopher SK
         return cls(**kwargs)
 
     def validate(self):

--- a/pypeit/pypeit.py
+++ b/pypeit/pypeit.py
@@ -653,6 +653,7 @@ class PypeIt(object):
         # Prep for manual extraction (if requested)
         manual_extract_dict = self.fitstbl.get_manual_extract(frames, det)
 
+        msgs.warn("Check that manual extract dict is passed: {}".format(manual_extract_dict))
         skymodel, objmodel, ivarmodel, outmask, sobjs, waveImg, tilts = self.redux.run(
             std_trace=std_trace, manual_extract_dict=manual_extract_dict, show_peaks=self.show,
             basename=self.basename, ra=self.fitstbl["ra"][frames[0]], dec=self.fitstbl["dec"][frames[0]],

--- a/pypeit/specobj.py
+++ b/pypeit/specobj.py
@@ -135,6 +135,14 @@ class SpecObj(datamodel.DataContainer):
         'ECH_NAME': dict(otype=str,
                          desc='Name of the object for echelle data. Same as NAME above but order numbers are '
                               'omitted giving a unique name per object.')
+
+        #NOTE: added by Christopher SK. I note that this is not keeping with the syntax of the abobe data elements
+        # but this was necessary for these data to pass checks in core/extract.py. nevertheless a renaming there 
+        # would clearly allow a renaming here and is likely desirable.
+        'hand_extract_spec': dict(otype=float, desc = 'Spectroscopic position of manual extraction'),
+        'hand_extract_spat': dict(otype=float, desc='Spatial position of manual extraction'),
+        'hand_extract_det': dict(otype=(int,np.int64), desc='The detector to perform manual extraction on'),
+        'hand_extract_fwhm': dict(otype=float, desc='FWHM of objects')                      
     }
 
     def __init__(self, PYPELINE, DET, OBJTYPE='unknown',


### PR DESCRIPTION
…ts. Generally I've used the object finding gui to determine the parameter set, but this isn't necessary to add manual extraction parameters. I've relied on access to par['reduce]['extraction']['manual'] in metadata.py from the pypeit file to make this functional and I'm a little uncertain if this is accessed in the same way as in v0.13.1 (which is where I've tested this code), but the code in extract.py should work once the manual extraction parameters are accessed from the pypeit file. I've also made it possible to manually add objects for the 2d coadding files through the same block as in the .pypeit file for the user. This code does not account for any shift in the spatial direction of the objects for multi science frame observations, so the user has to manually identify objects for each Science frame group (Though I believe it's suggested to have different .pypeit files for this anyway). Hopefully this code is helpful