### PR TITLE
Updates to quicklook

### DIFF
--- a/pypeit/scripts/ql_keck_mosfire.py
+++ b/pypeit/scripts/ql_keck_mosfire.py
@@ -11,6 +11,7 @@ import os
 import argparse
 import numpy as np
 import copy
+from glob import glob
 
 from astropy.io import fits
 from astropy.table import Table
@@ -213,6 +214,26 @@ def run_pair(A_files, B_files, caliBrate, spectrograph, det, parset, show=False,
                                       slits=copy.deepcopy(caliBrate.slits))
     return spec2DObj_A, spec2DObj_B
 
+def find_single_file(file_pattern):
+    """Find a single file matching a wildcard pattern.
+
+    Args:
+        file_pattern (str): A filename pattern, see the python 'glob' module.
+
+    Returns:
+        str: A file name, or None if no filename was found. This will give a warning
+             if multiple files are found and return the first one.
+    """
+
+    files = glob(file_pattern)
+    if len(files) == 1:
+        return files[0]
+    elif len(files) == 0:
+        return None
+    else:
+        msgs.warn(f'Found multiple files matching {file_pattern}; using the first one.')
+        return files[0]
+
 def main(args):
 
     # Read in the spectrograph, config the parset
@@ -237,14 +258,18 @@ def main(args):
 
     # Define some hard wired master files here to be later parsed out of the directory
     filter = spectrograph.get_meta_value(files[0], 'filter1')
-    slit_masterframe_name = os.path.join(args.master_dir, 'MOSFIRE_MASTERS', filter, 'MasterSlits_A_15_01.fits.gz')
-    tilts_masterframe_name = os.path.join(args.master_dir,  'MOSFIRE_MASTERS', filter, 'MasterTilts_A_4_01.fits')
-    wvcalib_masterframe_name = os.path.join(args.master_dir, 'MOSFIRE_MASTERS', filter, 'MasterWaveCalib_A_4_01.fits')
-    std_spec1d_file = os.path.join(args.master_dir, 'MOSFIRE_MASTERS', filter, 'spec1d_m191118_0064-GD71_MOSFIRE_2019Nov18T104704.507.fits')
-    sensfunc_masterframe_name = os.path.join(args.master_dir, 'MOSFIRE_MASTERS', filter, 'sens_m191118_0064-GD71_MOSFIRE_2019Nov18T104704.507.fits')
-    if (not os.path.isfile(slit_masterframe_name) or  not os.path.isfile(tilts_masterframe_name) or \
-        not os.path.isfile(tilts_masterframe_name) or not os.path.isfile(sensfunc_masterframe_name) or \
-        not os.path.isfile(std_spec1d_file)):
+    mosfire_masters = os.path.join(args.master_dir, 'MOSFIRE_MASTERS', filter)    
+
+    slit_masterframe_name = find_single_file(os.path.join(mosfire_masters, "MasterSlits*"))
+    tilts_masterframe_name = find_single_file(os.path.join(mosfire_masters, "MasterTilts*"))
+    wvcalib_masterframe_name = find_single_file(os.path.join(mosfire_masters, 'MasterWaveCalib*'))
+    std_spec1d_file = find_single_file(os.path.join(mosfire_masters, 'spec1d_*'))
+    sensfunc_masterframe_name = find_single_file(os.path.join(mosfire_masters,'sens_*'))
+
+    if (slit_masterframe_name is None or not os.path.isfile(slit_masterframe_name)) or  \
+       (tilts_masterframe_name is None or not os.path.isfile(tilts_masterframe_name)) or \
+       (sensfunc_masterframe_name is None or not os.path.isfile(sensfunc_masterframe_name)) or \
+       (std_spec1d_file is None or not os.path.isfile(std_spec1d_file)):
         msgs.error('Master frames not found. Check that environment variable QL_MASTERS  points at the Master Calibs')
 
 

