### PR TITLE
Faster running median

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -19,6 +19,6 @@ dependencies:
   - ginga>=3.0
   - qtpy>=1.9
   - pytest>=3.0.7
+  - bottleneck>=1.3
   - pip
-  - pip:
-    - linetools>=0.3dev2231
+  - linetools>=0.3dev2231

--- a/pypeit/core/extract.py
+++ b/pypeit/core/extract.py
@@ -1448,6 +1448,8 @@ def objfind(image, thismask, slit_left, slit_righ, inmask=None, fwhm=3.0, maxdev
         plt.title(qa_title + ': Slit# {:d}'.format(specobj_dict['SLITID']))
         plt.show()
         viewer, ch = display.show_image(image*(thismask*inmask))
+    if debug_all:
+        embed(header='1452 of extract')
 
     # Now loop over all the regular apertures and assign preliminary traces to them.
     for iobj in range(nobj_reg):

--- a/pypeit/core/extract.py
+++ b/pypeit/core/extract.py
@@ -1448,8 +1448,6 @@ def objfind(image, thismask, slit_left, slit_righ, inmask=None, fwhm=3.0, maxdev
         plt.title(qa_title + ': Slit# {:d}'.format(specobj_dict['SLITID']))
         plt.show()
         viewer, ch = display.show_image(image*(thismask*inmask))
-    if debug_all:
-        embed(header='1452 of extract')
 
     # Now loop over all the regular apertures and assign preliminary traces to them.
     for iobj in range(nobj_reg):

--- a/pypeit/core/skysub.py
+++ b/pypeit/core/skysub.py
@@ -119,6 +119,11 @@ def global_skysub(image, ivar, tilts, thismask, slit_left, slit_righ, inmask=Non
 
     # Sky pixels for fitting
     inmask_in = thismask & (ivar > 0.0) & inmask & np.logical_not(edgmask)
+    if not np.any(inmask_in):
+        msgs.warn("No pixels for fitting sky.  Could be bad object finding...")
+        return np.zeros(np.sum(thismask))
+
+    # Sub arrays
     isrt = np.argsort(piximg[thismask])
     pix = piximg[thismask][isrt]
     sky = image[thismask][isrt]

--- a/pypeit/core/skysub.py
+++ b/pypeit/core/skysub.py
@@ -118,9 +118,9 @@ def global_skysub(image, ivar, tilts, thismask, slit_left, slit_righ, inmask=Non
         msgs.error("Type of inmask should be bool and is of type: {:}".format(inmask.dtype))
 
     # Sky pixels for fitting
-    inmask_in = thismask & (ivar > 0.0) & inmask & np.logical_not(edgmask)
-    if not np.any(inmask_in):
-        msgs.warn("No pixels for fitting sky.  Could be bad object finding...")
+    gpm = thismask & (ivar > 0.0) & inmask & np.logical_not(edgmask)
+    if not np.any(gpm):
+        msgs.warn("Input pixel mask + edges has no good pixels.  There is likely a problem with this slit.")
         return np.zeros(np.sum(thismask))
 
     # Sub arrays
@@ -129,7 +129,7 @@ def global_skysub(image, ivar, tilts, thismask, slit_left, slit_righ, inmask=Non
     sky = image[thismask][isrt]
     sky_ivar = ivar[thismask][isrt]
     ximg_fit = ximg[thismask][isrt]
-    inmask_fit = inmask_in[thismask][isrt]
+    inmask_fit = gpm[thismask][isrt]
     inmask_prop = inmask_fit.copy()
     #spatial = spatial_img[fit_sky][isrt]
 

--- a/pypeit/reduce.py
+++ b/pypeit/reduce.py
@@ -368,6 +368,7 @@ class Reduce(object):
         self.sobjs_obj, self.nobj, skymask_init = \
             self.find_objects(self.sciImg.image, std_trace=std_trace,
                               show_peaks=show_peaks,
+                              debug=True,
                               show=self.reduce_show & (not self.std_redux),
                               manual_extract_dict=self.par['reduce']['extraction']['manual'].dict_for_objfind())
 
@@ -375,6 +376,7 @@ class Reduce(object):
         skymask_init, usersky = self.load_skyregions(skymask_init)
 
         # Global sky subtract
+        embed(header='378 of reduce')
         self.initial_sky = self.global_skysub(skymask=skymask_init).copy()
 
         # Second pass object finding on sky-subtracted image
@@ -576,13 +578,16 @@ class Reduce(object):
                 continue
 
             # Find sky
-            self.global_sky[thismask] = skysub.global_skysub(self.sciImg.image, self.sciImg.ivar, self.tilts,
+            try:
+                self.global_sky[thismask] = skysub.global_skysub(self.sciImg.image, self.sciImg.ivar, self.tilts,
                                                              thismask, self.slits_left[:,slit_idx],
                                                              self.slits_right[:,slit_idx],
                                                              inmask=inmask, sigrej=sigrej,
                                                              bsp=self.par['reduce']['skysub']['bspline_spacing'],
                                                              no_poly=self.par['reduce']['skysub']['no_poly'],
                                                              pos_mask=(not self.ir_redux), show_fit=show_fit)
+            except:
+                embed(header='588 of reduce')
             # Mask if something went wrong
             if np.sum(self.global_sky[thismask]) == 0.:
                 self.reduce_bpm[slit_idx] = True
@@ -996,6 +1001,8 @@ class MultiSlitReduce(Reduce):
 
         # Loop on slits
         for slit_idx in gdslits:
+            if slit_idx != 17:
+                continue
             slit_spat = self.slits.spat_id[slit_idx]
             qa_title ="Finding objects on slit # {:d}".format(slit_spat)
             msgs.info(qa_title)

--- a/pypeit/reduce.py
+++ b/pypeit/reduce.py
@@ -368,7 +368,6 @@ class Reduce(object):
         self.sobjs_obj, self.nobj, skymask_init = \
             self.find_objects(self.sciImg.image, std_trace=std_trace,
                               show_peaks=show_peaks,
-                              debug=True,
                               show=self.reduce_show & (not self.std_redux),
                               manual_extract_dict=self.par['reduce']['extraction']['manual'].dict_for_objfind())
 
@@ -376,7 +375,6 @@ class Reduce(object):
         skymask_init, usersky = self.load_skyregions(skymask_init)
 
         # Global sky subtract
-        embed(header='378 of reduce')
         self.initial_sky = self.global_skysub(skymask=skymask_init).copy()
 
         # Second pass object finding on sky-subtracted image
@@ -578,18 +576,16 @@ class Reduce(object):
                 continue
 
             # Find sky
-            try:
-                self.global_sky[thismask] = skysub.global_skysub(self.sciImg.image, self.sciImg.ivar, self.tilts,
+            self.global_sky[thismask] = skysub.global_skysub(self.sciImg.image, self.sciImg.ivar, self.tilts,
                                                              thismask, self.slits_left[:,slit_idx],
                                                              self.slits_right[:,slit_idx],
                                                              inmask=inmask, sigrej=sigrej,
                                                              bsp=self.par['reduce']['skysub']['bspline_spacing'],
                                                              no_poly=self.par['reduce']['skysub']['no_poly'],
                                                              pos_mask=(not self.ir_redux), show_fit=show_fit)
-            except:
-                embed(header='588 of reduce')
             # Mask if something went wrong
             if np.sum(self.global_sky[thismask]) == 0.:
+                msgs.warn("Bad fit to sky.  Rejecting slit: {:d}".format(slit_idx))
                 self.reduce_bpm[slit_idx] = True
 
         if update_crmask and self.par['scienceframe']['process']['mask_cr']:
@@ -1001,8 +997,6 @@ class MultiSlitReduce(Reduce):
 
         # Loop on slits
         for slit_idx in gdslits:
-            if slit_idx != 17:
-                continue
             slit_spat = self.slits.spat_id[slit_idx]
             qa_title ="Finding objects on slit # {:d}".format(slit_spat)
             msgs.info(qa_title)

--- a/pypeit/utils.py
+++ b/pypeit/utils.py
@@ -534,11 +534,10 @@ def fast_running_median(seq, window_size):
     Returns:
         ndarray: median filtered values
 
-    Code contributed by Peter Otten, made to be consistent with
+    Code originally contributed by Peter Otten, made to be consistent with
     scipy.ndimage.filters.median_filter by Joe Hennawi.
 
-    See discussion at:
-    http://groups.google.com/group/comp.lang.python/browse_thread/thread/d0e011c87174c2d0
+    Now makes use of the Bottleneck library https://pypi.org/project/Bottleneck/.
     """
     # Enforce that the window_size needs to be smaller than the sequence, otherwise we get arrays of the wrong size
     # upon return (very bad). Added by JFH. Should we print out an error here?

--- a/pypeit/utils.py
+++ b/pypeit/utils.py
@@ -17,6 +17,7 @@ from IPython import embed
 
 import numpy as np
 from numpy.lib.stride_tricks import as_strided
+import bottleneck as bn
 
 from scipy import interpolate, ndimage
 
@@ -553,21 +554,7 @@ def fast_running_median(seq, window_size):
     # pad the array for the reflection
     seq_pad = np.concatenate((seq[0:window_size][::-1],seq,seq[-1:(-1-window_size):-1]))
 
-    seq_pad = iter(seq_pad)
-    d = deque()
-    s = []
-    result = []
-    for item in itertools.islice(seq_pad, window_size):
-        d.append(item)
-        insort(s, item)
-        result.append(s[len(d)//2])
-    m = window_size // 2
-    for item in seq_pad:
-        old = d.popleft()
-        d.append(item)
-        del s[bisect_left(s, old)]
-        insort(s, item)
-        result.append(s[m])
+    result = bn.move_median(seq_pad, window=window_size)
 
     # This takes care of the offset produced by the original code deducec by trial and error comparison with
     # scipy.ndimage.filters.medfilt

--- a/pypeit/utils.py
+++ b/pypeit/utils.py
@@ -10,8 +10,6 @@ import inspect
 import pickle
 import warnings
 import itertools
-from collections import deque
-from bisect import insort, bisect_left
 
 from IPython import embed
 

--- a/pypeit/utils.py
+++ b/pypeit/utils.py
@@ -15,7 +15,7 @@ from IPython import embed
 
 import numpy as np
 from numpy.lib.stride_tricks import as_strided
-import bottleneck as bn
+import bottleneck
 
 from scipy import interpolate, ndimage
 
@@ -552,7 +552,7 @@ def fast_running_median(seq, window_size):
     # pad the array for the reflection
     seq_pad = np.concatenate((seq[0:window_size][::-1],seq,seq[-1:(-1-window_size):-1]))
 
-    result = bn.move_median(seq_pad, window=window_size)
+    result = bottleneck.move_median(seq_pad, window=window_size)
 
     # This takes care of the offset produced by the original code deducec by trial and error comparison with
     # scipy.ndimage.filters.medfilt

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,7 @@ install_requires =
     ginga>=3.0
     linetools
     qtpy>=1.9
+    bottleneck>=1.3
 scripts =
     bin/pypeit_c_enabled
     bin/pypeit_chk_plugins


### PR DESCRIPTION
This PR uses `bottleneck.move_median` to speed up fast_running_median by a factor of ~16 in a simple test I conducted on random data. In a simple real world test, this sped up calibrations by 30% in a quicklook-type DBSPr setup with 1 arc and 1 flat frame.

Additionally, while testing to see if this behaves the same as scipy.ndimage.median_filter and the old fast_running_median, I discovered a bug in scipy.ndimage.median_filter and the previous fast_running_median: when using an even window size, the average of the two middle elements is not taken, instead one of the middle elements is picked.

Example:
```python
>>> seq = np.array([2,1]*2)
>>> # old fast_running_median
>>> ret1 = fast_running_median(seq, 2)
>>> # new fast_running_median (bn = bottleneck)
>>> ret2 = fast_running_median_bn(seq, 2)

>>> print(seq)
[2 1 2 1]
>>> print(ret1)
[2 2 2 2]
>>> print(ret2)
[2.  1.5 1.5 1.5]
```
![image](https://user-images.githubusercontent.com/5816532/113059241-103b2200-9164-11eb-920f-f48fadf91a5f.png)

The new fast_running_median_filter works as expected here, as well as matching the old behavior exactly for odd window size

```python
>>> seq = np.random.random(1000)
>>> ret1 = fast_running_median(seq, 413)
>>> ret2 = fast_running_median_bn(seq, 413)
>>> np.all(ret1-ret2 == 0)
True
```

I moved the linetools dependency from pip to conda since the 0.3dev2231 is on [conda-forge](https://anaconda.org/conda-forge/linetools/files).

I think the attribution in the `fast_running_median` docstring may need to be updated, but I would like to hear others' thoughts on that.