### PR TITLE
Fix using Polynomial Telluric model for high-flux objects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -115,13 +115,13 @@ matrix:
 
         # Do a PEP8 test with pycodestyle
         - os: linux
-          env: MAIN_CMD='pycodestyle packagename --count' SETUP_CMD=''
+          env: MAIN_CMD='pycodestyle pypeit --count' SETUP_CMD=''
 
     allow_failures:
         # Do a PEP8 test with pycodestyle
         # (allow to fail unless your code completely compliant)
         - os: linux
-          env: MAIN_CMD='pycodestyle packagename --count' SETUP_CMD=''
+          env: MAIN_CMD='pycodestyle pypeit --count' SETUP_CMD=''
 
 install:
 

--- a/pypeit/core/coadd.py
+++ b/pypeit/core/coadd.py
@@ -1493,12 +1493,12 @@ def coadd_iexp_qa(wave, flux, rejivar, mask, wave_stack, flux_stack, ivar_stack,
                    label='originally masked')
 
     if norder is None:
-        spec_plot.plot(wave[wave_mask], flux[wave_mask], color='dodgerblue', linestyle='steps-mid',
+        spec_plot.plot(wave[wave_mask], flux[wave_mask], color='dodgerblue', drawstyle='steps-mid',
                        zorder=2, alpha=0.5,label='single exposure')
         spec_plot.plot(wave[wave_mask], np.sqrt(utils.inverse(rejivar[wave_mask])),zorder=3,
-                       color='0.7', alpha=0.5, linestyle='steps-mid')
+                       color='0.7', alpha=0.5, drawstyle='steps-mid')
         spec_plot.plot(wave_stack[wave_stack_mask],flux_stack[wave_stack_mask]*mask_stack[wave_stack_mask],color='k',
-                       linestyle='steps-mid',lw=2,zorder=3, alpha=0.5, label='coadd')
+                       drawstyle='steps-mid',lw=2,zorder=3, alpha=0.5, label='coadd')
 
         # TODO Use one of our telluric models here instead
         # Plot transmission
@@ -1511,11 +1511,11 @@ def coadd_iexp_qa(wave, flux, rejivar, mask, wave_stack, flux_stack, ivar_stack,
         npix = np.size(flux)
         nspec = int(npix / norder)
         spec_plot.plot(wave_stack[wave_stack_mask], flux_stack[wave_stack_mask] * mask_stack[wave_stack_mask],
-                       color='k', linestyle='steps-mid', lw=1, zorder=3, alpha=0.5, label='coadd')
+                       color='k', drawstyle='steps-mid', lw=1, zorder=3, alpha=0.5, label='coadd')
         for iord in range(norder):
             spec_plot.plot(wave[nspec*iord:nspec*(iord+1)][wave_mask[nspec*iord:nspec*(iord+1)]],
                            flux[nspec*iord:nspec*(iord+1)][wave_mask[nspec*iord:nspec*(iord+1)]],
-                           linestyle='steps-mid', zorder=1, alpha=0.7, label='order {:d}'.format(iord))
+                           drawstyle='steps-mid', zorder=1, alpha=0.7, label='order {:d}'.format(iord))
 
     # This logic below allows more of the spectrum to be plotted if wave_ref is a multi-order stack which has broader
     # wavelength coverage. For the longslit or single order case, this will plot the correct range as well