--- a/pypeit/scripts/ql_keck_mosfire.py
+++ b/pypeit/scripts/ql_keck_mosfire.py
@@ -15,6 +15,7 @@ from glob import glob
 
 from astropy.io import fits
 from astropy.table import Table
+from pypeit import utils
 from pypeit import pypeit
 from pypeit import par, msgs
 from pypeit import pypeitsetup
@@ -214,25 +215,6 @@ def run_pair(A_files, B_files, caliBrate, spectrograph, det, parset, show=False,
                                       slits=copy.deepcopy(caliBrate.slits))
     return spec2DObj_A, spec2DObj_B
 
-def find_single_file(file_pattern):
-    """Find a single file matching a wildcard pattern.
-
-    Args:
-        file_pattern (str): A filename pattern, see the python 'glob' module.
-
-    Returns:
-        str: A file name, or None if no filename was found. This will give a warning
-             if multiple files are found and return the first one.
-    """
-
-    files = glob(file_pattern)
-    if len(files) == 1:
-        return files[0]
-    elif len(files) == 0:
-        return None
-    else:
-        msgs.warn(f'Found multiple files matching {file_pattern}; using the first one.')
-        return files[0]
 
 def main(args):
 
@@ -260,11 +242,11 @@ def main(args):
     filter = spectrograph.get_meta_value(files[0], 'filter1')
     mosfire_masters = os.path.join(args.master_dir, 'MOSFIRE_MASTERS', filter)    
 
-    slit_masterframe_name = find_single_file(os.path.join(mosfire_masters, "MasterSlits*"))
-    tilts_masterframe_name = find_single_file(os.path.join(mosfire_masters, "MasterTilts*"))
-    wvcalib_masterframe_name = find_single_file(os.path.join(mosfire_masters, 'MasterWaveCalib*'))
-    std_spec1d_file = find_single_file(os.path.join(mosfire_masters, 'spec1d_*'))
-    sensfunc_masterframe_name = find_single_file(os.path.join(mosfire_masters,'sens_*'))
+    slit_masterframe_name = utils.find_single_file(os.path.join(mosfire_masters, "MasterSlits*"))
+    tilts_masterframe_name = utils.find_single_file(os.path.join(mosfire_masters, "MasterTilts*"))
+    wvcalib_masterframe_name = utils.find_single_file(os.path.join(mosfire_masters, 'MasterWaveCalib*'))
+    std_spec1d_file = utils.find_single_file(os.path.join(mosfire_masters, 'spec1d_*'))
+    sensfunc_masterframe_name = utils.find_single_file(os.path.join(mosfire_masters,'sens_*'))
 
     if (slit_masterframe_name is None or not os.path.isfile(slit_masterframe_name)) or  \
        (tilts_masterframe_name is None or not os.path.isfile(tilts_masterframe_name)) or \

--- a/pypeit/utils.py
+++ b/pypeit/utils.py
@@ -10,6 +10,7 @@ import inspect
 import pickle
 import warnings
 import itertools
+from glob import glob
 
 from IPython import embed
 
@@ -1273,3 +1274,23 @@ def is_float(s):
         return False
 
     return True
+
+def find_single_file(file_pattern):
+    """Find a single file matching a wildcard pattern.
+
+    Args:
+        file_pattern (str): A filename pattern, see the python 'glob' module.
+
+    Returns:
+        str: A file name, or None if no filename was found. This will give a warning
+             if multiple files are found and return the first one.
+    """
+
+    files = glob(file_pattern)
+    if len(files) == 1:
+        return files[0]
+    elif len(files) == 0:
+        return None
+    else:
+        msgs.warn(f'Found multiple files matching {file_pattern}; using the first one.')
+        return files[0]


### PR DESCRIPTION
This is a companion PR to [](https://github.com/pypeit/PypeIt-development-suite/pull/148) in the dev suite. It changes `ql_keck_mosfire.py` to use wild card patterns to find QL masters. This way the information on which files to use is only hard coded in the `build_ql_masters` script.

If that PR is not approved this PR should also not be approved, because in that case neither script will have the files for MOSFIRE QL Masters