### PR TITLE
Geting JWST/NIRCAM Wide-Field Slitless Spectroscopy Started

### DIFF
--- a/pypeit/core/skysub.py
+++ b/pypeit/core/skysub.py
@@ -706,7 +706,6 @@ def local_skysub_extract(sciimg, sciivar, tilts, waveimg, global_sky, thismask, 
     outmask : `numpy.ndarray`_
         Model mask where ``thismask`` is true.
     """
-
     # Check input
     if model_noise and base_var is None:
         msgs.error('Must provide base_var to iteratively update and improve the noise model.')
@@ -940,8 +939,7 @@ def local_skysub_extract(sciimg, sciivar, tilts, waveimg, global_sky, thismask, 
                     nrej = outmask.flat[isub[igood1]].sum()
                     msgs.info(
                         'Iteration = {:d}'.format(iiter) + ', rejected {:d}'.format(nrej) + ' of ' + '{:d}'.format(
-                            igood1.sum()) + 'fit pixels')
-
+                            igood1.sum()) + ' fit pixels')
             elif no_local_sky:
                 pass
             else:

--- a/pypeit/spectrographs/__init__.py
+++ b/pypeit/spectrographs/__init__.py
@@ -36,6 +36,8 @@ from pypeit.spectrographs import vlt_sinfoni
 from pypeit.spectrographs import wht_isis
 from pypeit.spectrographs import ntt_efosc2
 from pypeit.spectrographs import jwst_nirspec
+from pypeit.spectrographs import jwst_nircam
+
 
 # Build the list of names for the available spectrographs
 

--- a/pypeit/spectrographs/jwst_nircam.py
+++ b/pypeit/spectrographs/jwst_nircam.py
@@ -1,0 +1,173 @@
+"""
+Module for MMT/Blue Channel specific methods.
+
+.. include:: ../include/links.rst
+"""
+import glob
+import numpy as np
+from astropy.io import fits
+from astropy.time import Time
+
+from pypeit import msgs
+from pypeit import telescopes
+from pypeit.core import framematch
+from pypeit.par import pypeitpar
+from pypeit.spectrographs import spectrograph
+from pypeit.core import parse
+from pypeit.images import detector_container
+from IPython import embed
+
+class JWSTNIRCamSpectrograph(spectrograph.Spectrograph):
+    """
+    Child to handle MMT/Blue Channel specific code
+    """
+    ndet = 2
+    name = 'jwst_nircam'
+    header_name = 'jwst_nircam'
+    telescope = telescopes.JWSTTelescopePar()
+    camera = 'NIRCAM'
+    supported = True
+
+    def get_detector_par(self, det, hdu=None):
+        """
+        Return metadata for the selected detector.
+
+        .. warning::
+
+            Many of the necessary detector parameters are read from the file
+            header, meaning the ``hdu`` argument is effectively **required** for
+            MMT/BlueChannel.  The optional use of ``hdu`` is only viable for
+            automatically generated documentation.
+
+        Args:
+            det (:obj:`int`):
+                1-indexed detector number.
+            hdu (`astropy.io.fits.HDUList`_, optional):
+                The open fits file with the raw image of interest.  If not
+                provided, frame-dependent parameters are set to a default.
+
+        Returns:
+            :class:`~pypeit.images.detector_container.DetectorContainer`:
+            Object with the detector metadata.
+        """
+
+        # TODO Fill in values for NIRCAM, this is currently NIRSPEC
+
+        # Detector 1, i.e. NRS1 from
+        # https://jwst-docs.stsci.edu/jwst-near-infrared-spectrograph/nirspec-instrumentation/nirspec-detectors/nirspec-detector-performance
+        detector_dict1 = dict(
+            binning='1,1',
+            det=1,
+            dataext=0,
+            specaxis=1,
+            specflip=False,
+            spatflip=False,
+            xgap=0.,
+            ygap=0.,
+            ysize=1.,
+            platescale=0.1,
+            darkcurr=0.0092,
+            saturation=55100.,
+            nonlinear=0.95,  # need to look up and update
+            mincounts=-1e10,
+            numamplifiers=1,
+            gain=np.atleast_1d(0.996),
+            ronoise=np.atleast_1d(5.17),
+            datasec=None,
+            oscansec=None
+        )
+
+        # Detector 2
+        detector_dict2 = detector_dict1.copy()
+        detector_dict2.update(dict(
+            det=2,
+            dataext=0,
+            darkcurr=0.0057,
+            saturation=60400.,
+            gain=np.atleast_1d(1.137),
+            ronoise=np.atleast_1d(6.60),
+        ))
+        detector_dicts = [detector_dict1, detector_dict2]
+        detector = detector_container.DetectorContainer(**detector_dicts[det-1])
+        return detector
+
+
+    def init_meta(self):
+        """
+        Define how metadata are derived from the spectrograph files.
+
+        That is, this associates the ``PypeIt``-specific metadata keywords
+        with the instrument-specific header cards using :attr:`meta`.
+        """
+        self.meta = {}
+        # Required (core)
+        self.meta['ra'] = dict(ext=0, card='RA')
+        self.meta['dec'] = dict(ext=0, card='DEC')
+        self.meta['target'] = dict(ext=0, card='OBJECT')
+        self.meta['decker'] = dict(ext=0, card='APERTURE')
+        self.meta['dichroic'] = dict(ext=0, card='INSFILTE')
+        self.meta['binning'] = dict(ext=0, card=None, compound=True)
+        self.meta['mjd'] = dict(ext=0, card=None, compound=True)
+        self.meta['exptime'] = dict(ext=0, card='EXPTIME')
+        self.meta['airmass'] = dict(ext=0, card='AIRMASS')
+
+        # Extras for config and frametyping
+        self.meta['dispname'] = dict(ext=0, card='DISPERSE')
+        self.meta['idname'] = dict(ext=0, card='IMAGETYP')
+
+        # used for arc and continuum lamps
+        self.meta['lampstat01'] = dict(ext=0, card=None, compound=True)
+        self.meta['instrument'] = dict(ext=0, card='INSTRUME')
+
+
+    @classmethod
+    def default_pypeit_par(cls):
+        """
+        Return the default parameters to use for this instrument.
+
+        Returns:
+            :class:`~pypeit.par.pypeitpar.PypeItPar`: Parameters required by
+            all of ``PypeIt`` methods.
+        """
+        par = super().default_pypeit_par()
+
+
+        # Reduce
+        par['reduce']['trim_edge'] = [0,0]
+
+        # Object finding
+        par['reduce']['findobj']['find_trim_edge'] = [0,0]
+        par['reduce']['findobj']['maxnumber_sci'] = 2
+        par['reduce']['findobj']['snr_thresh'] = 10.0
+        par['reduce']['findobj']['trace_npoly'] = 5
+        par['reduce']['findobj']['snr_thresh'] = 10.0
+        par['reduce']['findobj']['find_fwhm'] = 2.0
+
+
+        # Sky-subtraction
+        par['reduce']['skysub']['bspline_spacing'] = 5.0 # JWST sky is smooth
+        par['reduce']['skysub']['max_mask_frac'] = 0.95
+        par['reduce']['skysub']['mask_by_boxcar'] = True
+        par['reduce']['skysub']['sky_sigrej'] = 4.0
+
+        # Extraction
+        par['reduce']['extraction']['model_full_slit'] = True
+        par['reduce']['extraction']['sn_gauss'] = 6.0
+        par['reduce']['extraction']['boxcar_radius'] = 0.2 # extent in calwebb is 0.55" source and on NIRSpec website
+        par['reduce']['extraction']['use_2dmodel_mask'] = False # Don't use 2d mask in local skysub
+
+        # Cosmic ray rejection parameters for science frames
+        par['scienceframe']['process']['sigclip'] = 5.0
+        par['scienceframe']['process']['objlim'] = 2.0
+        par['scienceframe']['process']['mask_cr'] = False # Turn off for now since we coadd.
+
+        # Skip reference frame correction for now.
+        par['calibrations']['wavelengths']['refframe'] = 'observed'
+
+
+
+        return par
+
+
+
+

--- a/pypeit/spectrographs/jwst_nircam.py
+++ b/pypeit/spectrographs/jwst_nircam.py
@@ -164,8 +164,6 @@ class JWSTNIRCamSpectrograph(spectrograph.Spectrograph):
         # Skip reference frame correction for now.
         par['calibrations']['wavelengths']['refframe'] = 'observed'
 
-
-
         return par
 
 

--- a/pypeit/spectrographs/jwst_nircam.py
+++ b/pypeit/spectrographs/jwst_nircam.py
@@ -51,10 +51,10 @@ class JWSTNIRCamSpectrograph(spectrograph.Spectrograph):
             Object with the detector metadata.
         """
 
-        # TODO Fill in values for NIRCAM, this is currently NIRSPEC
+        # TODO Fill in values for NIRCAM
 
-        # Detector 1, i.e. NRS1 from
-        # https://jwst-docs.stsci.edu/jwst-near-infrared-spectrograph/nirspec-instrumentation/nirspec-detectors/nirspec-detector-performance
+        # Detector 1, i.e. A5
+        # https://jwst-docs.stsci.edu/jwst-near-infrared-camera/nircam-instrumentation/nircam-detector-overview/nircam-detector-performance
         detector_dict1 = dict(
             binning='1,1',
             det=1,
@@ -65,14 +65,14 @@ class JWSTNIRCamSpectrograph(spectrograph.Spectrograph):
             xgap=0.,
             ygap=0.,
             ysize=1.,
-            platescale=0.1,
-            darkcurr=0.0092,
-            saturation=55100.,
+            platescale=0.063,
+            darkcurr=0.0335, # electron/s
+            saturation=59200.,
             nonlinear=0.95,  # need to look up and update
             mincounts=-1e10,
             numamplifiers=1,
-            gain=np.atleast_1d(0.996),
-            ronoise=np.atleast_1d(5.17),
+            gain=np.atleast_1d(1.84),
+            ronoise=np.atleast_1d(8.55), # This is in 1000s, its complicated
             datasec=None,
             oscansec=None
         )
@@ -82,10 +82,10 @@ class JWSTNIRCamSpectrograph(spectrograph.Spectrograph):
         detector_dict2.update(dict(
             det=2,
             dataext=0,
-            darkcurr=0.0057,
-            saturation=60400.,
-            gain=np.atleast_1d(1.137),
-            ronoise=np.atleast_1d(6.60),
+            darkcurr=0.035,
+            saturation=58500.,
+            gain=np.atleast_1d(1.80),
+            ronoise=np.atleast_1d(8.57),
         ))
         detector_dicts = [detector_dict1, detector_dict2]
         detector = detector_container.DetectorContainer(**detector_dicts[det-1])
@@ -145,15 +145,15 @@ class JWSTNIRCamSpectrograph(spectrograph.Spectrograph):
 
 
         # Sky-subtraction
-        par['reduce']['skysub']['bspline_spacing'] = 5.0 # JWST sky is smooth
+        par['reduce']['skysub']['bspline_spacing'] = 1.2 # JWST sky is smooth
         par['reduce']['skysub']['max_mask_frac'] = 0.95
-        par['reduce']['skysub']['mask_by_boxcar'] = True
+        par['reduce']['skysub']['mask_by_boxcar'] = False
         par['reduce']['skysub']['sky_sigrej'] = 4.0
 
         # Extraction
         par['reduce']['extraction']['model_full_slit'] = True
         par['reduce']['extraction']['sn_gauss'] = 6.0
-        par['reduce']['extraction']['boxcar_radius'] = 0.2 # extent in calwebb is 0.55" source and on NIRSpec website
+        par['reduce']['extraction']['boxcar_radius'] = 0.25 # extent in calwebb is 0.55" source and on NIRSpec website
         par['reduce']['extraction']['use_2dmodel_mask'] = False # Don't use 2d mask in local skysub
 
         # Cosmic ray rejection parameters for science frames

--- a/pypeit/spectrographs/jwst_nircam.py
+++ b/pypeit/spectrographs/jwst_nircam.py
@@ -1,5 +1,5 @@
 """
-Module for MMT/Blue Channel specific methods.
+Module for JWST NIRCAM WFSS  specific methods.
 
 .. include:: ../include/links.rst
 """
@@ -19,7 +19,7 @@ from IPython import embed
 
 class JWSTNIRCamSpectrograph(spectrograph.Spectrograph):
     """
-    Child to handle MMT/Blue Channel specific code
+    Child to handle JWST/NIRCAM WFSS specific code
     """
     ndet = 2
     name = 'jwst_nircam'
@@ -36,7 +36,7 @@ class JWSTNIRCamSpectrograph(spectrograph.Spectrograph):
 
             Many of the necessary detector parameters are read from the file
             header, meaning the ``hdu`` argument is effectively **required** for
-            MMT/BlueChannel.  The optional use of ``hdu`` is only viable for
+            NIRCAM.  The optional use of ``hdu`` is only viable for
             automatically generated documentation.
 
         Args:

--- a/pypeit/spectrographs/jwst_nircam.py
+++ b/pypeit/spectrographs/jwst_nircam.py
@@ -26,7 +26,7 @@ class JWSTNIRCamSpectrograph(spectrograph.Spectrograph):
     header_name = 'jwst_nircam'
     telescope = telescopes.JWSTTelescopePar()
     camera = 'NIRCAM'
-    supported = True
+    supported = False
 
     def get_detector_par(self, det, hdu=None):
         """


### PR DESCRIPTION
This very short PR to the JWST branch provides a starting implementation for JWST slitless spectroscopy with NIRCAM. Since the jwst branch has already been reviewed, it makes sense for this short PR to be reviewed by the same reviewers. 