### PR TITLE
Allow curved traces for user-added slit edges

### DIFF
--- a/pypeit/edgetrace.py
+++ b/pypeit/edgetrace.py
@@ -3946,7 +3946,7 @@ class EdgeTraceSet(DataContainer):
         elif method == 'pca':
             if self.is_empty:
                 msgs.error('No edge traces currently exist.  Cannot insert user slits with a '
-                           'shape based on the PCA decomposition of the existing slit edges!
+                           'shape based on the PCA decomposition of the existing slit edges!  '
                            'Set add_predict = straight.')
             if self.pcatype is None:
                 if not self.can_pca():

--- a/pypeit/edgetrace.py
+++ b/pypeit/edgetrace.py
@@ -3933,7 +3933,8 @@ class EdgeTraceSet(DataContainer):
         elif method == 'nearest':
             if self.is_empty:
                 msgs.error('No edge traces currently exist.  Cannot insert user slits with a '
-                           'shape based on the nearest existing slit edges!')
+                           'shape based on the nearest existing slit edges!  '
+                           'Set add_predict = straight.')
             # Use the measured edges if the functional forms don't exist (yet)
             trace_cen = self.edge_cen if self.edge_fit is None else self.edge_fit
             # Find the trace nearest to the one to be inserted
@@ -3945,12 +3946,13 @@ class EdgeTraceSet(DataContainer):
         elif method == 'pca':
             if self.is_empty:
                 msgs.error('No edge traces currently exist.  Cannot insert user slits with a '
-                           'shape based on the PCA decomposition of the existing slit edges!')
+                           'shape based on the PCA decomposition of the existing slit edges!
+                           'Set add_predict = straight.')
             if self.pcatype is None:
                 if not self.can_pca():
                     msgs.error('PCA does not exist and cannot be constructed!  Cannot insert user '
                                'slits with a shape based on the PCA decomposition of the existing '
-                               'slit edges!')
+                               'slit edges!  Use add_predict = straight or nearest.')
                 self.build_pca()
             # Use the pca to predict the traces at the requested spatial positions
             trace_ref = new_trace_coo[:,1]

--- a/pypeit/edgetrace.py
+++ b/pypeit/edgetrace.py
@@ -877,9 +877,12 @@ class EdgeTraceSet(DataContainer):
                                                     self.traceimg.detector.det)
             if add_user_slits is not None:
                 ad_rm = True
-                self.add_user_traces(add_user_slits)
+                self.add_user_traces(add_user_slits, method=self.par['add_predict'])
         if show_stages and ad_rm:
             self.show(title='After user-dictated adding/removing slits')
+
+        # TODO: If slits are added/removed, should the code check again if the
+        # traces are synced?
 
         # TODO: Add a parameter and an if statement that will allow for
         # this.
@@ -3113,7 +3116,7 @@ class EdgeTraceSet(DataContainer):
             use_center (:obj:`bool`, optional):
                 Use the center measurements for the PCA decomposition
                 instead of the functional fit to those data. This is
-                only relevant if both are available. If not fits have
+                only relevant if both are available. If no fits have
                 been performed, the function will automatically use
                 the center measurements.
             debug (:obj:`bool`, optional):
@@ -3171,7 +3174,7 @@ class EdgeTraceSet(DataContainer):
 
         # The call to can_pca means that short traces are fully masked
         # and that valid traces will be any trace with unmasked pixels.
-        use_trace = np.sum(np.invert(bpm), axis=0) > 0
+        use_trace = np.sum(np.logical_not(bpm), axis=0) > 0
 
         # Set the reference row so that, regardless of whether the PCA
         # is for the left, right, or all traces, the reference row is
@@ -3278,7 +3281,7 @@ class EdgeTraceSet(DataContainer):
         trace_ref = self.edge_cen[reference_row,:] if self.pcatype == 'center' \
                             else self.edge_fit[reference_row,:]
         side = self.is_right.astype(int)*2-1
-        self.edge_fit = self.predict_traces(trace_ref, side)
+        self.edge_fit = self.predict_traces(trace_ref, side=side)
 
         # TODO: Compare with the fit data. Remove traces where the mean
         # offset between the PCA prediction and the measured centroids
@@ -3839,7 +3842,7 @@ class EdgeTraceSet(DataContainer):
 
         # Predict the traces either using the PCA or using the nearest slit edge
         if self.par['sync_predict'] == 'pca':
-            trace_add = self.predict_traces(trace_ref[add_edge], side[add_edge])
+            trace_add = self.predict_traces(trace_ref[add_edge], side=side[add_edge])
         elif self.par['sync_predict'] == 'nearest':
             # Index of trace nearest the ones to add
             # TODO: Force it to use the nearest edge of the same side;
@@ -3848,7 +3851,7 @@ class EdgeTraceSet(DataContainer):
             nearest = utils.nearest_unmasked(np.ma.MaskedArray(trace_ref, mask=add_edge))
             # Indices of the original traces
             indx = np.zeros(len(add_edge), dtype=int)
