### PR TITLE
Silence VerifyWarning for "Keyword name ... is greater than 8..."

### DIFF
--- a/pypeit/io.py
+++ b/pypeit/io.py
@@ -22,6 +22,7 @@ from configobj import ConfigObj
 
 from astropy.io import fits
 from astropy.table import Table
+from astropy.io.fits.verify import VerifyWarning
 
 from pypeit import msgs
 from pypeit import par
@@ -657,6 +658,10 @@ def write_to_hdu(d, name=None, hdr=None, force_to_bintbl=False):
             types.
 
     """
+    # Silence the "Keyword name ... is greater than 8 characters ... a HIERARCH
+    #   card will be created" Warnings from [astropy.io.fits.card]
+    warnings.simplefilter('ignore', VerifyWarning)
+
     if isinstance(d, dict):
         return dict_to_hdu(d, name=name, hdr=hdr, force_to_bintbl=force_to_bintbl)
     if isinstance(d, Table):


### PR DESCRIPTION
This particular Warning (raised by `astropy.io.fits.card`) does not seem to be helpful for either the user or developer because the PypeIt team made the conscious decision to use long keyword names for reduction metadata added to the FITS headers of data products.

The user can't do anything about the long keywords, and the code base would require extensive overhaul to remove them.  Furthermore, there is universal support among modern software for handling the HIERARCH keyword as it has been around for more than 20 years (cf. https://www.eso.org/sci/software/esomidas/doc/user/18NOV/vola/node116.html and https://heasarc.gsfc.nasa.gov/fitsio/c/f_user/node28.html).

These warnings also make it challenging to follow the flow of PypeIt messages during reduction for debugging and troubleshooting.

Partially addresses #1251 .