### PR TITLE
turn off astrometric+grating corrections

### DIFF
--- a/pypeit/core/datacube.py
+++ b/pypeit/core/datacube.py
@@ -1078,8 +1078,9 @@ def coadd_cube(files, spectrograph=None, parset=None, overwrite=False):
         stdcube = fits.open(cubepar['standard_cube'])
         star_ra, star_dec = stdcube[1].header['CRVAL1'], stdcube[1].header['CRVAL2']
         # Extract the information about the blaze
-        blaze_wave, blaze_spec = stdcube['BLAZE_WAVE'].data, stdcube['BLAZE_SPEC'].data
-        blaze_spline = interp1d(blaze_wave, blaze_spec, kind='linear', bounds_error=False, fill_value="extrapolate")
+        if cubepar['grating_corr']:
+            blaze_wave, blaze_spec = stdcube['BLAZE_WAVE'].data, stdcube['BLAZE_SPEC'].data
+            blaze_spline = interp1d(blaze_wave, blaze_spec, kind='linear', bounds_error=False, fill_value="extrapolate")
         # Extract a spectrum of the standard star
         wave, Nlam_star, Nlam_ivar_star, gpm_star = extract_standard_spec(stdcube)
         # Read in some information above the standard star

--- a/pypeit/tests/test_coadd.py
+++ b/pypeit/tests/test_coadd.py
@@ -118,6 +118,8 @@ def test_coadd_datacube():
     parset = spec.default_pypeit_par()
     parset['reduce']['cube']['output_filename'] = output_filename
     parset['reduce']['cube']['combine'] = True
+    parset['reduce']['cube']['astrometric'] = False
+    parset['reduce']['cube']['grating_corr'] = False
     coadd_cube(files, parset=parset, overwrite=True)
     # Now test the fluxing
     flux_files = [files[0]]
@@ -125,6 +127,8 @@ def test_coadd_datacube():
     parset['reduce']['cube']['output_filename'] = output_fileflux
     parset['reduce']['cube']['combine'] = False
     parset['reduce']['cube']['standard_cube'] = output_filename
+    parset['reduce']['cube']['astrometric'] = False
+    parset['reduce']['cube']['grating_corr'] = False
     coadd_cube(flux_files, parset=parset, overwrite=True)
     # Check the files exist
     assert(os.path.exists(output_filename))


### PR DESCRIPTION
A fix to `test_coadd`... the other option is to include the master alignments and master flats in Cooked, or refactor the coadd3d file... Probably the latter needs to be done eventually, but this fix is enough for now.