### PR TITLE
EFOSC2 test fix

### DIFF
--- a/pypeit/tests/test_load_images.py
+++ b/pypeit/tests/test_load_images.py
@@ -167,7 +167,7 @@ def test_load_bok():
 
 @dev_suite_required
 def test_load_efosc2():
-    ifile = os.path.join(os.environ['PYPEIT_DEV'], 'RAW_DATA/ntt_efosc2/gr6_g4target3',
+    ifile = os.path.join(os.environ['PYPEIT_DEV'], 'RAW_DATA/ntt_efosc2/gr6',
                          'EFOSC.2020-02-12T02:03:38.359.fits')
     try:
         data_img = grab_img('ntt_efosc2', ifile)


### PR DESCRIPTION
as titled

(base) profx> py.test test_load_images.py::test_load_efosc2
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-6.1.2, py-1.9.0, pluggy-0.13.1
rootdir: /data/Projects/Python/PypeIt, configfile: setup.cfg
plugins: openfiles-0.5.0, ligo.skymap-0.5.0, filter-subpackage-0.1.1, hypothesis-6.8.5, astropy-header-0.1.2, cov-2.11.1, doctestplus-0.9.0, arraydiff-0.3, remotedata-0.3.2
collected 1 item                                                               

test_load_images.py .                                                    [100%]

=============================== warnings summary ===============================
../../../../../../home/xavier/Projects/anaconda3/lib/python3.8/site-packages/pkg_resources/__init__.py:1143
../../../../../../home/xavier/Projects/anaconda3/lib/python3.8/site-packages/pkg_resources/__init__.py:1143
../../../../../../home/xavier/Projects/anaconda3/lib/python3.8/site-packages/pkg_resources/__init__.py:1143
   DeprecationWarning: Use of .. or absolute path in a resource path is not allowed and will raise exceptions in a future release. (__init__.py:1143)

-- Docs: https://docs.pytest.org/en/stable/warnings.html
======================== 1 passed, 3 warnings in 3.86s =========================