### PR TITLE
Fix flatfield bitmask bug and address issues #1281 and #1283 

### DIFF
--- a/doc/flexure.rst
+++ b/doc/flexure.rst
@@ -76,20 +76,33 @@ This will:
 Spectral
 ========
 
-By default, the code will calculate a flexure shift based on the
-extracted sky spectrum (boxcar).
-A cross-correlation between this
-sky spectrum and an archived spectrum is performed to calculate
-a single, pixel shift.  This is then imposed on the wavelength solution
-with simple linear interpolation.
+``PypeIt`` calculates the spectral flexure correction, as a single pixel shift,
+by performing a cross-correlation between an extracted sky spectrum and an archived sky spectrum.
+This is then imposed on the wavelength solution with simple linear interpolation.
+To enable this correction the parameter ``spec_method`` in :ref:`pypeit_par:FlexurePar Keywords`
+should be set to ``boxcar`` or ``slitcen``. The default is ``spec_method = skip``, i.e.,
+no spectral flexure correction, for most spectrographs, except:
 
-The standard approach is to compare the sky model
-from the observation with an archived sky model. Generally, by default, the
-Paranal sky spectrum is used. The default is 
+- Gemini/GMOS (N&S)
+- Keck/DEIMOS
+- Keck/KCWI
+- Keck/LRIS (all)
+- LBT/MODS (all)
+- MMT/Binospec
+- NTT/EFOSC2
+- Shane/KAST (all)
+- VLT/FORS2
+
+If ``spec_method = boxcar`` (recommended) the observed sky spectrum flux is boxcar extracted,
+while the spectrum wavelength is taken from the extracted 1D object. If no objects have been
+extracted, set ``spec_method = slitcen``, which uses a spectrum extracted from the center of
+each slit.
+
+For the archived sky spectrum, generally, the Paranal sky spectrum is used by default. However, this is
 different for Kast blue and LRIS blue where sky_kastb_600.fits and sky_LRISb_600.fits
 are respectively used (see `Alternate sky models`_ for all sky models).
 
-Narrow sky emission liens dominate the analysis, but other features 
+Narrow sky emission lines dominate the analysis, but other features
 can affect the cross-correlation.
 
 

--- a/pypeit/display/display.py
+++ b/pypeit/display/display.py
@@ -413,7 +413,7 @@ def show_slits(viewer, ch, left, right, slit_ids=None, left_ids=None, right_ids=
     for i in range(nright):
         points = list(zip(y[::pstep].tolist(), _right[::pstep,i].tolist())) if rotate \
                     else list(zip(_right[::pstep,i].tolist(), y[::pstep].tolist()))
-        canvas.add(str('path'), points, color=str('red'))
+        canvas.add(str('path'), points, color=str('magenta'))
         if not synced:
             # Add text
             xt, yt = float(_right_id_loc[top,i]), float(y[top])

--- a/pypeit/flatfield.py
+++ b/pypeit/flatfield.py
@@ -1055,6 +1055,7 @@ class FlatField(object):
             if exit_status > 1:
                 msgs.warn('Two-dimensional fit to flat-field data failed!  No higher order '
                           'flat-field corrections included in model of slit {0}!'.format(slit_spat))
+                self.slits.mask[slit_idx] = self.slits.bitmask.turn_on(self.slits.mask[slit_idx], 'BADFLATCALIB')
             else:
                 twod_model[twod_gpm] = twod_flat_fit[np.argsort(twod_srt)]
                 twod_gpm_out[twod_gpm] = twod_gpm_fit[np.argsort(twod_srt)]

--- a/pypeit/scripts/show_2dspec.py
+++ b/pypeit/scripts/show_2dspec.py
@@ -44,7 +44,7 @@ def show_trace(specobjs, det, viewer, ch):
         else:
             trc_name = obj_id
         if maskdef_extr_flag is not None and maskdef_extr_flag is True:
-            display.show_trace(viewer, ch, trace, trc_name, color='gold') #hdu.name)
+            display.show_trace(viewer, ch, trace, trc_name, color='#f0e442') #hdu.name)
         elif manual_extr_flag is True:
             display.show_trace(viewer, ch, trace, trc_name, color='#33ccff') #hdu.name)
         else:


### PR DESCRIPTION
In `flatfield.py`, even if the flat field was not successful, the bitmask was not flagged as `BADFLATCALIB`. This is now fixed.

Also, addresses issues #1281 and #1283 