### PR TITLE
Hotfix for `LDT/DeVeny` frametype logic

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -76,8 +76,8 @@ jobs:
 
     strategy:
       matrix:
-        # Test both CentOS 7 and 8
-        centos_ver: [7, 8]
+        # Test CentOS 7
+        centos_ver: [7]
         # Test both pip and conda for installing dependencies
         toxenv: [test-alldeps, conda]
 

--- a/pypeit/spectrographs/ldt_deveny.py
+++ b/pypeit/spectrographs/ldt_deveny.py
@@ -279,8 +279,8 @@ class LDTDeVenySpectrograph(spectrograph.Spectrograph):
             return good_exp & (fitstbl['idname'] == 'SKY FLAT') & (fitstbl['lampstat01'] == 'off')
         if ftype == 'science':
             # Both OBJECT and STANDARD frames should be processed as science frames
-            return good_exp & (fitstbl['idname'] in ['OBJECT', 'STANDARD']) & \
-                   (fitstbl['lampstat01'] == 'off')
+            return good_exp & (fitstbl['lampstat01'] == 'off') & \
+                   ((fitstbl['idname'] == 'OBJECT') | (fitstbl['idname'] == 'STANDARD'))        
         if ftype == 'standard':
             return good_exp & (fitstbl['idname'] == 'STANDARD') & (fitstbl['lampstat01'] == 'off')
         if ftype == 'dark':


### PR DESCRIPTION
As titled.

Worked fine in earlier testing -- failed today on edge case of having neither `science` nor `standard` frames in a data set (calibrations only).

- Fix explicitly tests `OR` condition for `frametype` instead of relying on `if..in..` syntax.

Unit tests pass:
```
============================= test session starts ==============================
collected 318 items                                                            

pypeit/tests/test_alignments.py .                                        [  0%]
pypeit/tests/test_arc.py .                                               [  0%]
pypeit/tests/test_archive.py ..                                          [  1%]
pypeit/tests/test_arcimage.py ..                                         [  1%]
pypeit/tests/test_biasframe.py ....                                      [  3%]
pypeit/tests/test_bitmask.py ....                                        [  4%]
pypeit/tests/test_bpmimage.py ..                                         [  5%]
pypeit/tests/test_bspline.py ...............                             [  9%]
pypeit/tests/test_buildimage.py ..                                       [ 10%]
pypeit/tests/test_calibrations.py .......                                [ 12%]
pypeit/tests/test_chk_calibs.py ..                                       [ 13%]
pypeit/tests/test_coadd.py .                                             [ 13%]
pypeit/tests/test_collate_1d.py ........                                 [ 16%]
pypeit/tests/test_cooked.py .                                            [ 16%]
pypeit/tests/test_coremeta.py .                                          [ 16%]
pypeit/tests/test_datacontainer.py .......                               [ 18%]
pypeit/tests/test_detector.py ....                                       [ 20%]
pypeit/tests/test_display.py .                                           [ 20%]
pypeit/tests/test_edgetrace.py .                                         [ 20%]
pypeit/tests/test_fitting.py ....                                        [ 22%]
pypeit/tests/test_flatfield.py .                                         [ 22%]
pypeit/tests/test_flexure.py ..                                          [ 22%]
pypeit/tests/test_flux.py ....                                           [ 24%]
pypeit/tests/test_fluxspec.py .....                                      [ 25%]
pypeit/tests/test_frametype.py ..                                        [ 26%]
pypeit/tests/test_history.py ....                                        [ 27%]
pypeit/tests/test_load.py .                                              [ 27%]
pypeit/tests/test_load_images.py ................                        [ 33%]
pypeit/tests/test_manual.py ..                                           [ 33%]
pypeit/tests/test_maskdesign_matching.py ...                             [ 34%]
pypeit/tests/test_masterframe.py .                                       [ 34%]
pypeit/tests/test_match.py ....                                          [ 36%]
pypeit/tests/test_metadata.py ......                                     [ 38%]
pypeit/tests/test_moment.py ......                                       [ 39%]
pypeit/tests/test_mosaic.py ...                                          [ 40%]
pypeit/tests/test_msgs.py ..                                             [ 41%]
pypeit/tests/test_opticalmodel.py ....                                   [ 42%]
pypeit/tests/test_parse.py ...                                           [ 43%]
pypeit/tests/test_pca.py ........                                        [ 46%]
pypeit/tests/test_processimage.py ..                                     [ 46%]
pypeit/tests/test_procimg.py ........                                    [ 49%]
pypeit/tests/test_pydl.py .                                              [ 49%]
pypeit/tests/test_pypeit.py .                                            [ 50%]
pypeit/tests/test_pypeitimage.py ..                                      [ 50%]
pypeit/tests/test_pypeitpar.py ................................          [ 60%]
pypeit/tests/test_pypeitsetup.py ........                                [ 63%]
pypeit/tests/test_qa.py .                                                [ 63%]
pypeit/tests/test_runpypeit.py ..                                        [ 64%]
pypeit/tests/test_scienceimage.py ...                                    [ 65%]
pypeit/tests/test_scripts.py ...................                         [ 71%]
pypeit/tests/test_setups.py ......................                       [ 77%]
pypeit/tests/test_skysub.py ..                                           [ 78%]
pypeit/tests/test_slitmask.py ...                                        [ 79%]
pypeit/tests/test_slittrace.py ....                                      [ 80%]
pypeit/tests/test_spec2dobj.py ......                                    [ 82%]
pypeit/tests/test_specobj.py .......                                     [ 84%]
pypeit/tests/test_specobjs.py .....                                      [ 86%]
pypeit/tests/test_spectrographs.py .......................               [ 93%]
pypeit/tests/test_syncspec.py .                                          [ 94%]
pypeit/tests/test_telluric.py ..                                         [ 94%]
pypeit/tests/test_traceimage.py .                                        [ 94%]
pypeit/tests/test_transform.py ...                                       [ 95%]
pypeit/tests/test_utils.py ....                                          [ 97%]
pypeit/tests/test_vcorr.py ..                                            [ 97%]
pypeit/tests/test_wavemodel.py .                                         [ 98%]
pypeit/tests/test_wavetilts.py ....                                      [ 99%]
pypeit/tests/test_wvcalib.py ..                                          [100%]

======================= 318 passed in 1905.40s (0:31:45) =======================
```
`dev-suite` run on `ldt_deveny` only passes:
```
Running tests on the following instruments:
    ldt_deveny

Reducing data from ldt_deveny for the following setups:
    DV1
    DV2
    DV5
    DV6
    DV8

--- PYPEIT DEVELOPMENT SUITE PASSED 5/5 TESTS (Masters ignored) ---
Testing Started at 2022-02-01T12:16:54.672710
Testing Completed at 2022-02-01T12:33:22.807035
Total Time: 0:16:28.134325
```
Full `dev-suite` not run, as passed earlier for #1324.