### PR TITLE
Add missing pypeit.msgs import

### DIFF
--- a/pypeit/scripts/ql_keck_nires.py
+++ b/pypeit/scripts/ql_keck_nires.py
@@ -32,6 +32,7 @@ def main(pargs):
     from pypeit import pypeit
     from pypeit import pypeitsetup
     from pypeit.core import framematch
+    from pypeit import msgs
 
 
     # Setup


### PR DESCRIPTION
Quick fix for a missing import.

Unit Tests:
================================================ 246 passed, 680 warnings in 452.43s (0:07:32) =================================================

> dev suite for keck_nires:
> Running tests on the following instruments:
>     keck_nires
> 
> Reducing data from keck_nires for the following setups:
>     NIRES
> 
> Directories:
>          Raw data: /home/dusty/work/PypeIt-development-suite/RAW_DATA/keck_nires/NIRES
>     PypeIt output: /home/dusty/work/PypeIt-development-suite/REDUX_OUT/keck_nires/NIRES
> 
> Directory: /home/dusty/work/PypeIt-development-suite/REDUX_OUT/keck_nires/NIRES
> Command line: run_pypeit keck_nires_nires.pypeit -o
> Wrote: /home/dusty/work/PypeIt-development-suite/REDUX_OUT/keck_nires/NIRES/QA/MF_A.html
> Running pypeit on keck_nires/NIRES (ignores masters)  --- PASSED
> [INFO]    :: Data reduction complete
> [INFO]    :: Generating QA HTML
> 
> 
> Directory: /home/dusty/work/PypeIt-development-suite/REDUX_OUT/keck_nires/NIRES/QL
> Command line: pypeit_ql_keck_nires /home/dusty/work/PypeIt-development-suite/RAW_DATA/keck_nires/NIRES s190519_0067.fits s190519_0068.fits
> Wrote: /home/dusty/work/PypeIt-development-suite/REDUX_OUT/keck_nires/NIRES/QL/keck_nires_A/QA/MF_A.html
> Running pypeit_ql_mos on keck_niresQL  --- PASSED
> [INFO]    :: Execution time: 23.89s
> [INFO]    :: Data reduction complete
> [INFO]    :: Generating QA HTML
> 
> 
> 
> --- PYPEIT DEVELOPMENT SUITE PASSED 2/2 TESTS (Masters ignored) ---
> 