### PR TITLE
Remove CentOS 8 from test matrix since it's now EOL

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -76,8 +76,8 @@ jobs:
 
     strategy:
       matrix:
-        # Test both CentOS 7 and 8
-        centos_ver: [7, 8]
+        # Test CentOS 7
+        centos_ver: [7]
         # Test both pip and conda for installing dependencies
         toxenv: [test-alldeps, conda]
 


### PR DESCRIPTION
All of the package mirrors for CentOS 8 have been moved now that it has been EOL for a month. This PR removes testing under CentOS 8, but keeps CentOS 7 which is still supported for a while longer and is still being used within the PypeIt community.