-            indx[np.invert(add_edge)] = np.arange(self.ntrace)
+            indx[np.logical_not(add_edge)] = np.arange(self.ntrace)
             # Offset the original traces by a constant based on the
             # reference trace position to construct the new traces.
             trace_add = trace_cen[:,indx[nearest[add_edge]]] + trace_ref[add_edge] \
@@ -3886,31 +3889,86 @@ class EdgeTraceSet(DataContainer):
         self.log += [inspect.stack()[0][3]]
         return True
 
-    def add_user_traces(self, user_traces):
+    def add_user_traces(self, user_traces, method='straight'):
         """
-        Add user-defined slit(s)
+        Add traces for user-defined slits.
 
         Args:
-            user_slits (list):
+            user_slits (:obj:`list`):
+                A list of lists with the coordinates for the new traces.  For
+                each new slit, the list provides the spectral coordinate at
+                which the slit edges are defined and the left and right spatial
+                pixels that the traces should pass through.  I.e., ``[664, 323,
+                348]`` mean construct a left edge that passes through pixel
+                ``(664,323)`` (ordered spectral then spatial) and a right edge
+                that passes through pixel ``(664,348)``.
+
+            method (:obj:`str`, optional):
+                The method used to construct the traces.  Options are:
+
+                    - ``'straight'``: Simply insert traces that have a constant
+                      spatial position as a function of spectral pixel.
+
+                    - ``'nearest'``: Constrain the trace to follow the same form
+                      as an existing trace that is nearest the provided new
+                      trace coordinates.
+
+                    - ``'pca'``: Use the PCA decomposition of the traces to
+                      predict the added trace.  If the PCA does not currently
+                      exist, the function will try to (re)build it.
 
         """
-        sides = []
-        new_traces = np.zeros((self.nspec, len(user_traces)*2))
-        # Add user input slits
-        for kk, new_slit in enumerate(user_traces):
-            # Parse
-            y_spec, x_spat0, x_spat1 = new_slit
-            msgs.info("Adding new slits at x0, x1 (left, right)".format(x_spat0, x_spat1))
-            #
-            # TODO -- Use existing traces (ideally the PCA) not just vertical lines!
-            sides.append(-1)
-            sides.append(1)
-            # Trace cen
-            new_traces[:,kk*2] = x_spat0
-            new_traces[:,kk*2+1] = x_spat1
+        #msgs.info("Adding new slits at x0, x1 (left, right)".format(x_spat0, x_spat1))
+        # Number of added slits
+        n_add = len(user_traces)
+        # Add two traces for each slit, one left and one right
+        side = np.tile([-1,1], (1,n_add)).ravel()
+        # Reformat the user-defined input into an array of spectral and spatial
+        # coordiates for the new traces
+        new_trace_coo = np.array(user_traces, dtype=float)
+        new_trace_coo = np.insert(new_trace_coo, 2, new_trace_coo[:,0], axis=1).reshape(-1,2)
+        if method == 'straight':
+            # Just repeat the spatial positions
+            new_traces = np.tile(new_trace_coo[:,1], (self.nspec,1))
+        elif method == 'nearest':
+            if self.is_empty:
+                msgs.error('No edge traces currently exist.  Cannot insert user slits with a '
+                           'shape based on the nearest existing slit edges!')
+            # Use the measured edges if the functional forms don't exist (yet)
+            trace_cen = self.edge_cen if self.edge_fit is None else self.edge_fit
+            # Find the trace nearest to the one to be inserted
+            nearest = np.array([np.argmin(np.absolute(trace_cen[int(coo[0])] - coo[1]))
+                                    for coo in new_trace_coo])
+            # Construct the new traces by offseting the existing ones
+            new_traces = trace_cen[:,nearest] + new_trace_coo[:,1] \
+                            - trace_cen[new_trace_coo[:,0].astype(int), nearest]
+        elif method == 'pca':
+            if self.is_empty:
+                msgs.error('No edge traces currently exist.  Cannot insert user slits with a '
+                           'shape based on the PCA decomposition of the existing slit edges!')
+            if self.pcatype is None:
+                if not self.can_pca():
+                    msgs.error('PCA does not exist and cannot be constructed!  Cannot insert user '
+                               'slits with a shape based on the PCA decomposition of the existing '
+                               'slit edges!')
+                self.build_pca()
+            # Use the pca to predict the traces at the requested spatial positions
+            trace_ref = new_trace_coo[:,1]
+            new_traces = self.predict_traces(trace_ref, side=side)
+            # NOTE: The users can pick spectral rows in the definition of the
+            # new slits that are not the same as the reference row at which the
+            # PCA is defined.  This iteration in the prediction tries to adjust
+            # the reference spatial position for the prediction so that the
+            # predicted trace runs through the user-specific spatial position at
+            # the user-specified spectral position.
+            trace_ref += new_trace_coo[:,1] \
+                            - new_traces[new_trace_coo[:,0].astype(int),np.arange(n_add*2)]
+            new_traces = self.predict_traces(trace_ref, side=side)
+        else:
+            msgs.error(f'Unknown method for adding user slit: {method}')
 
         # Insert
-        self.insert_traces(np.array(sides), new_traces, mode='user')
+        self.insert_traces(side, new_traces, mode='user')
         # Sync
         self.check_synced(rebuild_pca=False)
 

