### PR TITLE
Hotfix for spatial flexure

### DIFF
--- a/pypeit/images/rawimage.py
+++ b/pypeit/images/rawimage.py
@@ -564,10 +564,10 @@ class RawImage:
         if self.steps[step] and not force:
             # Already field flattened
             msgs.warn('Spatial flexure shift already calculated.')
-            return self.spat_flexure_shift 
         else:
             self.spat_flexure_shift = flexure.spat_flexure_shift(self.image, slits)
             self.steps[step] = True
+
         # Return
         return self.spat_flexure_shift 
 

--- a/pypeit/images/rawimage.py
+++ b/pypeit/images/rawimage.py
@@ -556,6 +556,9 @@ class RawImage:
                 Force the image to be field flattened, even if the step log
                 (:attr:`steps`) indicates that it already has been.
 
+        Return:
+            float: The calcualted flexure correction
+
         """
         step = inspect.stack()[0][3]
         if self.steps[step] and not force:
@@ -564,6 +567,8 @@ class RawImage:
             return
         self.spat_flexure_shift = flexure.spat_flexure_shift(self.image, slits)
         self.steps[step] = True
+        # Return
+        return self.spat_flexure_shift 
 
     def flatfield(self, flatimages, slits=None, force=False, debug=False):
         """

--- a/pypeit/images/rawimage.py
+++ b/pypeit/images/rawimage.py
@@ -565,8 +565,9 @@ class RawImage:
             # Already field flattened
             msgs.warn('Spatial flexure shift already calculated.')
             return self.spat_flexure_shift 
-        self.spat_flexure_shift = flexure.spat_flexure_shift(self.image, slits)
-        self.steps[step] = True
+        else:
+            self.spat_flexure_shift = flexure.spat_flexure_shift(self.image, slits)
+            self.steps[step] = True
         # Return
         return self.spat_flexure_shift 
 

--- a/pypeit/images/rawimage.py
+++ b/pypeit/images/rawimage.py
@@ -557,14 +557,14 @@ class RawImage:
                 (:attr:`steps`) indicates that it already has been.
 
         Return:
-            float: The calcualted flexure correction
+            float: The calculated flexure correction
 
         """
         step = inspect.stack()[0][3]
         if self.steps[step] and not force:
             # Already field flattened
             msgs.warn('Spatial flexure shift already calculated.')
-            return
+            return self.spat_flexure_shift 
         self.spat_flexure_shift = flexure.spat_flexure_shift(self.image, slits)
         self.steps[step] = True
         # Return


### PR DESCRIPTION
As titled.  Because the value was not returned
it was being set to `None`.

Only affects, `keck_lris`, I hope..

I've started a branch in the DevSuite Repo to have a test
to check this was run.  I otherwise tested it directly on 
`keck_lris_red/multi_600_5000_d560`