@@ -1617,7 +1617,7 @@ def coadd_qa(wave, flux, ivar, nused, mask=None, tell=None, title=None, qafile=N
     # [left, bottom, width, height]
     num_plot =  fig.add_axes([0.10, 0.70, 0.80, 0.23])
     spec_plot = fig.add_axes([0.10, 0.10, 0.80, 0.60])
-    num_plot.plot(wave[wave_mask],nused[wave_mask],linestyle='steps-mid',color='k',lw=2)
+    num_plot.plot(wave[wave_mask],nused[wave_mask],drawstyle='steps-mid',color='k',lw=2)
     num_plot.set_xlim([wave_min, wave_max])
     num_plot.set_ylim([0.0, np.fmax(1.1*nused.max(), nused.max()+1.0)])
     num_plot.set_ylabel('$\\rm N_{EXP}$')

--- a/pypeit/core/coadd.py
+++ b/pypeit/core/coadd.py
@@ -548,7 +548,7 @@ def solve_poly_ratio(wave, flux, ivar, flux_ref, ivar_ref, norder, mask = None, 
     nspec = wave.size
     # Determine an initial guess
     ratio = robust_median_ratio(flux, ivar, flux_ref, ivar_ref, mask=mask, mask_ref=mask_ref,
-                                ref_percentile=ref_percentile)
+                                ref_percentile=ref_percentile, max_factor=scale_max)
     if 'poly' in model:
         guess = np.append(ratio, np.zeros(norder-1))
     elif 'square' in model:

--- a/pypeit/core/coadd.py
+++ b/pypeit/core/coadd.py
@@ -267,9 +267,9 @@ def renormalize_errors(chi, mask, clip = 6.0, max_corr = 5.0, title = '', debug=
                       " Errors are overestimated so not applying correction")
             sigma_corr = 1.0
         if sigma_corr > max_corr:
-            msgs.warn("Error renormalization found sigma_corr/sigma = {:f} > {:f}." + msgs.newline() +
+            msgs.warn(("Error renormalization found sigma_corr/sigma = {:f} > {:f}." + msgs.newline() +
                       "Errors are severely underestimated." + msgs.newline() +
-                      "Setting correction to sigma_corr = {:4.2f}".format(sigma_corr, max_corr, max_corr))
+                      "Setting correction to sigma_corr = {:4.2f}").format(sigma_corr, max_corr, max_corr))
             sigma_corr = max_corr
 
         if debug:

--- a/pypeit/metadata.py
+++ b/pypeit/metadata.py
@@ -1019,7 +1019,7 @@ class PypeItMetaData:
         """
         if 'framebit' not in self.keys():
             msgs.error('Frame types are not set.  First run get_frame_types.')
-        if ftype is 'None':
+        if ftype == 'None':
             return self['framebit'] == 0
         # Select frames
         indx = self.type_bitmask.flagged(self['framebit'], ftype)

--- a/pypeit/wavemodel.py
+++ b/pypeit/wavemodel.py
@@ -564,7 +564,7 @@ def conv2res(wavelength, flux, resolution, central_wl='midpt',
         Size of one pixel at central_wl
     """
 
-    if central_wl is 'midpt':
+    if central_wl == 'midpt':
         wl_cent = np.median(wavelength)
     else:
         wl_cent = np.float(central_wl)


### PR DESCRIPTION
The `max_scale` of `1e5` set in `poly_telluric` was not being propagated through to `core.coadd.solve_poly_ratio`.  This caused high flux objects (like standard stars) to be completely masked when using a polynomial object model because the initial ratio found by `robust_median_ratio` would max out at 10, resulting in a bad initial fit, and all data points being masked before the differential evolution. This presented (to me at least) as a `numpy` `ValueError: output array is read-only`.

```
    TelPoly = telluric.poly_telluric(args['spec1dfile'], par['tellfit']['tell_grid'], modelfile, outfile,
  File "/home/mroberso/mroberso/anaconda3/envs/dbsp_drp_dev/lib/python3.8/site-packages/pypeit/core/telluric.py", line 1590, in poly_telluric
    TelObj = Telluric(wave, flux, ivar, mask_tot, telgridfile, obj_params,
  File "/home/mroberso/mroberso/anaconda3/envs/dbsp_drp_dev/lib/python3.8/site-packages/pypeit/core/telluric.py", line 1875, in __init__
    obj_dict, bounds_obj = init_obj_model(obj_params, iord,
  File "/home/mroberso/mroberso/anaconda3/envs/dbsp_drp_dev/lib/python3.8/site-packages/pypeit/core/telluric.py", line 1001, in init_poly_model
    scale, fit_tuple, flux_scale, ivar_scale, outmask = coadd.solve_poly_ratio(
  File "/home/mroberso/mroberso/anaconda3/envs/dbsp_drp_dev/lib/python3.8/site-packages/pypeit/core/coadd.py", line 575, in solve_poly_ratio
    result, ymodel, ivartot, outmask = utils.robust_optimize(flux_ref, poly_ratio_fitfunc, arg_dict, inmask=mask_ref,
  File "/home/mroberso/mroberso/anaconda3/envs/dbsp_drp_dev/lib/python3.8/site-packages/pypeit/utils.py", line 1011, in robust_optimize
    ret_tuple = fitfunc(ydata, thismask, arg_dict, **kwargs_optimizer)
  File "/home/mroberso/mroberso/anaconda3/envs/dbsp_drp_dev/lib/python3.8/site-packages/pypeit/core/coadd.py", line 423, in poly_ratio_fitfunc
    result = scipy.optimize.minimize(poly_ratio_fitfunc_chi2, guess, args=(flux_ref, thismask, arg_dict),  **kwargs_opt)
  File "/home/mroberso/mroberso/anaconda3/envs/dbsp_drp_dev/lib/python3.8/site-packages/scipy/optimize/_minimize.py", line 612, in minimize
    return _minimize_bfgs(fun, x0, args, jac, callback, **options)
  File "/home/mroberso/mroberso/anaconda3/envs/dbsp_drp_dev/lib/python3.8/site-packages/scipy/optimize/optimize.py", line 1101, in _minimize_bfgs
    sf = _prepare_scalar_function(fun, x0, jac, args=args, epsilon=eps,
  File "/home/mroberso/mroberso/anaconda3/envs/dbsp_drp_dev/lib/python3.8/site-packages/scipy/optimize/optimize.py", line 261, in _prepare_scalar_function
    sf = ScalarFunction(fun, x0, args, grad, hess,
  File "/home/mroberso/mroberso/anaconda3/envs/dbsp_drp_dev/lib/python3.8/site-packages/scipy/optimize/_differentiable_functions.py", line 76, in __init__
    self._update_fun()
  File "/home/mroberso/mroberso/anaconda3/envs/dbsp_drp_dev/lib/python3.8/site-packages/scipy/optimize/_differentiable_functions.py", line 166, in _update_fun
    self._update_fun_impl()
  File "/home/mroberso/mroberso/anaconda3/envs/dbsp_drp_dev/lib/python3.8/site-packages/scipy/optimize/_differentiable_functions.py", line 73, in update_fun
    self.f = fun_wrapped(self.x)
  File "/home/mroberso/mroberso/anaconda3/envs/dbsp_drp_dev/lib/python3.8/site-packages/scipy/optimize/_differentiable_functions.py", line 70, in fun_wrapped
    return fun(x, *args)
  File "/home/mroberso/mroberso/anaconda3/envs/dbsp_drp_dev/lib/python3.8/site-packages/pypeit/core/coadd.py", line 368, in poly_ratio_fitfunc_chi2
    chi_mean, chi_median, chi_std = stats.sigma_clipped_stats(
  File "/home/mroberso/mroberso/anaconda3/envs/dbsp_drp_dev/lib/python3.8/site-packages/astropy/stats/sigma_clipping.py", line 756, in sigma_clipped_stats
    mean = np.nanmean(data_clipped, axis=axis)
  File "<__array_function__ internals>", line 5, in nanmean
  File "/home/mroberso/mroberso/anaconda3/envs/dbsp_drp_dev/lib/python3.8/site-packages/numpy/lib/nanfunctions.py", line 950, in nanmean
    avg = _divide_by_count(tot, cnt, out=out)
  File "/home/mroberso/mroberso/anaconda3/envs/dbsp_drp_dev/lib/python3.8/site-packages/numpy/lib/nanfunctions.py", line 212, in _divide_by_count
    return np.divide(a, b, out=a, casting='unsafe')
ValueError: output array is read-only
```