### PR TITLE
1.3.3 tag 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,11 @@
 
+1.3.3 (24 Feb 2021)
+-------------------
+
+- (Hotfix) Command-line argument bug in `pypeit_coadd_1dspec` script.
+- (Hotfix) Bug fix in `pypeit_obslog` script.
+
+
 1.3.2 (08 Feb 2021)
 -------------------
 


### PR DESCRIPTION
Updates `release` for new tag 1.3.3.  This tag only includes hotfixes to `release` compared to tag `1.3.2`.  Tag 1.3.3 is already pushed.