### PR TITLE
Refactor check_requirements.py

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -19,5 +19,4 @@ dependencies:
   - extension-helpers>=0.1
   - ginga>=3.0
   - linetools>=0.3
-  - PySide2>=5.0
   - pytest>=3.0.7

--- a/pypeit/check_requirements.py
+++ b/pypeit/check_requirements.py
@@ -2,6 +2,7 @@
 Version checking.
 """
 
+import importlib
 import pkg_resources
 from pypeit import msgs
 
@@ -12,7 +13,7 @@ for requirement in install_requires:
     pkg, version = requirement.split('>=', maxsplit=1)
     version, *not_found_msg = version.split(",", maxsplit=1)
     try:
-        pkg = __import__(pkg, globals(), locals(), [], 0)
+        pkg = importlib.import_module(pkg)
         pv = pkg.__version__
     except ModuleNotFoundError:
         if not_found_msg:

--- a/pypeit/check_requirements.py
+++ b/pypeit/check_requirements.py
@@ -3,18 +3,28 @@ Version checking.
 """
 
 import pkg_resources
+from pypeit import msgs
 
-requirements_file = pkg_resources.resource_filename('pypeit', 'requirements.txt')
+requirements_file = pkg_resources.resource_filename('pypeit', 'requirements_imports.txt')
 install_requires = [line.strip().replace('==', '>=') for line in open(requirements_file)
                     if not line.strip().startswith('#') and line.strip() != '']
 for requirement in install_requires:
-    pkg, version = requirement.split('>=')
+    pkg, version = requirement.split('>=', maxsplit=1)
+    version, *not_found_msg = version.split(",", maxsplit=1)
     try:
-        pv = pkg_resources.get_distribution(pkg).version
-    except pkg_resources.DistributionNotFound:
-        raise ImportError("Package: {:s} not installed!".format(pkg))
+        pkg = __import__(pkg, globals(), locals(), [], 0)
+        pv = pkg.__version__
+    except ModuleNotFoundError:
+        if not_found_msg:
+            msgs.warn(f"Package {pkg} not found. {not_found_msg[0]}")
+        else:
+            msgs.warn(f"Package {pkg} not found.")
     else:
         if pkg_resources.parse_version(pv) < pkg_resources.parse_version(version):
-            raise ImportError('Your version of {0} is incompatible with PypeIt.  '.format(pkg)
-                                + 'Please update to version >= {0}'.format(version))
-
+            if not_found_msg:
+                msgs.warn(f"Your {pkg.__name__} (version {pv}) is incompatible"
+                    f" with PypeIt. Please update to version >= {version}. "
+                    f"{not_found_msg[0]}")
+            else:
+                msgs.warn(f"Your {pkg.__name__} (version {pv}) is incompatible"
+                    f" with PypeIt. Please update to version >= {version}")

--- a/pypeit/requirements_imports.txt
+++ b/pypeit/requirements_imports.txt
@@ -1,0 +1,23 @@
+# check_requirements.py looks here!
+#
+# Each line should have the form
+# package >= version[, error message]
+# If an error message is provided, it will be printed if the package is
+# missing or if the version is incorrect.
+
+packaging>=19.0
+numpy>=1.18.0
+scipy>=1.4
+matplotlib>=3.1
+astropy>=4.0
+extension_helpers>=0.1
+yaml>=5.1
+configobj>=5.0.6
+sklearn>=0.20
+IPython>=7.2.0
+ginga>=3.0
+numba>=0.39.0
+linetools==0.3.dev2147
+PySide2>=5.0
+pytest>=6.0.0,pytest is only required for running tests
+shapely>=1.7,shapely is required only for KCWI


### PR DESCRIPTION
Using `setuptools`'s `pkg_resources` to find packages and verify their version has caused headaches in the past (see pytest erroring CI builds because `pkg_resources` thought its version was 0.0.0, using `conda install pyside2` with PypeIt v1.3 causes `pkg_resources` to complain that PySide2 is not installed, even though it can be imported).
Directly importing packages and checking their `__version__` attribute is more stable than relying on packages to correctly create and install a `.egg-info` or `.dist-info` metadata directory along with the package itself.

Additionally, this reduces the severity of a package not being found from an error to a warning, and allows an optional error/warning message to be specified in `requirements_imports.txt` (good for `shapely` and `pytest`, which are not required by all users). Note, however, that `requirements_imports.txt` cannot just be a copy of `requirements.txt` since some package names (looking at you `extension-helpers`) are not valid Python identifiers and the name of the module that is imported is different that what is in `requirements.txt` (or `PyYAML` vs `import yaml`).

Happy to hear suggestions/feedback on my particular implementation of this, especially on the `requirements_imports.txt` file (its format, filename, any other [optional] fields we want to put in it).