### PR TITLE
CTIO coords and minor docstrings

### DIFF
--- a/pypeit/core/flux_calib.py
+++ b/pypeit/core/flux_calib.py
@@ -396,6 +396,7 @@ def load_extinction_data(longitude, latitude, toler=5. * units.deg):
 
     Parameters
     ----------
+    longitude, latitude: Geocentric coordinates in degrees (floats).
     toler : Angle, optional
         Tolerance for matching detector to site (5 deg)
 
@@ -438,8 +439,8 @@ def extinction_correction(wave, airmass, extinct):
     Parameters
     ----------
     wave (`numpy.ndarray`_):
-        Wavelengths for interpolation. Should be sorted Assumes
-        Angstroms
+        Wavelengths for interpolation. Should be sorted.
+        Assumes angstroms.
     airmass : float
         Airmass
     extinct : Table
@@ -448,7 +449,10 @@ def extinction_correction(wave, airmass, extinct):
     Returns:
     -------
     `numpy.ndarray`_:
-        Flux corrections at the input wavelengths
+        Multiplucative flux correction factors
+        at the input wavelengths.
+        i.e. true_flux = correction_factor*observed_flux
+
     """
     # Checks
     if airmass < 1.:

--- a/pypeit/data/extinction/README
+++ b/pypeit/data/extinction/README
@@ -1,7 +1,7 @@
 # Airmass Extinction files
 #   Generally grabbed from the Internet.  Buyer beware
     File             Lon         Lat      Elevation  
-ctioextinct.dat     70.8150    -30.1653   2215.0
+ctioextinct.dat     -70.8150    -30.1653   2215.0
 kpnoextinct.dat    111.600     31.9633    2120.0
 lapalmaextinct.dat  17.8947    28.7636    2396.0
 mkoextinct.dat     155.47833   19.82833   4160.0

--- a/pypeit/data/extinction/README
+++ b/pypeit/data/extinction/README
@@ -1,11 +1,11 @@
 # Airmass Extinction files
 #   Generally grabbed from the Internet.  Buyer beware
     File             Lon         Lat      Elevation  
-ctioextinct.dat     -70.8150    -30.1653   2215.0
+ctioextinct.dat     70.8150    -30.1653   2215.0
 kpnoextinct.dat    111.600     31.9633    2120.0
 lapalmaextinct.dat  17.8947    28.7636    2396.0
 mkoextinct.dat     155.47833   19.82833   4160.0
 mthamextinct.dat   121.6428    37.34139   1290.0
 paranalextinct.dat 70.4048305 -24.627167  2635.43
 palomarextinct.dat 116.86489   33.35631   1713.
-lasillaextinct.dat 289.2700   -29.2567    2400.
+lasillaextinct.dat 70.73   -29.2567    2400.


### PR DESCRIPTION
The CTIO longitude was missing a minus sign and I just made some minor edits to the `extinction_correction` docstring.