### PR TITLE
Fix installation from sdist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Folders#
 .idea/
 .vscode/
+build/*
+dist/*
 
 # Compiled source #
 ###################

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,6 +4,7 @@ include README.md
 include setup.cfg
 
 recursive-include pypeit *.pyx *.c *.pxd *.h
+recursive-include pypeit/data *
 recursive-include docs *
 recursive-include licenses *
 recursive-include cextern *
@@ -14,10 +15,10 @@ include pypeit/requirements.txt
 prune build
 prune docs/_build
 prune docs/api
+prune pypeit/deprecated
 
 #recursive-include astropy_helpers *
 #exclude astropy_helpers/.git
 #exclude astropy_helpers/.gitignore
 
-global-exclude *.pyc *.o
-
+global-exclude *.pyc *.o *.so *.DS_Store


### PR DESCRIPTION
This PR includes the ``pypeit/data`` dir in sdists, which are used to build/install PypeIt from pip on non macOS py3.7 platforms.