### PR TITLE
PyPI upload hotfix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,11 @@
 
+1.3.2 (08 Feb 2021)
+-------------------
+
+- (Hotfix) Bug in content type of README file that prevented upload to
+  PyPI
+
+
 1.3.1 (01 Feb 2021)
 -------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,7 @@
 name = pypeit
 description = PypeIt Spectroscopic Reduction
 long_description = file: README.md
+long_description_content_type = text/markdown
 author = PypeIt Collaboration
 author_email = pypeit@ucolick.org
 license = BSD-3


### PR DESCRIPTION
This is a hotfix that fixes a bug in the content type for our README file that was preventing upload to PyPI.  I've already tagged the new version, so this just needs to be approved and merged and then I can release the new version (now 1.3.2 instead of 1.3.1).