### PR TITLE
Fix missing import in slittrace.py

### DIFF
--- a/pypeit/slittrace.py
+++ b/pypeit/slittrace.py
@@ -25,6 +25,7 @@ from pypeit import msgs
 from pypeit import datamodel
 from pypeit import specobj
 from pypeit.bitmask import BitMask
+from pypeit.core import parse
 
 
 class SlitTraceBitMask(BitMask):


### PR DESCRIPTION
There was a missing import in slittrace.py.  I found this when running the DEIMOS QL dev-suite test. 
This isn't found by a normal "develop" run of the dev suite because of a problem that causes the DEIMOS QL to only run on a "ql" run. 

Devsuite "QL" run:
(pypeit) dusty@River:~/work/PypeIt-development-suite$ ./pypeit_test -t 3 ql
Running tests on the following instruments:
    keck_nires
    keck_mosfire
    keck_deimos

Reducing data from keck_nires for the following setups:
    NIRES

Reducing data from keck_mosfire for the following setups:
    Y_long

Reducing data from keck_deimos for the following setups:
    QL

Running tests in 3 parallel processes
 0 passed/ 0 failed/ 0 skipped STARTED keck_mosfire/Y_long pypeit_ql
 0 passed/ 0 failed/ 0 skipped STARTED keck_nires/NIRES pypeit_ql
 0 passed/ 0 failed/ 0 skipped STARTED keck_deimos/QL pypeit_ql
 1 passed/ 0 failed/ 0 skipped PASSED  keck_mosfire/Y_long pypeit_ql
 2 passed/ 0 failed/ 0 skipped PASSED  keck_nires/NIRES pypeit_ql
 3 passed/ 0 failed/ 0 skipped PASSED  keck_deimos/QL pypeit_ql

--- PYPEIT DEVELOPMENT SUITE PASSED 3/3 TESTS (Masters ignored) ---
Testing Started at 2022-01-26T18:01:40.358919
Testing Completed at 2022-01-26T18:30:12.872434
Total Time: 0:28:32.513515

Unit test run:
=============================== 318 passed, 640 warnings in 1070.66s (0:17:50) ==========================================