### PR TITLE
LRIS hotfix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@
    wavelength coverage slits results in reidentification with a purely zero-padded array.
  - Fixed another such bug arising from these zero-padded arrays. 
  - (Hotfix) Deal with chk_calibs test
+ - Correct det bug in keck_lris
 
 1.0.6 (22 Jul 2020)
 -------------------

--- a/pypeit/spectrographs/keck_lris.py
+++ b/pypeit/spectrographs/keck_lris.py
@@ -346,7 +346,7 @@ class KeckLRISSpectrograph(spectrograph.Spectrograph):
         # Need the exposure time
         exptime = hdu[self.meta['exptime']['ext']].header[self.meta['exptime']['card']]
         # Return
-        return self.get_detector_par(hdu, det if det is None else 1), \
+        return self.get_detector_par(hdu, det if det is not None else 1), \
                 array.T, hdu, exptime, rawdatasec_img.T, oscansec_img.T
 
     def subheader_for_spec(self, row_fitstbl, raw_header):
@@ -423,7 +423,7 @@ class KeckLRISBSpectrograph(KeckLRISSpectrograph):
 
         # Instantiate
         detector_dicts = [detector_dict1, detector_dict2]
-        detector = detector_container.DetectorContainer(**detector_dicts[det])
+        detector = detector_container.DetectorContainer(**detector_dicts[det-1])
 
         # Deal with number of amps
         namps = hdu[0].header['NUMAMPS']
@@ -694,7 +694,7 @@ class KeckLRISRSpectrograph(KeckLRISSpectrograph):
 
         # Instantiate
         detector_dicts = [detector_dict1, detector_dict2]
-        detector = detector_container.DetectorContainer(**detector_dicts[det])
+        detector = detector_container.DetectorContainer(**detector_dicts[det-1])
 
         # Deal with number of amps
         namps = hdu[0].header['NUMAMPS']


### PR DESCRIPTION
Corrects a bug I likely introduced when dealing with the original data
format(s) for LRIS.

Running tests on long slit of red/blue now.