### PR TITLE
Hotfix for using download/cache `reid_arxiv`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -19,6 +19,6 @@ prune pypeit/deprecated
 global-exclude *.pyc *.o *.so *.DS_Store
 
 # Exclude certain package data for compactness
-recursive-exclude pypeit/data/arc_lines/reid_arxiv *.fits
+recursive-exclude pypeit/data/arc_lines/reid_arxiv *.fits *.json
 recursive-exclude pypeit/data/sensfuncs *.fits
 recursive-exclude pypeit/data/skisim *.dat

--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -136,7 +136,7 @@ provide a yaml file that can be used to setup a conda environment called
 To use this:
 
     #. Download `environment.yml
-       <https://github.com/pypeit/PypeIt/blob/release/environment.yml>`__.
+       <https://raw.githubusercontent.com/pypeit/PypeIt/release/environment.yml>`__.
 
     #. Create the conda environment and install ``pypeit`` into it:
 

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python>=3.7,<3.10
+  - python>=3.8,<3.10
   - pyyaml>=5.4
   - requests>=2.26
   - packaging>=21.0

--- a/pypeit/core/wavecal/waveio.py
+++ b/pypeit/core/wavecal/waveio.py
@@ -109,7 +109,7 @@ def load_reid_arxiv(arxiv_file):
     # ToDO put in some code to allow user specified files rather than everything in the main directory
     calibfile, in_cache = data.get_reid_arxiv_filepath(arxiv_file)
     # This is a hack as it will fail if we change the data model yet again for wavelength solutions
-    if calibfile[-4:] == 'json':
+    if calibfile[-4:] == 'json' or in_cache == 'json':
         wv_calib_arxiv = load_wavelength_calibration(calibfile)
         par = wv_calib_arxiv['par'].copy()
         # Pop out par and steps if they were inserted in this calibration dictionary
@@ -121,7 +121,7 @@ def load_reid_arxiv(arxiv_file):
             wv_calib_arxiv.pop('par')
         except KeyError:
             pass
-    elif calibfile[-4:] == 'fits' or in_cache:
+    elif calibfile[-4:] == 'fits' or in_cache == 'fits':
         # The following is a bit of a hack too
         par = None
         wv_tbl = Table.read(calibfile, format='fits')

--- a/pypeit/core/wavecal/waveio.py
+++ b/pypeit/core/wavecal/waveio.py
@@ -71,7 +71,7 @@ def load_template(arxiv_file, det, wvrng=None):
     """
     # Path already included?
     if os.path.basename(arxiv_file) == arxiv_file:
-        calibfile = data.get_reid_arxiv_filepath(arxiv_file)
+        calibfile, _ = data.get_reid_arxiv_filepath(arxiv_file)
     else:
         calibfile = arxiv_file
     # Read me
@@ -107,7 +107,7 @@ def load_reid_arxiv(arxiv_file):
 
     """
     # ToDO put in some code to allow user specified files rather than everything in the main directory
-    calibfile = data.get_reid_arxiv_filepath(arxiv_file)
+    calibfile, in_cache = data.get_reid_arxiv_filepath(arxiv_file)
     # This is a hack as it will fail if we change the data model yet again for wavelength solutions
     if calibfile[-4:] == 'json':
         wv_calib_arxiv = load_wavelength_calibration(calibfile)
@@ -121,7 +121,7 @@ def load_reid_arxiv(arxiv_file):
             wv_calib_arxiv.pop('par')
         except KeyError:
             pass
-    elif calibfile[-4:] == 'fits':
+    elif calibfile[-4:] == 'fits' or in_cache:
         # The following is a bit of a hack too
         par = None
         wv_tbl = Table.read(calibfile, format='fits')

--- a/pypeit/data/utils.py
+++ b/pypeit/data/utils.py
@@ -225,10 +225,14 @@ def get_reid_arxiv_filepath(arxiv_file):
           The base filename of the ``reid_arxiv`` file to be located
 
     Returns:
