### PR TITLE
Fix increased memory usage with matplotlib >= 3.6.1

### DIFF
--- a/pypeit/core/flexure.py
+++ b/pypeit/core/flexure.py
@@ -877,7 +877,7 @@ def spec_flexure_qa(slitords, bpm, basename, flex_list,
             is used.
     """
     plt.rcdefaults()
-    plt.rcParams['font.family'] = 'times new roman'
+    plt.rcParams['font.family'] = 'serif'
 
     # What type of QA are we doing
     slit_cen = False

--- a/pypeit/core/gui/identify.py
+++ b/pypeit/core/gui/identify.py
@@ -351,7 +351,7 @@ class Identify:
 
         axes = dict(main=ax, fit=axfit, resid=axres, info=axinfo)
         # Initialise the identify window and display to screen
-        fig.canvas.set_window_title('PypeIt - Identify')
+        fig.canvas.manager.set_window_title('PypeIt - Identify')
         ident = Identify(fig.canvas, axes, spec, specres, detns, line_lists, par,
                          lflag_color, slit=slit, y_log=y_log, wv_calib=wv_calib,
                          spatid=str(slits.spat_id[slit]), pxtoler=pxtoler,

--- a/pypeit/core/gui/object_find.py
+++ b/pypeit/core/gui/object_find.py
@@ -953,7 +953,7 @@ def initialise(det, frame, left, right, obj_trace, trace_models, sobjs, slit_ids
     axes = dict(main=ax, profile=axprof, info=axinfo)
     profdict = dict(profile=profile[0], fwhm=[vlinel, vliner])
     # Initialise the object finding window and display to screen
-    fig.canvas.set_window_title('PypeIt - Object Tracing')
+    fig.canvas.manager.set_window_title('PypeIt - Object Tracing')
     ofgui = ObjFindGUI(fig.canvas, image, frame, det, sobjs, _left, _right, obj_trace,
                        trace_models, axes, profdict, slit_ids=slit_ids, printout=printout,
                        runtime=runtime)

--- a/pypeit/core/tracewave.py
+++ b/pypeit/core/tracewave.py
@@ -912,7 +912,7 @@ def arc_tilts_2d_qa(tilts_dspat, tilts, tilts_model, tot_mask, rej_mask, spat_or
 
     """
     plt.rcdefaults()
-    plt.rcParams['font.family'] = 'Helvetica'
+    plt.rcParams['font.family'] = 'sans-serif'
 
     # Outfile
     method = inspect.stack()[0][3]
@@ -961,7 +961,7 @@ def arc_tilts_spec_qa(tilts_spec_fit, tilts, tilts_model, tot_mask, rej_mask, rm
     """
 
     plt.rcdefaults()
-    plt.rcParams['font.family'] = 'Helvetica'
+    plt.rcParams['font.family'] = 'sans-serif'
 
     # Outfil
     method = inspect.stack()[0][3]
@@ -1039,7 +1039,7 @@ def arc_tilts_spat_qa(tilts_dspat, tilts, tilts_model, tilts_spec_fit, tot_mask,
                    fwhm,
                    setup='A', slitord_id=0, outfile=None, show_QA=False, out_dir=None):
     plt.rcdefaults()
-    plt.rcParams['font.family'] = 'Helvetica'
+    plt.rcParams['font.family'] = 'sans-serif'
 
     # Outfil
     method = inspect.stack()[0][3]

--- a/pypeit/core/wavecal/autoid.py
+++ b/pypeit/core/wavecal/autoid.py
@@ -50,7 +50,7 @@ def arc_fit_qa(waveFit, outfile=None, ids_only=False, title=None,
 
     """
     plt.rcdefaults()
-    plt.rcParams['font.family']= 'times new roman'
+    plt.rcParams['font.family']= 'serif'
 
     arc_spec = waveFit['spec']
 

--- a/pypeit/flatfield.py
+++ b/pypeit/flatfield.py
@@ -1528,7 +1528,7 @@ def spatillum_finecorr_qa(normed, finecorr, left, right, ypos, cut, outfile=None
         In this case, each output pixel shown contains about 2 detector pixels.
     """
     plt.rcdefaults()
-    plt.rcParams['font.family'] = 'times new roman'
+    plt.rcParams['font.family'] = 'serif'
 
     msgs.info("Generating QA for spatial illumination fine correction")
     # Setup some plotting variables


### PR DESCRIPTION
When processing in the nautilus cloud I discovered that newer jobs were using more memory than they used to. It turned out that it was caused by the jobs doing a fresh install of PypeIt and picking up a new version of matplotlib. Apparently in this version using an unrecognized font will cause extra memory to be used (and a lot of error message to stderr). In my testing I had a keck_deimos reduction go from 5GiB in matplotlib 5.2.6 to 25GiB in matplotlib 5.3.1. To fix this I changed the font families "Helvetica" and "Times New Roman" to "San Serif" and "Serif" respectively, and fixed a deprecated call to set_window_title to be compatible with both matplotlib versions.

Test Results:
```
Test Summary
--------------------------------------------------------
--- PYTEST PYPEIT UNIT TESTS PASSED  201 passed, 1180 warnings in 295.90s (0:04:55) ---
--- PYTEST UNIT TESTS PASSED  118 passed, 1823 warnings in 1392.05s (0:23:12) ---
--- PYTEST VET TESTS PASSED  25 passed, 1597 warnings in 1393.80s (0:23:13) ---
--- PYPEIT DEVELOPMENT SUITE PASSED 153/153 TESTS  ---
Testing Started at 2022-11-03T23:58:33.714542
Testing Completed at 2022-11-04T14:37:32.877161
Total Time: 14:38:59.162619

```