### PR TITLE
M1 install doc hotfix.

### DIFF
--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -191,22 +191,22 @@ following is the current step-by-step installation:
         conda create -n pypeit python=3.8
         conda activate pypeit
 
-#. Install PyQt5 (this is the only step that's different from a typical conda installation)
+#. Install PyQt5 and bottleneck directly (these are the only step that's different from a nominal conda installation)
 
    .. code-block:: console
 
         conda install pyqt
+        conda install -c conda-forge bottleneck
 
 #. Install ``PypeIt`` via pip with the ``pyqt5`` option.  **Do not include** the
-   ``bottleneck`` option.  
+   ``bottleneck`` option; you've already installed it in the previous step.  
 
    .. code-block:: console
 
         pip install "pypeit[pyqt5]"
 
-We currently cannot install ``bottleneck`` with ``PypeIt`` on an M1 Mac.
-Solutions/Recommendations for this installation are welcome; please `Submit an
-issue`_.
+Other solutions/recommendations for M1 Mac installations are welcome; to provide
+it, please `Submit an issue`_.
 
 ----
 

--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -191,7 +191,8 @@ following is the current step-by-step installation:
         conda create -n pypeit python=3.8
         conda activate pypeit
 
-#. Install PyQt5 and bottleneck directly (these are the only step that's different from a nominal conda installation)
+#. Install PyQt5 and bottleneck directly (these are the only steps that are
+   different from a nominal conda installation)
 
    .. code-block:: console
 


### PR DESCRIPTION
Hotfix for M1 installation instructions.

A couple of questions for @jhennawi on this:

- Can we do the pyqt and bottleneck installations on the same line?  Something like: `conda install -c conda-forge bottleneck pyqt`?
- Is it true that users should omit the bottleneck option in the last step?  Is the `pyqt5` option actually needed?  I.e., after installing pyqt and bottleneck directly, can someone simply `pip install pypeit`?

