### PR TITLE
slitmask and extraction hotfixes

### DIFF
--- a/pypeit/core/extract.py
+++ b/pypeit/core/extract.py
@@ -667,7 +667,7 @@ def fit_profile(image, ivar, waveimg, thismask, spat_img, trace_in, wave, flux, 
     indsp = (wave >= wave_min) & (wave <= wave_max) & np.isfinite(flux_sm) & (flux_sm > -1000.0) & (fluxivar_sm > 0.0)
     eligible_pixels = np.sum((wave >= wave_min) & (wave <= wave_max))
     good_pix_frac = 0.05
-    if np.sum(indsp) < good_pix_frac*eligible_pixels:
+    if (np.sum(indsp) < good_pix_frac*eligible_pixels) or (eligible_pixels == 0):
         msgs.warn('There are no pixels eligible to be fit for the object profile.' + msgs.newline() +
                   'There is likely an issue in local_skysub_extract. Returning a Gassuain with fwhm={:5.3f}'.format(thisfwhm))
         profile_model = return_gaussian(sigma_x, None, thisfwhm, 0.0, obj_string, False)

--- a/pypeit/spectrographs/slitmask.py
+++ b/pypeit/spectrographs/slitmask.py
@@ -948,7 +948,9 @@ def load_keck_deimoslris(filename:str, instr:str):
     mapid = hdu['SlitObjMap'].data['ObjectID']
     catid = hdu['ObjectCat'].data['ObjectID']
     indx = index_of_x_eq_y(mapid, catid)
-    objname = [item.strip() for item in hdu['ObjectCat'].data['OBJECT']]
+    # .decode() assumes encoding is the default 'utf-8'
+    objname = [item.strip().decode() if isinstance(item, bytes) else item.strip()
+               for item in hdu['ObjectCat'].data['OBJECT']]
     #   - Pull out the slit ID, object ID, name, object coordinates, top and bottom distance
     objects = numpy.array([hdu['SlitObjMap'].data['dSlitId'][indx].astype(int),
                         catid.astype(int),
@@ -998,4 +1000,6 @@ def load_keck_deimoslris(filename:str, instr:str):
                                             hdu['MaskDesign'].data['DEC_PNT'][0]),
                                 posx_pa=posx_pa)
     # Return
-    return slitmask 
+    return slitmask
+
+


### PR DESCRIPTION
This fixes 2 bugs found while running the reduction for the ADAP:

- (probably rare) byte decoding issue when retrieving the object name from the slitmask design.
-  crash in optimal extraction when "eligible_pixels" for extraction is equal to zero.


I'll run the tests.