-        str: The full path to the ``reid_arxiv`` file
+        tuple: The full path and whether the path is in the cache:
+
+           * reid_path (str): The full path to the ``reid_arxiv`` file
+           * in_cache (bool): Whether the returned path is in the cache
     """
     # Full path within the package data structure:
     reid_path = os.path.join(Paths.reid_arxiv, arxiv_file)
+    in_cache = False
 
     # Check if the file does NOT exist in the package directory
     # NOTE: This should be the case for all but from-source installations
@@ -239,9 +243,10 @@ def get_reid_arxiv_filepath(arxiv_file):
                   "the package directory.  Checking cache or downloading the file now.")
 
         reid_path = fetch_remote_file(arxiv_file, "arc_lines/reid_arxiv")
+        in_cache = True
 
-    # Return the path to the `reid_arxiv` file
-    return reid_path
+    # Return the path to the `reid_arxiv` file, plus whether this is in the cache
+    return reid_path, in_cache
 
 
 def get_skisim_filepath(skisim_file):

--- a/pypeit/data/utils.py
+++ b/pypeit/data/utils.py
@@ -228,7 +228,9 @@ def get_reid_arxiv_filepath(arxiv_file):
         tuple: The full path and whether the path is in the cache:
 
            * reid_path (str): The full path to the ``reid_arxiv`` file
-           * in_cache (bool): Whether the returned path is in the cache
+           * in_cache (bool or str): If the returned path is in the cache,
+                indicate whether it is a "fits" or "json", otherwise
+                return False
     """
     # Full path within the package data structure:
     reid_path = os.path.join(Paths.reid_arxiv, arxiv_file)
@@ -243,7 +245,7 @@ def get_reid_arxiv_filepath(arxiv_file):
                   "the package directory.  Checking cache or downloading the file now.")
 
         reid_path = fetch_remote_file(arxiv_file, "arc_lines/reid_arxiv")
-        in_cache = True
+        in_cache = arxiv_file[-4:]
 
     # Return the path to the `reid_arxiv` file, plus whether this is in the cache
     return reid_path, in_cache

--- a/pypeit/tests/test_pkgdata.py
+++ b/pypeit/tests/test_pkgdata.py
@@ -2,10 +2,10 @@
 Module to run fetching remote package data from GitHub
 """
 
-import pkg_resources
 import requests
 
 from pypeit import data
+from pypeit.core.wavecal import waveio
 from pypeit import __version__ 
 
 
@@ -44,3 +44,8 @@ def test_load_sky_spectrum():
 
     # Load in the most common sky spectrum to ensure this function works 
     data.load_sky_spectrum("paranal_sky.fits")
+
+def test_waveio_load_reid_arxiv():
+
+    # Test the extension logic, given the download/cache system
+    waveio.load_reid_arxiv("vlt_xshooter_vis1x1.fits")

--- a/pypeit/tests/test_pkgdata.py
+++ b/pypeit/tests/test_pkgdata.py
@@ -49,3 +49,4 @@ def test_waveio_load_reid_arxiv():
 
     # Test the extension logic, given the download/cache system
     waveio.load_reid_arxiv("vlt_xshooter_vis1x1.fits")
+    waveio.load_reid_arxiv("vlt_xshooter_vis1x1.json")

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,8 @@ classifiers =
     Natural Language :: English
     Operating System :: OS Independent
     Programming Language :: Python
-    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Topic :: Documentation :: Sphinx
     Topic :: Scientific/Engineering :: Astronomy
     Topic :: Software Development :: Libraries :: Python Modules
@@ -27,7 +28,7 @@ classifiers =
 zip_safe = False
 use_2to3=False
 packages = find:
-python_requires = >=3.8
+python_requires = >=3.8,<3.10
 setup_requires = setuptools_scm
 include_package_data = True
 install_requires =


### PR DESCRIPTION
Hotfix for (show-stopping) issue reported on Users Slack (https://pypeit-users.slack.com/archives/CTKPQM7AL/p1654765807992059) related to using a downloaded `reid_arxiv` with the `reidentify` wavelength calibration method.  Includes a new unit test to ensure cached files load.

**NOTE:** This is an ugly hack for functionality, and I will look to provide a more elegant solution to this (and any other `get_*_filepath()` bugs) in a regular PR to `develop`.

2 minor fixes also included:
- Correct URL for raw version of the `environment.yml` file needed to create a `conda` virtual environment.
- Affirm the currently supported versions of python for `PypeIt`.

Unit tests pass:
```
============================= test session starts ==============================
platform linux -- Python 3.9.13, pytest-7.1.2, pluggy-1.0.0
collected 329 items                                                            
======================= 329 passed in 1939.60s (0:32:19) =======================
```