### PR TITLE
Disallow fz files to be used for the reduction

### DIFF
--- a/pypeit/pypeitsetup.py
+++ b/pypeit/pypeitsetup.py
@@ -25,6 +25,9 @@ from pypeit.par.util import parse_pypeit_file, make_pypeit_file
 from pypeit.spectrographs.util import load_spectrograph
 
 
+bad_ext = [".fz"]
+
+
 # TODO: Instantiation should just automatically trigger the run
 # method...
 class PypeItSetup:
@@ -128,6 +131,9 @@ class PypeItSetup:
         self.setups = setups
         self.pypeit_file = pypeit_file
         self.user_cfg = cfg_lines
+
+        # Check the input file list
+        self.check_file_list()
 
         # Determine the spectrograph name
         _spectrograph_name = spectrograph_name if cfg_lines is None \
@@ -259,6 +265,15 @@ class PypeItSetup:
 
     def __repr__(self):
         return '<{:s}: nfiles={:d}>'.format(self.__class__.__name__, self.nfiles)
+
+    def check_file_list(self):
+        """Check that the input file list only contains allowed types"""
+        for ff in range(len(self.file_list)):
+            for ee in range(len(bad_ext)):
+                if self.file_list[ff].endswith(bad_ext[ee]):
+                    msgs.error("Frames with extension {0:s} are not permitted:".format(bad_ext[ee]) + msgs.newline() +
+                               self.file_list[ff])
+        return
 
     def build_fitstbl(self, strict=True):
         """

--- a/pypeit/spectrographs/soar_goodman.py
+++ b/pypeit/spectrographs/soar_goodman.py
@@ -52,27 +52,27 @@ class SOARGoodmanSpectrograph(spectrograph.Spectrograph):
         """
         self.meta = {}
         # Required (core)
-        self.meta['ra'] = dict(ext=1, card='RA')
-        self.meta['dec'] = dict(ext=1, card='DEC')
-        self.meta['target'] = dict(ext=1, card='OBJECT')
-        self.meta['decker'] = dict(ext=1, card='SLIT')
+        self.meta['ra'] = dict(ext=0, card='RA')
+        self.meta['dec'] = dict(ext=0, card='DEC')
+        self.meta['target'] = dict(ext=0, card='OBJECT')
+        self.meta['decker'] = dict(ext=0, card='SLIT')
         self.meta['binning'] = dict(card=None, compound=True)
-        self.meta['exptime'] = dict(ext=1, card='EXPTIME')
+        self.meta['exptime'] = dict(ext=0, card='EXPTIME')
         self.meta['mjd'] = dict(card=None, compound=True)
-        self.meta['airmass'] = dict(ext=1, card='AIRMASS')
+        self.meta['airmass'] = dict(ext=0, card='AIRMASS')
         # Extras for config and frametyping
-        self.meta['dispname'] = dict(ext=1, card='GRATING')
-        self.meta['dispangle'] = dict(ext=1, card='GRT_ANG', rtol=1e-3)
-        self.meta['idname'] = dict(ext=1, card='OBSTYPE')
+        self.meta['dispname'] = dict(ext=0, card='GRATING')
+        self.meta['dispangle'] = dict(ext=0, card='GRT_ANG', rtol=1e-3)
+        self.meta['idname'] = dict(ext=0, card='OBSTYPE')
         # used for arc and continuum lamps
-        self.meta['lampstat01'] = dict(ext=1, card='LAMP_HGA')
-        self.meta['lampstat02'] = dict(ext=1, card='LAMP_NE')
-        self.meta['lampstat03'] = dict(ext=1, card='LAMP_AR')
-        self.meta['lampstat04'] = dict(ext=1, card='LAMP_FE')
-        self.meta['lampstat05'] = dict(ext=1, card='LAMP_CU')
-        self.meta['lampstat06'] = dict(ext=1, card='LAMP_QUA')
-        self.meta['lampstat07'] = dict(ext=1, card='LAMP_BUL')
-        self.meta['lampstat08'] = dict(ext=1, card='LAMP_DOM')
+        self.meta['lampstat01'] = dict(ext=0, card='LAMP_HGA')
+        self.meta['lampstat02'] = dict(ext=0, card='LAMP_NE')
+        self.meta['lampstat03'] = dict(ext=0, card='LAMP_AR')
+        self.meta['lampstat04'] = dict(ext=0, card='LAMP_FE')
+        self.meta['lampstat05'] = dict(ext=0, card='LAMP_CU')
+        self.meta['lampstat06'] = dict(ext=0, card='LAMP_QUA')
+        self.meta['lampstat07'] = dict(ext=0, card='LAMP_BUL')
+        self.meta['lampstat08'] = dict(ext=0, card='LAMP_DOM')
 
     def compound_meta(self, headarr, meta_key):
         """
@@ -89,10 +89,10 @@ class SOARGoodmanSpectrograph(spectrograph.Spectrograph):
             object: Metadata value read from the header(s).
         """
         if meta_key == 'binning':
-            binspec, binspatial = [int(item) for item in headarr[1]['CCDSUM'].split(' ')]
+            binspec, binspatial = [int(item) for item in headarr[0]['CCDSUM'].split(' ')]
             return parse.binning2string(binspec, binspatial)
         elif meta_key == 'mjd':
-            ttime = Time(headarr[1]['DATE-OBS'], format='isot')
+            ttime = Time(headarr[0]['DATE-OBS'], format='isot')
             return ttime.mjd
         else:
             msgs.error("Not ready for this compound meta")
@@ -145,8 +145,8 @@ class SOARGoodmanRedSpectrograph(SOARGoodmanSpectrograph):
         else:
             # TODO: Could this be detector dependent??
             binning = self.get_meta_value(self.get_headarr(hdu), 'binning')
-            gain = np.atleast_1d(hdu[1].header['GAIN'])
-            ronoise = np.atleast_1d(hdu[1].header['RDNOISE'])
+            gain = np.atleast_1d(hdu[0].header['GAIN'])
+            ronoise = np.atleast_1d(hdu[0].header['RDNOISE'])
             datasec = None
             oscansec = None
 
@@ -154,7 +154,7 @@ class SOARGoodmanRedSpectrograph(SOARGoodmanSpectrograph):
         detector_dict = dict(
             binning         = binning,
             det             = 1,
-            dataext         = 1,
+            dataext         = 0,
             specaxis        = 1,
             specflip        = False,
             spatflip        = False,
@@ -176,7 +176,7 @@ class SOARGoodmanRedSpectrograph(SOARGoodmanSpectrograph):
         # Only tested for 2x2
         if binning == '2,2':
             # parse TRIMSEC
-            col0 = int(hdu[1].header['TRIMSEC'][1:].split(':')[0])
+            col0 = int(hdu[0].header['TRIMSEC'][1:].split(':')[0])
             dsec = f"[:,{col0*2}:]"  # rows, columns on the raw frame
             detector_dict['datasec'] = np.atleast_1d(dsec)
             # Overscan


### PR DESCRIPTION
fz files change the extension where the data and header information are loaded, so I've fixed the soar goodman spectrograph file, and added an error for those that include fz files. There is a related PR in the dev suite