### PR TITLE
Enable codecov

### DIFF
--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python: [3.8]
+        python: [3.8, 3.9]
         toxenv: [test-alldeps, test-numpydev, test-linetoolsdev, test-gingadev, test-astropydev, conda]
     steps:
     - name: Check out repository

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python: [3.8, 3.9]
-        toxenv: [test, test-alldeps, test-linetoolsdev, test-gingadev, test-astropydev, conda]
+        toxenv: [test, test-alldeps-cov, test-linetoolsdev, test-gingadev, test-astropydev, conda]
     steps:
     - name: Check out repository
       uses: actions/checkout@v2
@@ -35,6 +35,11 @@ jobs:
     - name: Test with tox
       run: |
         tox -e ${{ matrix.toxenv }}
+    - name: Upload coverage to codecov
+      if: "contains(matrix.tox_env, '-cov')"
+      uses: codecov/codecov-action@v1
+      with:
+        file: ./coverage.xml
 
   os-tests:
     name: Python ${{ matrix.python }} on ${{ matrix.os }}

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -3,9 +3,8 @@ name: CI Tests
 on:
   push:
     branches:
-    - master
+    - release
     - develop
-    tags:
   pull_request:
   schedule:
     # run every Monday at 6am UTC


### PR DESCRIPTION
This PR makes a few minor CI workflow tweaks:

- adds python 3.9 to weekly cron tests
- changes `master` to `release` in list of branches that can trigger workflow when changes are pushed
- enables coverage calculation within the CI tests and uploads results to codecov.io

The existing `tox` configuration already had everything set up to calculate coverage and generate reports. 