### PR TITLE
Another hotfix for data handling schema

### DIFF
--- a/pypeit/data/utils.py
+++ b/pypeit/data/utils.py
@@ -84,6 +84,7 @@ from pypeit import __version__
 __all__ = ['Paths', 'load_telluric_grid', 'load_thar_spec',
            'load_sky_spectrum', 'get_reid_arxiv_filepath',
            'get_skisim_filepath', 'get_sensfunc_filepath',
+           'get_telgrid_filepath',
            'fetch_remote_file', 'write_file_to_cache']
 
 
@@ -372,11 +373,11 @@ def get_telgrid_filepath(telgrid_file):
     particular reductions, the remote fetch will only occur once per file.
 
     Args:
-        sensfunc_file (str):
-          The base filename of the ``sensfunc`` file to be located
+        telgrid_file (str):
+          The base filename of the ``telgrid`` file to be located
 
     Returns:
-        str: The full path to the ``sensfunc`` file
+        str: The full path to the ``telgrid`` file
     """
     # Full path within the package data structure:
     telgrid_path = os.path.join(Paths.telgrid, telgrid_file)

--- a/pypeit/scripts/tellfit.py
+++ b/pypeit/scripts/tellfit.py
@@ -117,7 +117,7 @@ class TellFit(scriptbase.ScriptBase):
         # Checks
         if par['telluric']['telgridfile'] is None:
             msgs.error('A file with the telluric grid must be provided.')
-        elif not os.path.isfile(os.path.join(data.Paths.telgrid, par['telluric']['telgridfile'])):
+        elif not os.path.isfile(data.get_telgrid_filepath(par['telluric']['telgridfile'])):
             msgs.error(f"{par['telluric']['telgridfile']} does not exist.  Check your "
                        f"installation.")
 


### PR DESCRIPTION
Correct `scripts.tellfit` to use the `data.get_telgrid_filepath()` routine
instead of just looking in the PypeIt package directory.



Unit tests pass
```
============================= test session starts ==============================
platform linux -- Python 3.9.12, pytest-7.1.2, pluggy-1.0.0
collected 329 items                                                            
======================= 329 passed in 2093.35s (0:34:53) =======================
```
