### PR TITLE
`pypeit_identify` hotfixes

### DIFF
--- a/pypeit/core/gui/identify.py
+++ b/pypeit/core/gui/identify.py
@@ -1246,6 +1246,6 @@ class Identify:
                       'flag' : self._lineflg},
                      names=['pixel', 'wavelength', 'flag'],
                      meta=meta)
-        ascii_io.write(data, fname, format='fixed_width')
+        ascii_io.write(data, fname, format='fixed_width', overwrite=True)
         msgs.info("Line IDs saved as:" + msgs.newline() + fname)
         self.update_infobox(message="Line IDs saved as: {0:s}".format(fname), yesno=False)

--- a/pypeit/scripts/identify.py
+++ b/pypeit/scripts/identify.py
@@ -103,7 +103,7 @@ class Identify(scriptbase.ScriptBase):
         if 'WaveFit' in arcfitter._fitdict.keys():
             waveCalib = WaveCalib(nslits=1, wv_fits=np.atleast_1d(arcfitter._fitdict['WaveFit']),
                                   arc_spectra=np.atleast_2d(arcfitter.specdata).T,
-                                  spat_ids=np.atleast_1d(int(arcfitter._spatid)), PYP_SPEC=specname,
+                                  spat_ids=np.atleast_1d(int(arcfitter._spatid)), PYP_SPEC=msarc.PYP_SPEC,
                                   lamps=','.join(lamps))
         else:
             waveCalib = None


### PR DESCRIPTION
Two minor issues were causing crashes with `pypeit_identify`.

- The variable name `specname` was removed from `Identify.main()`, replacing it with the attribute `msarc.PYP_SPEC`. 
 The variable change was not propagated to the call to `WaveCalib()` within an `if`-block at the end of the function.
- Astropy 5.0+ has removed support for overwriting tables on disk without explicitly specifying `overwrite=True` (see #1330).  `pypeit_identify` will overwrite existing line IDs (`waveid.ascii`) automatically if run multiple times.

`pypeit_identify` now runs as before.

The `test_identify()` in `test_scripts.py` does not tickle the affected section of `pypeit.scripts.identify` because it does not send `WaveFit` as a key in `arcfitter._fitdict`.  This may need to be rectified by someone more knowledgable about the inner workings of `arcfitter`.

Unit tests pass:
```
============================= test session starts ==============================
collected 318 items                                                            

pypeit/tests/test_alignments.py .                                        [  0%]
pypeit/tests/test_arc.py .                                               [  0%]
pypeit/tests/test_archive.py ..                                          [  1%]
pypeit/tests/test_arcimage.py ..                                         [  1%]
pypeit/tests/test_biasframe.py ....                                      [  3%]
pypeit/tests/test_bitmask.py ....                                        [  4%]
pypeit/tests/test_bpmimage.py ..                                         [  5%]
pypeit/tests/test_bspline.py ...............                             [  9%]
pypeit/tests/test_buildimage.py ..                                       [ 10%]
pypeit/tests/test_calibrations.py .......                                [ 12%]
pypeit/tests/test_chk_calibs.py ..                                       [ 13%]
pypeit/tests/test_coadd.py .                                             [ 13%]
pypeit/tests/test_collate_1d.py ........                                 [ 16%]
pypeit/tests/test_cooked.py .                                            [ 16%]
pypeit/tests/test_coremeta.py .                                          [ 16%]
pypeit/tests/test_datacontainer.py .......                               [ 18%]
pypeit/tests/test_detector.py ....                                       [ 20%]
pypeit/tests/test_display.py .                                           [ 20%]
pypeit/tests/test_edgetrace.py .                                         [ 20%]
pypeit/tests/test_fitting.py ....                                        [ 22%]
pypeit/tests/test_flatfield.py .                                         [ 22%]
pypeit/tests/test_flexure.py ..                                          [ 22%]
pypeit/tests/test_flux.py ....                                           [ 24%]
pypeit/tests/test_fluxspec.py .....                                      [ 25%]
pypeit/tests/test_frametype.py ..                                        [ 26%]
pypeit/tests/test_history.py ....                                        [ 27%]
pypeit/tests/test_load.py .                                              [ 27%]
pypeit/tests/test_load_images.py ................                        [ 33%]
pypeit/tests/test_manual.py ..                                           [ 33%]
pypeit/tests/test_maskdesign_matching.py ...                             [ 34%]
pypeit/tests/test_masterframe.py .                                       [ 34%]
pypeit/tests/test_match.py ....                                          [ 36%]
pypeit/tests/test_metadata.py ......                                     [ 38%]
pypeit/tests/test_moment.py ......                                       [ 39%]
pypeit/tests/test_mosaic.py ...                                          [ 40%]
pypeit/tests/test_msgs.py ..                                             [ 41%]
pypeit/tests/test_opticalmodel.py ....                                   [ 42%]
pypeit/tests/test_parse.py ...                                           [ 43%]
pypeit/tests/test_pca.py ........                                        [ 46%]
pypeit/tests/test_processimage.py ..                                     [ 46%]
pypeit/tests/test_procimg.py ........                                    [ 49%]
pypeit/tests/test_pydl.py .                                              [ 49%]
pypeit/tests/test_pypeit.py .                                            [ 50%]
pypeit/tests/test_pypeitimage.py ..                                      [ 50%]
pypeit/tests/test_pypeitpar.py ................................          [ 60%]
pypeit/tests/test_pypeitsetup.py ........                                [ 63%]
pypeit/tests/test_qa.py .                                                [ 63%]
pypeit/tests/test_runpypeit.py ..                                        [ 64%]
pypeit/tests/test_scienceimage.py ...                                    [ 65%]
pypeit/tests/test_scripts.py ...................                         [ 71%]
pypeit/tests/test_setups.py ......................                       [ 77%]
pypeit/tests/test_skysub.py ..                                           [ 78%]
pypeit/tests/test_slitmask.py ...                                        [ 79%]
pypeit/tests/test_slittrace.py ....                                      [ 80%]
pypeit/tests/test_spec2dobj.py ......                                    [ 82%]
pypeit/tests/test_specobj.py .......                                     [ 84%]
pypeit/tests/test_specobjs.py .....                                      [ 86%]
pypeit/tests/test_spectrographs.py .......................               [ 93%]
pypeit/tests/test_syncspec.py .                                          [ 94%]
pypeit/tests/test_telluric.py ..                                         [ 94%]
pypeit/tests/test_traceimage.py .                                        [ 94%]
pypeit/tests/test_transform.py ...                                       [ 95%]
pypeit/tests/test_utils.py ....                                          [ 97%]
pypeit/tests/test_vcorr.py ..                                            [ 97%]
pypeit/tests/test_wavemodel.py .                                         [ 98%]
pypeit/tests/test_wavetilts.py ....                                      [ 99%]
pypeit/tests/test_wvcalib.py ..                                          [100%]
======================= 318 passed in 1850.81s (0:30:50) =======================
```
`dev-suite` not run because these files are not part of the autonomous running of PypeIt.