### PR TITLE
SOAR file format fix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,7 @@
       `pypeit.sensfunc.sensfunc_weights`
 - Add LDT/DeVeny spectrograph
 - Add 6440.25A CdI line (LDT/DeVeny)
+- Modify SOAR to read their (truly) raw files
 
 
 1.4.1 (11 Jun 2021)

--- a/pypeit/spectrographs/soar_goodman.py
+++ b/pypeit/spectrographs/soar_goodman.py
@@ -51,27 +51,27 @@ class SOARGoodmanSpectrograph(spectrograph.Spectrograph):
         """
         self.meta = {}
         # Required (core)
-        self.meta['ra'] = dict(ext=0, card='RA')
-        self.meta['dec'] = dict(ext=0, card='DEC')
-        self.meta['target'] = dict(ext=0, card='OBJECT')
-        self.meta['decker'] = dict(ext=0, card='SLIT')
+        self.meta['ra'] = dict(ext=1, card='RA')
+        self.meta['dec'] = dict(ext=1, card='DEC')
+        self.meta['target'] = dict(ext=1, card='OBJECT')
+        self.meta['decker'] = dict(ext=1, card='SLIT')
         self.meta['binning'] = dict(card=None, compound=True)
-        self.meta['exptime'] = dict(ext=0, card='EXPTIME')
+        self.meta['exptime'] = dict(ext=1, card='EXPTIME')
         self.meta['mjd'] = dict(card=None, compound=True)
-        self.meta['airmass'] = dict(ext=0, card='AIRMASS')
+        self.meta['airmass'] = dict(ext=1, card='AIRMASS')
         # Extras for config and frametyping
-        self.meta['dispname'] = dict(ext=0, card='GRATING')
-        self.meta['dispangle'] = dict(ext=0, card='GRT_ANG', rtol=1e-3)
-        self.meta['idname'] = dict(ext=0, card='OBSTYPE')
+        self.meta['dispname'] = dict(ext=1, card='GRATING')
+        self.meta['dispangle'] = dict(ext=1, card='GRT_ANG', rtol=1e-3)
+        self.meta['idname'] = dict(ext=1, card='OBSTYPE')
         # used for arc and continuum lamps
-        self.meta['lampstat01'] = dict(ext=0, card='LAMP_HGA')
-        self.meta['lampstat02'] = dict(ext=0, card='LAMP_NE')
-        self.meta['lampstat03'] = dict(ext=0, card='LAMP_AR')
-        self.meta['lampstat04'] = dict(ext=0, card='LAMP_FE')
-        self.meta['lampstat05'] = dict(ext=0, card='LAMP_CU')
-        self.meta['lampstat06'] = dict(ext=0, card='LAMP_QUA')
-        self.meta['lampstat07'] = dict(ext=0, card='LAMP_BUL')
-        self.meta['lampstat08'] = dict(ext=0, card='LAMP_DOM')
+        self.meta['lampstat01'] = dict(ext=1, card='LAMP_HGA')
+        self.meta['lampstat02'] = dict(ext=1, card='LAMP_NE')
+        self.meta['lampstat03'] = dict(ext=1, card='LAMP_AR')
+        self.meta['lampstat04'] = dict(ext=1, card='LAMP_FE')
+        self.meta['lampstat05'] = dict(ext=1, card='LAMP_CU')
+        self.meta['lampstat06'] = dict(ext=1, card='LAMP_QUA')
+        self.meta['lampstat07'] = dict(ext=1, card='LAMP_BUL')
+        self.meta['lampstat08'] = dict(ext=1, card='LAMP_DOM')
 
     def compound_meta(self, headarr, meta_key):
         """
@@ -88,10 +88,10 @@ class SOARGoodmanSpectrograph(spectrograph.Spectrograph):
             object: Metadata value read from the header(s).
         """
         if meta_key == 'binning':
-            binspec, binspatial = [int(item) for item in headarr[0]['CCDSUM'].split(' ')]
+            binspec, binspatial = [int(item) for item in headarr[1]['CCDSUM'].split(' ')]
             return parse.binning2string(binspec, binspatial)
         elif meta_key == 'mjd':
-            ttime = Time(headarr[0]['DATE-OBS'], format='isot')
+            ttime = Time(headarr[1]['DATE-OBS'], format='isot')
             return ttime.mjd
         else:
             msgs.error("Not ready for this compound meta")
@@ -127,7 +127,7 @@ class SOARGoodmanRedSpectrograph(SOARGoodmanSpectrograph):
             :class:`~pypeit.images.detector_container.DetectorContainer`:
             Object with the detector metadata.
         """
-        header = hdu[0].header
+        header = hdu[1].header
         # Binning
         binning = self.get_meta_value(self.get_headarr(hdu), 'binning')  # Could this be detector dependent??
 
@@ -135,7 +135,7 @@ class SOARGoodmanRedSpectrograph(SOARGoodmanSpectrograph):
         detector_dict = dict(
             binning         = binning,
             det             = 1,
-            dataext         = 0,
+            dataext         = 1,
             specaxis        = 1,
             specflip        = False,
             spatflip        = False,

--- a/pypeit/tests/test_load_images.py
+++ b/pypeit/tests/test_load_images.py
@@ -177,7 +177,7 @@ def test_load_efosc2():
 @dev_suite_required
 def test_load_goodman():
     ifile = os.path.join(os.environ['PYPEIT_DEV'], 'RAW_DATA/soar_goodman_red/M2',
-                         '0320_FRB210320_host_05-04-2021.fits')
+                         '0320_FRB210320_host_05-04-2021.fits.fz')
     try:
         data_img = grab_img('soar_goodman_red', ifile)
     except:


### PR DESCRIPTION
The original 'raw' data files I was given were not truly raw.

This PR modifies PypeIt to handle the proper, off-the-telescope files format.