### PR TITLE
Keck/NIRSPEC fix

### DIFF
--- a/pypeit/spectrographs/keck_nirspec.py
+++ b/pypeit/spectrographs/keck_nirspec.py
@@ -257,16 +257,16 @@ class KeckNIRSPECSpectrograph(spectrograph.Spectrograph):
         if status == 'off':
             # Check if all are off
             lamp_stat = [k for k in fitstbl.keys() if 'lampstat' in k]
-            retarr = np.zeros((len(lamp_stat), len(fitstbl)))
+            retarr = np.zeros((len(lamp_stat), len(fitstbl)), dtype=bool)
             for kk, key in enumerate(lamp_stat):
-                retarr[kk,:] = fitstbl['lampstat01'].data.astype(np.int) == 0
+                retarr[kk,:] = fitstbl[key].data.astype(np.int) == 0
             return np.all(retarr, axis=0)
         if status == 'arcs':
             # Check if any arc lamps are on
             lamp_stat = [ 'lampstat{0:02d}'.format(i) for i in range(1,6) ]
             retarr = np.zeros((len(lamp_stat), len(fitstbl)))
             for kk, key in enumerate(lamp_stat):
-                retarr[kk,:] = fitstbl['lampstat01'].data.astype(np.int) == 1
+                retarr[kk,:] = fitstbl[key].data.astype(np.int) == 1
             return np.any(retarr, axis=0)
         if status == 'dome':
             return fitstbl['lampstat06'].data.astype(int) == 1

--- a/pypeit/tests/test_metadata.py
+++ b/pypeit/tests/test_metadata.py
@@ -13,6 +13,8 @@ from pypeit.metadata import PypeItMetaData
 from pypeit.spectrographs.util import load_spectrograph
 from pypeit.scripts.setup import Setup
 from pypeit.inputfiles import PypeItFile
+from astropy.table import Table
+
 
 def test_read_combid():
 
@@ -54,3 +56,27 @@ def test_read_combid():
     assert pmd['comb_id'][np.where(~indx)[0]][0] == -1, 'Incorrect combination group ID'
 
     shutil.rmtree(config_dir)
+
+
+def test_nirspec_lamps():
+    # Load the spectrograph
+    spectrograph = load_spectrograph("keck_nirspec_low")
+    # Setup a fake table with information about files
+    fitstbl = Table(names=('fakename', 'lampstat01', 'lampstat02', 'lampstat03', 'lampstat04', 'lampstat05', 'lampstat06'), dtype=('S', 'd', 'd', 'd', 'd', 'd', 'd'))
+    fitstbl.add_row(('off_01', 0, 0, 0, 0, 0, 0))
+    fitstbl.add_row(('off_02', 0, 0, 0, 0, 0, 0))
+    fitstbl.add_row(('arcs_01', 0, 0, 0, 0, 1, 0))
+    fitstbl.add_row(('arcs_02', 0, 0, 1, 0, 0, 0))
+    fitstbl.add_row(('arcs_03', 1, 1, 1, 1, 1, 0))
+    fitstbl.add_row(('dome_01', 0, 0, 0, 0, 0, 1))
+    fitstbl.add_row(('dome_02', 0, 0, 0, 0, 0, 1))
+    fitstbl.add_row(('dome_03', 0, 0, 0, 0, 0, 1))
+    # Check off
+    tst = spectrograph.lamps(fitstbl, 'off')
+    assert np.array_equal(tst, np.array([True, True, False, False, False,  False,  False,  False]))
+    # Check arcs
+    tst = spectrograph.lamps(fitstbl, 'arcs')
+    assert np.array_equal(tst, np.array([False, False, True, True, True, False, False, False]))
+    # Check dome
+    tst = spectrograph.lamps(fitstbl, 'dome')
+    assert np.array_equal(tst, np.array([False, False, False, False, False,  True,  True,  True]))


### PR DESCRIPTION
I was reducing some low resolution Keck NIRSPEC data, and the frame typing was not working. It seems this was due to a type issue, but also, the one line statements in `spectrograph.lamps()` were throwing errors about unknown variables.. Something that must be new in python 3 🤷 