### PR TITLE
Data type bug fix in `show_2dspec`

### DIFF
--- a/pypeit/display/display.py
+++ b/pypeit/display/display.py
@@ -162,7 +162,8 @@ def show_image(inp, chname='Image', waveimg=None, bitmask=None, mask=None, exten
 #    waveimg = None
     if waveimg is not None:
         sh = viewer.shell()
-        args = [chname, chname, grc.Blob(img.tobytes()), img.shape, 'float', header, grc.Blob(waveimg.tobytes()), 'float', {}]
+        args = [chname, chname, grc.Blob(img.tobytes()), img.shape, img.dtype.name, header,
+                grc.Blob(waveimg.tobytes()), waveimg.dtype.name, {}]
         sh.call_global_plugin_method('SlitWavelength', 'load_buffer', args, {})
     else:
         ch.load_np(chname, img, 'fits', header)


### PR DESCRIPTION
This fixes a bug that crept in via the change in the data types for the spec2d files when displaying them in ginga.