### PR TITLE
Fix location of LDT

### DIFF
--- a/pypeit/telescopes.py
+++ b/pypeit/telescopes.py
@@ -184,7 +184,7 @@ class BokTelescopePar(TelescopePar):
 
 class LDTTelescopePar(TelescopePar):
     def __init__(self):
-        loc = EarthLocation.of_site('Lowell Observatory')
+        loc = EarthLocation.of_site('Discovery Channel Telescope')
         super(LDTTelescopePar, self).__init__(name='LDT',
                                               longitude=loc.lon.to(units.deg).value,
                                               latitude=loc.lat.to(units.deg).value,


### PR DESCRIPTION
AstroPy's listing for `EarthLocation.of_site('Lowell Observatory')` is our Anderson Mesa station, some 30 miles distant from the LDT.  A PR to AstroPy was submitted some time ago to change this, but...

The proper site in the AstroPy database is 'Discovery Channel Telescope'.  For those wondering, DCT --> Lowell Discovery Telescope name change happened in early 2020.

	modified:   pypeit/telescopes.py