### PR TITLE
Update slittrace smash_nsig to smash_snr

### DIFF
--- a/pypeit/slittrace.py
+++ b/pypeit/slittrace.py
@@ -1158,7 +1158,7 @@ class SlitTraceSet(datamodel.DataContainer):
         return
 
     def get_maskdef_offset(self, sobjs, platescale, spat_flexure, slitmask_off, bright_maskdefid,
-                           nsig_thrshd, use_alignbox, dither_off=None):
+                           snr_thrshd, use_alignbox, dither_off=None):
         """
         Determine the Slitmask offset (pixels) from position expected by the slitmask design
 
@@ -1168,7 +1168,7 @@ class SlitTraceSet(datamodel.DataContainer):
             spat_flexure (:obj:`float`): Shifts, in spatial pixels, between this image and SlitTrace
             slitmask_off (:obj:`float`): User provided slitmask offset in pixels
             bright_maskdefid (:obj:`str`): User provided maskdef_id of a bright object to be used to measure offset
-            nsig_thrshd (:obj:`float`): Objects detected above this sigma threshold will be use to
+            snr_thrshd (:obj:`float`): Objects detected above this S/N ratio threshold will be use to
                                         compute the slitmask offset
             use_alignbox (:obj:`bool`): Flag that determines if the alignment boxes are used to measure the offset
             dither_off (:obj:`float`, optional): dither offset recorded in the header of the observations
@@ -1296,25 +1296,25 @@ class SlitTraceSet(datamodel.DataContainer):
                 self.maskdef_offset = 0.0
             return
 
-        # Determine offsets using only detections with the highest significance
-        # objects added in manual extraction have smash_nsig = None
-        nonone = cut_sobjs.smash_nsig != None
+        # Determine offsets using only detections with the highest signal
+        # objects added in manual extraction have smash_snr = None
+        nonone = cut_sobjs.smash_snr != None
         if len(cut_sobjs[nonone]) > 0:
-            highsig_measured = measured[nonone][cut_sobjs[nonone].smash_nsig > nsig_thrshd]
-            highsig_expected = expected[nonone][cut_sobjs[nonone].smash_nsig > nsig_thrshd]
-            if len(highsig_measured) >= 3:
-                off = highsig_measured - highsig_expected
+            highsnr_measured = measured[nonone][cut_sobjs[nonone].smash_snr > snr_thrshd]
+            highsnr_expected = expected[nonone][cut_sobjs[nonone].smash_snr > snr_thrshd]
+            if len(highsnr_measured) >= 3:
+                off = highsnr_measured - highsnr_expected
                 mean, median_off, std = sigma_clipped_stats(off, sigma=2.)
                 self.maskdef_offset = median_off
                 msgs.info(f'Slitmask offset estimated in {self.detname}: '
                           f'{round(self.maskdef_offset, 2)} pixels ('
                           f'{round(self.maskdef_offset*platescale, 2)} arcsec)')
             else:
-                msgs.warn(f'Less than 3 objects detected above {nsig_thrshd} sigma threshold. '
+                msgs.warn(f'Less than 3 objects detected above {snr_thrshd} sigma threshold. '
                           f'Slitmask offset cannot be estimated in {self.detname}.')
                 self.maskdef_offset = 0.0
         else:
-            msgs.warn(f'Less than 3 objects detected above {nsig_thrshd} sigma threshold. '
+            msgs.warn(f'Less than 3 objects detected above {snr_thrshd} sigma threshold. '
                       f'Slitmask offset cannot be estimated in {self.detname}.')
             self.maskdef_offset = 0.0
 


### PR DESCRIPTION
Updated slittrace.py::get_maskdef_offset to use the new SpecObj.smash_snr field instead of smash_nsig. This was causing the keck_lris_blue multi_600_4000_slitmask test to fail (this test is in the devsuite cooked_refactor_dev, but not in develop yet). 

Unit tests:
`===== 328 passed, 3844 warnings in 1025.53s (0:17:05) =====
`

keck_lris_blue/multi_600_4000_slitmask results:
```
(pypeit) dusty@River:~/work/PypeIt-development-suite$ ./pypeit_test reduce -i keck_lris_blue -s multi_600_4000_slitmask
Running reduce tests.
Running tests on the following instruments:
    keck_lris_blue

Reducing data from keck_lris_blue for the following setups:
    multi_600_4000_slitmask

 0 passed/ 0 failed/ 0 skipped STARTED keck_lris_blue/multi_600_4000_slitmask pypeit 
 1 passed/ 0 failed/ 0 skipped PASSED  keck_lris_blue/multi_600_4000_slitmask pypeit 
--- PYPEIT DEVELOPMENT SUITE PASSED 1/1 TESTS  ---

Test Summary
--------------------------------------------------------
--- PYPEIT DEVELOPMENT SUITE PASSED 1/1 TESTS  ---
Testing Started at 2022-05-27T13:50:04.036016
Testing Completed at 2022-05-27T13:58:13.528742
Total Time: 0:08:09.492726

```