### PR TITLE
Turn back on script tests

### DIFF
--- a/pypeit/tests/test_scripts.py
+++ b/pypeit/tests/test_scripts.py
@@ -29,7 +29,7 @@ def data_path(filename):
     data_dir = os.path.join(os.path.dirname(__file__), 'files')
     return os.path.join(data_dir, filename)
 
-'''
+
 @dev_suite_required
 def test_quicklook():
     # The following needs the LRISb calibration files to be
@@ -198,7 +198,7 @@ def test_chk_flat():
     #
     pargs = chk_flats.parse_args([mstrace_root])
     chk_flats.main(pargs)
-'''
+
 
 
 def test_coadd1d_1():
@@ -251,4 +251,4 @@ def test_coadd1d_2():
     os.remove(coadd_ofile)
 
 
-# TODO: Include tests for coadd2d, sensfunc, flux_calib
+# TODO: Include tests for coadd2d, sensfunc, flux_calib, identify


### PR DESCRIPTION
Hot fix to uncomment out script tests.
Probably was something I put in accidentally in a previous PR.