### PR TITLE
pypeit_setup fix for xshooter

### DIFF
--- a/pypeit/io.py
+++ b/pypeit/io.py
@@ -838,16 +838,23 @@ def fits_open(filename, **kwargs):
             Passed directly to `astropy.io.fits.open`_.
 
     Returns:
-        `astropy.io.fits.HDUList`_: List of all the HDUs in the fits file
+        `astropy.io.fits.HDUList`_: List of all the HDUs in the fits file.
+
+    Raises:
+        PypeItError: Raised if the file does not exist.
     """
     if not os.path.isfile(filename):
         msgs.error(f'{filename} does not exist!')
     try:
         return fits.open(filename, **kwargs)
     except OSError as e:
-        msgs.warn('Error opening {0}: {1}'.format(filename, str(e))
-                   + '\nTrying again, assuming the error was a header problem.')
-        return fits.open(filename, ignore_missing_end=True, **kwargs)
+        msgs.warn(f'Error opening {filename} ({e}).  Trying again by setting '
+                  'ignore_missing_end=True, assuming the error was a header problem.')
+        try:
+            return fits.open(filename, ignore_missing_end=True, **kwargs)
+        except OSError as e:
+            msgs.error(f'That failed, too!  Astropy is unable to open {filename} and reports the '
+                      f'following error: {e}')
 
 
 def create_symlink(filename, symlink_dir, relative_symlink=False, overwrite=False, quiet=False):

--- a/pypeit/metadata.py
+++ b/pypeit/metadata.py
@@ -195,7 +195,7 @@ class PypeItMetaData:
 
             # Read the fits headers.  NOTE: If the file cannot be opened,
             # headarr will be None, and the subsequent loop over the meta keys
-            # will fill data dictionary with None values.
+            # will fill the data dictionary with None values.
             headarr = self.spectrograph.get_headarr(ifile, strict=strict)
 
             # Grab Meta

--- a/pypeit/metadata.py
+++ b/pypeit/metadata.py
@@ -72,7 +72,7 @@ class PypeItMetaData:
         strict (:obj:`bool`, optional):
             Function will fault if there is a problem with the reading
             the header for any of the provided files; see
-            :func:`pypeit.spectrographs.spectrograph.get_headarr`.  Set
+            :func:`~pypeit.spectrographs.spectrograph.get_headarr`.  Set
             to False to instead report a warning and continue.
 
     Attributes:
@@ -193,7 +193,9 @@ class PypeItMetaData:
             if not data['directory'][idx]:
                 data['directory'][idx] = '.'
 
-            # Read the fits headers
+            # Read the fits headers.  NOTE: If the file cannot be opened,
+            # headarr will be None, and the subsequent loop over the meta keys
+            # will fill data dictionary with None values.
             headarr = self.spectrograph.get_headarr(ifile, strict=strict)
 
             # Grab Meta
@@ -221,10 +223,10 @@ class PypeItMetaData:
             filenames = np.asarray(data['filename'])
             bad_files = filenames[mjd == None]
             # Print status message
-            msg = 'Time invalid for {0} files.\n'.format(len(bad_files))
-            msg += 'Continuing, but the following frames may be empty or have corrupt headers:\n'
+            msg = f'Time invalid for {len(bad_files)} files.\nContinuing, but the following ' \
+                  'frames either could not be opened, are empty, or have corrupt headers:\n'
             for file in bad_files:
-                msg += '    {0}\n'.format(file)
+                msg += f'    {file}\n'
             msgs.warn(msg)
 
         # Return

--- a/pypeit/par/util.py
+++ b/pypeit/par/util.py
@@ -597,7 +597,9 @@ def parse_pypeit_file(ifile, file_check=True, runtime=False):
     if s >= 0 and e < 0:
         msgs.error("Missing 'setup end' in {0}".format(ifile))
     if s < 0:
-        msgs.warn("Missing setup block! This may be a problem")
+        # TODO: This gets issued every time anyone runs pypeit_setup.  Is this
+        # warning worthwhile and/or still true?
+#        msgs.warn("Missing setup block! This may be a problem")
         setups, sdict = [], {}
     else:
         setups, sdict = _parse_setup_lines(lines[s:e])

--- a/pypeit/spectrographs/vlt_xshooter.py
+++ b/pypeit/spectrographs/vlt_xshooter.py
@@ -374,6 +374,7 @@ class VLTXShooterNIRSpectrograph(VLTXShooterSpectrograph):
             exposures in ``fitstbl`` that are ``ftype`` type frames.
         """
         good_exp = framematch.check_frame_exptime(fitstbl['exptime'], exprng)
+        good_seq = np.array([seq is not None and int(seq) % 2 == 1 for seq in fitstbl['seq_expno']])
         # TODO: Allow for 'sky' frame type, for now include sky in
         # 'science' category
         if ftype == 'science':
@@ -393,14 +394,14 @@ class VLTXShooterNIRSpectrograph(VLTXShooterSpectrograph):
             return good_exp & (((fitstbl['target'] == 'LAMP,DFLAT')
                                | (fitstbl['target'] == 'LAMP,QFLAT')
                                | (fitstbl['target'] == 'LAMP,FLAT'))
-                               & (fitstbl['seq_expno'].astype(int) % 2 == 1))
+                               & good_seq)
         
         if ftype in ['dark']:
             # Lamp off flats are taken second (even exposure number)
             return good_exp & (((fitstbl['target'] == 'LAMP,DFLAT')
                                 | (fitstbl['target'] == 'LAMP,QFLAT')
                                 | (fitstbl['target'] == 'LAMP,FLAT'))
-                               & (fitstbl['seq_expno'].astype(int) % 2 == 0))
+                               & good_seq)
         
         if ftype == 'pinhole':
             # Don't type pinhole


### PR DESCRIPTION
Addresses #1407 .  I added a few changes to how bad files are propagated through the collection of the relevant metadata, but this mostly boiled down to a fix in the frame-typing for VLT-XShooter-NIR.

I'm getting some test failures, but these are likely because of the changes to the datamodel in some pending PRs.  E.g., this should get merged after #1384 , and I'll re-run the tests and dev-suite then.