--- a/pypeit/par/pypeitpar.py
+++ b/pypeit/par/pypeitpar.py
@@ -2584,8 +2584,8 @@ class EdgeTracePar(ParSet):
     see :ref:`pypeitpar`.
     """
     prefix = 'ETP'  # Prefix for writing parameters to a header is a class attribute
-    def __init__(self, filt_iter=None, sobel_mode=None, edge_thresh=None, exclude_regions=None, follow_span=None,
-                 det_min_spec_length=None, max_shift_abs=None, max_shift_adj=None,
+    def __init__(self, filt_iter=None, sobel_mode=None, edge_thresh=None, exclude_regions=None,
+                 follow_span=None, det_min_spec_length=None, max_shift_abs=None, max_shift_adj=None,
                  max_spat_error=None, match_tol=None, fit_function=None, fit_order=None,
                  fit_maxdev=None, fit_maxiter=None, fit_niter=None, fit_min_spec_length=None,
                  auto_pca=None, left_right_pca=None, pca_min_edges=None, pca_n=None,
@@ -2598,7 +2598,7 @@ class EdgeTracePar(ParSet):
                  length_range=None, minimum_slit_gap=None, clip=None, order_match=None,
                  order_offset=None, use_maskdesign=None, maskdesign_maxsep=None,
                  maskdesign_step=None, maskdesign_sigrej=None, pad=None, add_slits=None,
-                 rm_slits=None):
+                 add_predict=None, rm_slits=None):
 
         # Grab the parameter names and values from the function
         # arguments
@@ -2991,6 +2991,16 @@ class EdgeTracePar(ParSet):
                              'extending spatially from 2121 to 2322 and another on detector 3 ' \
                              'at spec=2000 extending from 1201 to 1500.'
 
+        defaults['add_predict'] = 'nearest'
+        dtypes['add_predict'] = str
+        descr['add_predict'] = 'Sets the method used to predict the shape of the left and right ' \
+                               'traces for a user-defined slit inserted.  Options are (1) ' \
+                               '``straight`` inserts traces with a constant spatial pixels ' \
+                               'position, (2) ``nearest`` inserts traces with a form identical ' \
+                               'to the automatically identified trace at the nearest spatial ' \
+                               'position to the inserted slit, or (3) ``pca`` uses the PCA ' \
+                               'decomposition to predict the shape of the traces.'
+
         dtypes['rm_slits'] = [str, list]
         descr['rm_slits'] = 'Remove one or more user-specified slits.  The syntax used to ' \
                             'define a slit to remove is: \'det:spec:spat\' where det=detector, ' \
@@ -3022,7 +3032,8 @@ class EdgeTracePar(ParSet):
                    'sync_to_edge', 'bound_detector', 'minimum_slit_length',
                    'minimum_slit_length_sci', 'length_range', 'minimum_slit_gap', 'clip',
                    'order_match', 'order_offset', 'use_maskdesign', 'maskdesign_maxsep',
-                   'maskdesign_step', 'maskdesign_sigrej', 'pad', 'add_slits', 'rm_slits']
+                   'maskdesign_step', 'maskdesign_sigrej', 'pad', 'add_slits', 'add_predict',
+                   'rm_slits']
 
         badkeys = np.array([pk not in parkeys for pk in k])
         if np.any(badkeys):

--- a/pypeit/tests/test_scripts.py
+++ b/pypeit/tests/test_scripts.py
@@ -123,7 +123,7 @@ def test_trace_add_rm():
     # Add lines to remove and add slits. This removes the one slit that
     # is found and adds another.
     ps.user_cfg += ['[calibrations]', '[[slitedges]]', 'rm_slits = 1:1028:170',
-                    'add_slits = 1:1028:30:300']
+                    'add_slits = 1:1028:30:300', 'add_predict = straight']
 
     # Use PypeItMetaData to write the complete PypeIt file
     pypeit_file = ps.fitstbl.write_pypeit(output_path=os.getcwd(), cfg_lines=ps.user_cfg,


### PR DESCRIPTION
When users add slits, the code currently forces the pseudo-slit edge traces to be linear; i.e., the spatial pixel of the edge trace is the same at every spectral pixel.  This PR allows the user to define how the spectral form of the trace is predicted.  They can either specify "straight" (mimics the current behavior), "nearest", or "pca".  Selection of "nearest" and "pca" is effectively identical to how the automatic tracing code inserts missing left or right traces when syncing the traces into slit pairs.  The code works well in a single test case, shown below.

Poor result when using "add_predict = straight":

![straight_test](https://user-images.githubusercontent.com/15785898/162516269-e4a6b114-51ba-43ee-ac25-bd8879709f57.png)

Better result when using "add_predict = nearest"

![nearest_test](https://user-images.githubusercontent.com/15785898/162516363-fca0aa1a-c015-405b-87f3-9596178baae1.png)

or "add_predict = pca"

![pca_test](https://user-images.githubusercontent.com/15785898/162516402-e1456d88-9ae7-43d1-9f22-3c0a0eb80aae.png)

Tests pass.  Dev suite pending.
