### PR TITLE
Make par_outfile a real command line parameter

### DIFF
--- a/pypeit/scripts/coadd_1dspec.py
+++ b/pypeit/scripts/coadd_1dspec.py
@@ -183,7 +183,7 @@ def parse_args(options=None, return_parser=False):
                              "\n")
     parser.add_argument("--debug", default=False, action="store_true", help="show debug plots?")
     parser.add_argument("--show", default=False, action="store_true", help="show QA during coadding process")
-    parser.add_argument("--par_outfile", default='coadd1d.par', action="store_true", help="Output to save the parameters")
+    parser.add_argument("--par_outfile", default='coadd1d.par', help="Output to save the parameters")
     parser.add_argument("--test_spec_path", type=str, help="Path for testing")
 #    parser.add_argument("--plot", default=False, action="store_true", help="Show the sensitivity function?")
 


### PR DESCRIPTION
Looks to me like this was just a copy-and-paste error since this really shouldn't ever be a boolean.