### PR TITLE
Hotfix for chk_calibs test

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,11 +1,11 @@
 
 1.0.7dev
 --------
+ - (Hotfix) Deal with chk_calibs test
 
 1.0.6 (22 Jul 2020)
 -------------------
 
- - (Hotfix) Deal with chk_calibs crash
  - (Hotfix) Deal with wavecalib crash
  - Fix class and version check for DataContainer objects.
  - Script to check for calibration files

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@
 1.0.6 (22 Jul 2020)
 -------------------
 
+ - (Hotfix) Deal with chk_calibs crash
  - (Hotfix) Deal with wavecalib crash
  - Fix class and version check for DataContainer objects.
  - Script to check for calibration files

--- a/pypeit/tests/test_chk_calibs.py
+++ b/pypeit/tests/test_chk_calibs.py
@@ -27,9 +27,15 @@ def test_chk_calibs_not():
 
 @dev_suite_required
 def test_chk_calibs_deimos():
-    droot = os.path.join(os.environ['PYPEIT_DEV'], 'RAW_DATA/keck_deimos/*/')
+    # 830G
+    droot = os.path.join(os.environ['PYPEIT_DEV'], 'RAW_DATA/keck_deimos/830G_M_8600/')
     pargs = chk_calibs.parser([droot, '-s', 'keck_deimos'])
     answers, _ = chk_calibs.main(pargs)
+    assert np.all(answers['pass'][:-1]), 'One or more failures!'
 
+    # 600ZD
+    droot = os.path.join(os.environ['PYPEIT_DEV'], 'RAW_DATA/keck_deimos/600ZD_M_7500/')
+    pargs = chk_calibs.parser([droot, '-s', 'keck_deimos'])
+    answers, _ = chk_calibs.main(pargs)
     assert np.all(answers['pass'][:-1]), 'One or more failures!'
 


### PR DESCRIPTION
As titled.

Restricts to just two folders as at least one of the new ones 
is problematic (and this could arise again.