### PR TITLE
Fix GNIRS setup resulting from wronger decker card

### DIFF
--- a/pypeit/spectrographs/gemini_gnirs.py
+++ b/pypeit/spectrographs/gemini_gnirs.py
@@ -221,7 +221,7 @@ class GeminiGNIRSSpectrograph(spectrograph.Spectrograph):
         meta['ra'] = dict(ext=0, card='RA')
         meta['dec'] = dict(ext=0, card='DEC')
         meta['target'] = dict(ext=0, card='OBJECT')
-        meta['decker'] = dict(ext=0, card='SLIT')
+        meta['decker'] = dict(ext=0, card='decker')
 
         meta['binning'] = dict(ext=0, card=None, default='1,1')
         meta['mjd'] = dict(ext=0, card='MJD_OBS')


### PR DESCRIPTION
## Description
In the GNIRS spectrograph, `meta['decker']` is assigned the `'SLIT'` card. 
When running `pypeit_setup` the created `.pypeit` file contains `0.68arcsec_G5530` instead of `SCXD_G5531` under the column `decker`. 
As a result, `run_pypeit` crashes because the `.fits` files contain the correct decker.

It is unclear to me why decker is assigned the `'SLIT'` card. If this change was required by something else, a solution for `pypeit_setup` needs to be found.

I haven't tested other spectrographs and thus I'm not sure if this is unique to GNIRS.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)