### PR TITLE
Add CentOS to CI

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -75,7 +75,7 @@ jobs:
     # Some PypeIt users have to run under CentOS and have run into unique issues. GitHub Actions does not
     # provide CentOS as a runtime environment like it does Ubuntu. However, it can be used by running
     # it as a container within a provided Ubuntu environment.
-    name: CentOS ${{ matrix.centos_ver }}
+    name: CentOS ${{ matrix.centos_ver }} ${{ matrix.toxenv }}
     runs-on: ubuntu-latest
 
     strategy:
@@ -102,13 +102,14 @@ jobs:
         bash ./miniconda.sh -b -p /conda
         /conda/bin/conda update -y --all
         /conda/bin/conda init
-        source /root/.bashrc
     - name: Install base dependencies
       run: |
+        source /root/.bashrc
         python -m pip install --upgrade pip tox
         python --version
     - name: Test with tox
       run: |
+        source /root/.bashrc
         tox -e ${{ matrix.toxenv }}
 
   codestyle:

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -104,10 +104,10 @@ jobs:
         /conda/bin/conda init
     - name: Install base dependencies
       run: |
-        source /root/.bashrc && python -m pip install --upgrade pip tox && python --version
+        source ~/.bashrc && python -m pip install --upgrade pip tox && python --version
     - name: Test with tox
       run: |
-        source /root/.bashrc && tox -e ${{ matrix.toxenv }}
+        source ~/.bashrc && tox -e ${{ matrix.toxenv }}
 
   codestyle:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -89,7 +89,7 @@ jobs:
       run: |
         yum update -y && yum install -y wget git gcc
     - name: Check out repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v1
       with:
         fetch-depth: 0
     - name: Install and configure miniconda

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -90,6 +90,8 @@ jobs:
         yum update -y && yum install -y wget git gcc
     - name: Check out repository
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: Install and configure miniconda
       run: |
         wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -104,13 +104,10 @@ jobs:
         /conda/bin/conda init
     - name: Install base dependencies
       run: |
-        source /root/.bashrc
-        python -m pip install --upgrade pip tox
-        python --version
+        source /root/.bashrc && python -m pip install --upgrade pip tox && python --version
     - name: Test with tox
       run: |
-        source /root/.bashrc
-        tox -e ${{ matrix.toxenv }}
+        source /root/.bashrc && tox -e ${{ matrix.toxenv }}
 
   codestyle:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -72,7 +72,7 @@ jobs:
         tox -e ${{ matrix.toxenv }}
 
   centos:
-    # Some PypeIt users have to run under CentOS and run into unique issues. GitHub Actions does not
+    # Some PypeIt users have to run under CentOS and have run into unique issues. GitHub Actions does not
     # provide CentOS as a runtime environment like it does Ubuntu. However, it can be used by running
     # it as a container within a provided Ubuntu environment.
     name: CentOS ${{ matrix.centos_ver }}

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Check out repository
       uses: actions/checkout@v2
       with:
-        fetch-depth: 0
+        fetch-depth: 1
     - name: Set up Python ${{ matrix.python }}
       uses: actions/setup-python@v2
       with:
@@ -59,7 +59,7 @@ jobs:
     - name: Check out repository
       uses: actions/checkout@v2
       with:
-        fetch-depth: 0
+        fetch-depth: 1
     - name: Set up Python ${{ matrix.python }}
       uses: actions/setup-python@v2
       with:
@@ -95,7 +95,7 @@ jobs:
     - name: Check out repository
       uses: actions/checkout@v2
       with:
-        fetch-depth: 0
+        fetch-depth: 1
     - name: Install and configure miniconda
       run: |
         wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
@@ -116,7 +116,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-          fetch-depth: 0
+          fetch-depth: 1
     - name: Python codestyle check
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -71,6 +71,46 @@ jobs:
       run: |
         tox -e ${{ matrix.toxenv }}
 
