### PR TITLE
Fix bug in flatfield.py related to `pixelflat_min_wave`

### DIFF
--- a/pypeit/core/tracewave.py
+++ b/pypeit/core/tracewave.py
@@ -954,9 +954,9 @@ def arc_tilts_spec_qa(tilts_spec_fit, tilts, tilts_model, tot_mask, rej_mask, rm
                     markersize=7.0)
 
     ax.text(0.90, 0.90, 'Slit {:d}:  Residual (pixels) = {:0.5f}'.format(slitord_id, rms),
-            transform=ax.transAxes, size='large', ha='right', color='black', fontsize=16)
+            transform=ax.transAxes, ha='right', color='black', fontsize=16)
     ax.text(0.90, 0.80, ' Slit {:d}:  RMS/FWHM = {:0.5f}'.format(slitord_id, rms / fwhm),
-            transform=ax.transAxes, size='large', ha='right', color='black', fontsize=16)
+            transform=ax.transAxes, ha='right', color='black', fontsize=16)
     # Label
     ax.set_xlabel('Spectral Pixel')
     ax.set_ylabel('RMS (pixels)')

--- a/pypeit/flatfield.py
+++ b/pypeit/flatfield.py
@@ -617,14 +617,6 @@ class FlatField(object):
         npoly = self.flatpar['twod_fit_npoly']
         saturated_slits = self.flatpar['saturated_slits']
 
-        # Build wavelength image -- not always used, but for convenience done here
-        slitmask = self.slits.slit_img(initial=True, 
-                                       flexure=self.wavetilts.spat_flexure)
-        tilts = self.wavetilts.fit2tiltimg(slitmask, 
-                                           flexure=self.wavetilts.spat_flexure)
-        waveimg = self.wv_calib.build_waveimg(
-            tilts, self.slits, spat_flexure=self.wavetilts.spat_flexure)
-
         # Setup images
         nspec, nspat = self.rawflatimg.image.shape
         rawflat = self.rawflatimg.image
@@ -1072,6 +1064,16 @@ class FlatField(object):
             self.mspixelflat[onslit_tweak] = rawflat[onslit_tweak]/self.flat_model[onslit_tweak]
             # TODO: Add some code here to treat the edges and places where fits
             #  go bad?
+
+            # Build wavelength image AFTER the slits have been tweaked.  This is
+            #  the only place in this method that uses it.  It is not always used, 
+            #  but for convenience done here
+            slitmask = self.slits.slit_img(initial=True, 
+                                        flexure=self.wavetilts.spat_flexure)
+            tilts = self.wavetilts.fit2tiltimg(slitmask, 
+                                            flexure=self.wavetilts.spat_flexure)
+            waveimg = self.wv_calib.build_waveimg(
+                tilts, self.slits, spat_flexure=self.wavetilts.spat_flexure)
 
             # Minimum wavelength?
             if self.flatpar['pixelflat_min_wave'] is not None:

--- a/pypeit/flatfield.py
+++ b/pypeit/flatfield.py
@@ -667,6 +667,10 @@ class FlatField(object):
         twod_model = np.ones_like(rawflat)
         twod_gpm_out = np.ones_like(rawflat, dtype=np.bool)
 
+        # Before looping over slits, check if we need to create a waveimg
+        make_waveimg = self.flatpar['pixelflat_min_wave'] is not None or \
+                       self.flatpar['pixelflat_max_wave'] is not None
+
         # #################################################
         # Model each slit independently
         for slit_idx, slit_spat in enumerate(self.slits.spat_id):
@@ -1066,15 +1070,13 @@ class FlatField(object):
             # TODO: Add some code here to treat the edges and places where fits
             #  go bad?
 
-            # Build wavelength image AFTER the slits have been tweaked.  This is
-            #  the only place in this method that uses it.  It is not always used, 
-            #  but for convenience done here
-            slitmask = self.slits.slit_img(initial=True, 
-                                        flexure=self.wavetilts.spat_flexure)
-            tilts = self.wavetilts.fit2tiltimg(slitmask, 
-                                            flexure=self.wavetilts.spat_flexure)
-            waveimg = self.wv_calib.build_waveimg(
-                tilts, self.slits, spat_flexure=self.wavetilts.spat_flexure)
+            # If needed, build wavelength image AFTER the slits have been tweaked.
+            if make_waveimg:
+                slitmask = self.slits.slit_img(flexure=self.wavetilts.spat_flexure)
+                tilts = self.wavetilts.fit2tiltimg(slitmask, 
+                                                flexure=self.wavetilts.spat_flexure)
+                waveimg = self.wv_calib.build_waveimg(
+                    tilts, self.slits, spat_flexure=self.wavetilts.spat_flexure)
 
             # Minimum wavelength?
             if self.flatpar['pixelflat_min_wave'] is not None:


### PR DESCRIPTION
When the `pixelflat_min_wave` and `pixelflat_max_wave` parameters were
introduced in #1225, they required the use of a `waveimg` array specifying
the wavelength at each pixel on the slit(s) in the flat frame.  The `waveimg`
was included in #1225, but placed BEFORE the slit edges are tweaked in the
`FlatField.fit()` method.

If the slit edges are tweaked OUTWARD, the `onslit_tweak` mask will then include
parts of `waveimg` outside the original slit mask (and therefore have wavelength
equal to zero).  When the `pixelflat_min_wave` parameter is invoked (even with
a value of zero), the code finds matching wavelengths in all rows of the image,
and the pixelflat_norm becomes identically 1.

I am not familiar enough with the slit tweaking to know if OUTWARD tweaking is
normal or expected -- this change only addresses the `waveimg` <--> 
`pixelflat_min_wave` interaction.

Because `waveimg` is only used within this method for the `pixelflat_min_wave`
and `pixelflat_max_wave` parameters, this commit moves its creation to AFTER the
slit tweaking and just before its use.

	modified:   pypeit/flatfield.py


All unit tests pass (except my weird, un-reproducible error discussed in #1266).
```
======================================== short test summary info ========================================
FAILED pypeit/tests/test_setups.py::test_setup_vlt_fors2 - TypeError: NoneType takes no arguments
======================= 1 failed, 301 passed, 5088 warnings in 1549.17s (0:25:49) =======================
```

@ntejos, you may want to double-check this change still works for your data. 