### PR TITLE
Xshooter hotfixes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@
 
 - (Hotfix) Command-line argument bug in `pypeit_coadd_1dspec` script.
 - (Hotfix) Bug fix in `pypeit_obslog` script.
+- (Hotfix) X-Shooter bits
 
 
 1.3.2 (08 Feb 2021)

--- a/pypeit/spectrographs/vlt_xshooter.py
+++ b/pypeit/spectrographs/vlt_xshooter.py
@@ -51,9 +51,10 @@ class VLTXShooterSpectrograph(spectrograph.Spectrograph):
         self.meta['dispname'] = dict(ext=0, card=None, default='default')
         self.meta['idname'] = dict(ext=0, card='HIERARCH ESO DPR CATG')
         self.meta['arm'] = dict(ext=0, card='HIERARCH ESO SEQ ARM')
-        # Dithering
-        self.meta['dither'] = dict(ext=0, card='HIERARCH ESO SEQ CUMOFF Y')
-                                   #required_ftypes=['science', 'standard'])
+        # Dithering -- Not required for redux
+        self.meta['dither'] = dict(ext=0, card='HIERARCH ESO SEQ CUMOFF Y',
+            required=False,  # This header card is *not* always present in science/standard frames
+            required_ftypes=['science', 'standard'])
 
     def compound_meta(self, headarr, meta_key):
         """

--- a/pypeit/spectrographs/vlt_xshooter.py
+++ b/pypeit/spectrographs/vlt_xshooter.py
@@ -52,8 +52,8 @@ class VLTXShooterSpectrograph(spectrograph.Spectrograph):
         self.meta['idname'] = dict(ext=0, card='HIERARCH ESO DPR CATG')
         self.meta['arm'] = dict(ext=0, card='HIERARCH ESO SEQ ARM')
         # Dithering
-        self.meta['dither'] = dict(ext=0, card='HIERARCH ESO SEQ CUMOFF Y',
-                                   required_ftypes=['science', 'standard'])
+        self.meta['dither'] = dict(ext=0, card='HIERARCH ESO SEQ CUMOFF Y')
+                                   #required_ftypes=['science', 'standard'])
 
     def compound_meta(self, headarr, meta_key):
         """
@@ -140,7 +140,7 @@ class VLTXShooterSpectrograph(spectrograph.Spectrograph):
             return good_exp & (fitstbl['target'] == 'BIAS')
         if ftype == 'dark':
             return good_exp & (fitstbl['target'] == 'DARK')
-        if ftype in ['pixelflat', 'trace']:
+        if ftype in ['pixelflat', 'trace', 'illumflat']:
             # Flats and trace frames are typed together
             return good_exp & ((fitstbl['target'] == 'LAMP,DFLAT')
                                | (fitstbl['target'] == 'LAMP,QFLAT')


### PR DESCRIPTION
Two minor items for X-Shooter.

One for frame-typing
One for handling absence of `dither` header cards