+  centos:
+    # Some PypeIt users have to run under CentOS and run into unique issues. GitHub Actions does not
+    # provide CentOS as a runtime environment like it does Ubuntu. However, it can be used by running
+    # it as a container within a provided Ubuntu environment.
+    name: CentOS ${{ matrix.centos_ver }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        # Test both CentOS 7 and 8
+        centos_ver: [7, 8]
+        # Test both pip and conda for installing dependencies
+        toxenv: [test-alldeps, conda]
+
+    container:
+      image: "centos:${{ matrix.centos_ver }}"
+
+    steps:
+    - name: Install base CentOS dependencies
+      run: |
+        yum update -y && yum install -y wget git gcc
+    - name: Check out repository
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Install and configure miniconda
+      run: |
+        wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+        bash ./miniconda.sh -b -p /conda
+        /conda/bin/conda update -y --all
+        /conda/bin/conda init
+        source /root/.bashrc
+    - name: Install base dependencies
+      run: |
+        python -m pip install --upgrade pip tox
+        python --version
+    - name: Test with tox
+      run: |
+        tox -e ${{ matrix.toxenv }}
+
   codestyle:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Check out repository
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: Set up Python ${{ matrix.python }}
       uses: actions/setup-python@v2
       with:
@@ -56,6 +58,8 @@ jobs:
     steps:
     - name: Check out repository
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: Set up Python ${{ matrix.python }}
       uses: actions/setup-python@v2
       with:
@@ -71,6 +75,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+          fetch-depth: 0
     - name: Python codestyle check
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -25,8 +25,6 @@ jobs:
     steps:
     - name: Check out repository
       uses: actions/checkout@v2
-      with:
-        fetch-depth: 1
     - name: Set up Python ${{ matrix.python }}
       uses: actions/setup-python@v2
       with:
@@ -58,8 +56,6 @@ jobs:
     steps:
     - name: Check out repository
       uses: actions/checkout@v2
-      with:
-        fetch-depth: 1
     - name: Set up Python ${{ matrix.python }}
       uses: actions/setup-python@v2
       with:
@@ -94,8 +90,6 @@ jobs:
         yum update -y && yum install -y wget git gcc
     - name: Check out repository
       uses: actions/checkout@v2
-      with:
-        fetch-depth: 1
     - name: Install and configure miniconda
       run: |
         wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
@@ -113,8 +107,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-      with:
-          fetch-depth: 1
     - name: Python codestyle check
       uses: actions/setup-python@v2
       with:

--- a/environment.yml
+++ b/environment.yml
@@ -18,6 +18,6 @@ dependencies:
   - ginga>=3.0
   - qtpy>=1.9
   - pytest>=3.0.7
-  - bottleneck>=1.3
+  - bottleneck
   - pip
   - linetools>=0.3dev2231

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ install_requires =
     ginga>=3.0
     linetools
     qtpy>=1.9
-    bottleneck>=1.3
+    bottleneck
 scripts =
     bin/pypeit_c_enabled
     bin/pypeit_chk_plugins

--- a/tox.ini
+++ b/tox.ini
@@ -81,6 +81,7 @@ commands = pycodestyle pypeit --count --select=E9
 
 [testenv:conda]
 description = run tests in environment created via conda
-deps = tox-conda
+requires = tox-conda
+conda_deps = numpy,astropy,scipy,bottleneck
 conda_env = {toxinidir}/environment.yml
 commands = pytest --pyargs pypeit {posargs}


### PR DESCRIPTION
This PR adds a section of CI tests that are run under CentOS. GitHub Actions does not support CentOS directly, but it does support the ability to run tests within custom containers. The containers used here are the stock ones for CentOS 7 and 8 that are available from Docker Hub. 

The version pinning for `bottleneck` was removed since it doesn't appear to be strictly necessary and was causing acceptable pre-built packages to be ignored. 

The `fetch-depth` parameter is now explicitly set to 1 to make it clear only the latest commit is cloned. This matches the default and shouldn't change anything, but guards against the default changing in the future. 