### PR TITLE
Hotfix for GMOS edge tracing parameters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -61,6 +61,7 @@
   for reading arc lamps used from frames, and `reid_arxiv` templates for
   three additional gratings.  
 - Slurps in and uses slitmask design for Keck/LRIS (limited usage) 
+- Hotfix for `gemini_gmos` mosaic tracing parameters
 
 
 1.7.0 (19 Nov 2021)

--- a/pypeit/spectrographs/gemini_gmos.py
+++ b/pypeit/spectrographs/gemini_gmos.py
@@ -190,7 +190,8 @@ class GeminiGMOSSpectrograph(spectrograph.Spectrograph):
         # Always default to reducing as a mosaic
         par['rdx']['detnum'] = [(1,2,3)]
 
-        par['calibrations']['slitedges']['edge_thresh'] = 20.
+        par['calibrations']['slitedges']['follow_span'] = 80
+        par['calibrations']['slitedges']['edge_thresh'] = 100.
         par['calibrations']['slitedges']['fit_order'] = 3
 
         # 1D wavelength solution


### PR DESCRIPTION
This is a hotfix for the edge-trace parameters for `gemini_gmos` to facilitate jumping the chip gap created by the mosaic.