### PR TITLE
Spec2d hotfix

### DIFF
--- a/pypeit/core/datacube.py
+++ b/pypeit/core/datacube.py
@@ -17,7 +17,7 @@ from scipy.interpolate import interp1d
 import numpy as np
 
 from pypeit import msgs
-from pypeit import spec2dobj, alignframe
+from pypeit import spec2dobj, alignframe, masterframe
 from pypeit.core.flux_calib import load_extinction_data, extinction_correction
 from pypeit.core.flexure import calculate_image_offset
 from pypeit.core import parse
@@ -661,8 +661,7 @@ def coadd_cube(files, spectrograph=None, parset=None, overwrite=False):
         astrometric = cubepar['astrometric']
         msgs.info("Loading alignments")
         hdr = fits.open(fil)[0].header
-        alignfile = "{0:s}/Master{1:s}_{2:s}_01.{3:s}".format(hdr['PYPMFDIR'], alignframe.Alignments.master_type,
-                                                              hdr['TRACMKEY'], alignframe.Alignments.master_file_format)
+        alignfile = masterframe.construct_file_name(alignframe.Alignments, hdr['TRACMKEY'], master_dir=hdr['PYPMFDIR'])
         alignments = None
         if os.path.exists(alignfile) and cubepar['astrometric']:
             alignments = alignframe.Alignments.from_file(alignfile)

--- a/pypeit/spec2dobj.py
+++ b/pypeit/spec2dobj.py
@@ -463,13 +463,13 @@ class AllSpec2DObj:
         # TODO -- Should this be in the header of the individual HDUs ?
         if master_key_dict is not None:
             if 'bias' in master_key_dict.keys():
-                hdr['BIASMKEY'] = master_key_dict['bias'][:-2]
+                hdr['BIASMKEY'] = master_key_dict['bias'][:-5]
             if 'arc' in master_key_dict.keys():
-                hdr['ARCMKEY'] = master_key_dict['arc'][:-2]
+                hdr['ARCMKEY'] = master_key_dict['arc'][:-5]
             if 'trace' in master_key_dict.keys():
-                hdr['TRACMKEY'] = master_key_dict['trace'][:-2]
+                hdr['TRACMKEY'] = master_key_dict['trace'][:-5]
             if 'flat' in master_key_dict.keys():
-                hdr['FLATMKEY'] = master_key_dict['flat'][:-2]
+                hdr['FLATMKEY'] = master_key_dict['flat'][:-5]
 
         # Processing steps
         # TODO: Assumes processing steps for all detectors are the same...  Does

--- a/pypeit/spec2dobj.py
+++ b/pypeit/spec2dobj.py
@@ -463,13 +463,13 @@ class AllSpec2DObj:
         # TODO -- Should this be in the header of the individual HDUs ?
         if master_key_dict is not None:
             if 'bias' in master_key_dict.keys():
-                hdr['BIASMKEY'] = master_key_dict['bias'][:-3]
+                hdr['BIASMKEY'] = master_key_dict['bias'][:-2]
             if 'arc' in master_key_dict.keys():
-                hdr['ARCMKEY'] = master_key_dict['arc'][:-3]
+                hdr['ARCMKEY'] = master_key_dict['arc'][:-2]
             if 'trace' in master_key_dict.keys():
-                hdr['TRACMKEY'] = master_key_dict['trace'][:-3]
+                hdr['TRACMKEY'] = master_key_dict['trace'][:-2]
             if 'flat' in master_key_dict.keys():
-                hdr['FLATMKEY'] = master_key_dict['flat'][:-3]
+                hdr['FLATMKEY'] = master_key_dict['flat'][:-2]
 
         # Processing steps
         # TODO: Assumes processing steps for all detectors are the same...  Does

--- a/pypeit/spec2dobj.py
+++ b/pypeit/spec2dobj.py
@@ -463,13 +463,13 @@ class AllSpec2DObj:
         # TODO -- Should this be in the header of the individual HDUs ?
         if master_key_dict is not None:
             if 'bias' in master_key_dict.keys():
-                hdr['BIASMKEY'] = master_key_dict['bias'][:-5]
+                hdr['BIASMKEY'] = master_key_dict['bias']
             if 'arc' in master_key_dict.keys():
-                hdr['ARCMKEY'] = master_key_dict['arc'][:-5]
+                hdr['ARCMKEY'] = master_key_dict['arc']
             if 'trace' in master_key_dict.keys():
-                hdr['TRACMKEY'] = master_key_dict['trace'][:-5]
+                hdr['TRACMKEY'] = master_key_dict['trace']
             if 'flat' in master_key_dict.keys():
-                hdr['FLATMKEY'] = master_key_dict['flat'][:-5]
+                hdr['FLATMKEY'] = master_key_dict['flat']
 
         # Processing steps
         # TODO: Assumes processing steps for all detectors are the same...  Does

--- a/pypeit/tests/test_setups.py
+++ b/pypeit/tests/test_setups.py
@@ -80,7 +80,7 @@ def test_setup_made_pypeit_file():
 
 @dev_suite_required
 def test_setup_keck_lris_red_mark4():
-    droot = os.path.join(os.environ['PYPEIT_DEV'], 'RAW_DATA/keck_lris_red_mark4/long_400_8500')
+    droot = os.path.join(os.environ['PYPEIT_DEV'], 'RAW_DATA/keck_lris_red_mark4/long_400_8500_d560')
     droot += '/'
     pargs = Setup.parse_args(['-r', droot, '-s', 'keck_lris_red_mark4'])
     Setup.main(pargs)


### PR DESCRIPTION
The headers of spec2d files are written out with:

```
BIASMKEY= 'A_1_DE  '
ARCMKEY = 'A_1_DE  '
TRACMKEY= 'A_1_DE  '
FLATMKEY= 'A_1_DE  '
```

This PR has a simple fix to remove the `DE`. The master key can be reconstructed with `BIASMKEY + spec.get_det_name(det)`
