### PR TITLE
Allow for old 2D verisons in chk_2dslits

### DIFF
--- a/pypeit/scripts/chk_2dslits.py
+++ b/pypeit/scripts/chk_2dslits.py
@@ -23,7 +23,7 @@ def main(args):
     # bitmask
     bitmask = slittrace.SlitTraceBitMask()
     # Load
-    allspec2D = spec2dobj.AllSpec2DObj.from_fits(args.spec2d_file)
+    allspec2D = spec2dobj.AllSpec2DObj.from_fits(args.spec2d_file, chk_version=False)
     # Loop on Detectors
     for det in allspec2D.detectors:
         print("================ DET {:02d} ======================".format(det))

--- a/pypeit/spec2dobj.py
+++ b/pypeit/spec2dobj.py
@@ -236,11 +236,14 @@ class AllSpec2DObj(object):
     """
     hdr_prefix = 'ALLSPEC2D_'
     @classmethod
-    def from_fits(cls, filename):
+    def from_fits(cls, filename, chk_version=True):
         """
 
         Args:
             filename (str):
+            chk_version (bool, optional):
+                If True, demand the on-disk datamodel equals the current
+                Passed to from_hdu() of DataContainer
 
         Returns:
             :class:`AllSpec2DObj`:
@@ -258,7 +261,7 @@ class AllSpec2DObj(object):
         # Detectors included
         detectors = hdul[0].header[slf.hdr_prefix+'DETS']
         for det in [int(item) for item in detectors.split(',')]:
-            obj = Spec2DObj.from_hdu(hdul, hdu_prefix=spec2d_hdu_prefix(det))
+            obj = Spec2DObj.from_hdu(hdul, hdu_prefix=spec2d_hdu_prefix(det), chk_version=chk_version)
             slf[det] = obj
         # Header
         slf['meta']['head0'] = hdul[0].header


### PR DESCRIPTION
As titled.

Mimics behaviour of `pypeit_show_2dspec`