### PR TITLE
Hotfix: pypeit_obslog missing entry_point()

### DIFF
--- a/pypeit/scripts/obslog.py
+++ b/pypeit/scripts/obslog.py
@@ -142,5 +142,9 @@ def main(args):
         embed()
 
 
+def entry_point():
+    main(parse_args())
+
+
 if __name__ == '__main__':
     entry_point()


### PR DESCRIPTION
In the recent change to pypeit_obslog to define the entry point and deprecate
the wrapper script (commit 9ef92cd0f017dc9f68a4bec0661f4c6cf1034efc), the
actual entry_point() function was not defined in obslog.py.

This bug causes `pypeit_obslog` to crash.

This commit adds the function entry_point() to match other scripts in this
directory.

	modified:   pypeit/scripts/obslog.py