### PR TITLE
(HOTFIX) Fix typo related to GitHub download

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@
 
 - (Hotfix) Fixed bug that allowed science frames to be assigned to multiple
   instrument configurations
+- (Hotfix) Fixed typo related to GitHub download for offline processing
 
 1.11.0 (21 Oct 2022)
 --------------------

--- a/pypeit/data/utils.py
+++ b/pypeit/data/utils.py
@@ -654,7 +654,7 @@ def _build_remote_url(f_name, f_type, remote_host=""):
         # Hard-wire the URL based on PypeIt Version
         data_url = (
             "https://raw.githubusercontent.com/pypeit/PypeIt/"
-            f"{'develop' if '.dev' in __version__ else __version__}/pypeit/data/"
+            f"{'develop' if '.dev' in __version__ else __version__}/pypeit/data"
         )
         return f"{data_url}/{f_type}/{f_name}", None
 


### PR DESCRIPTION
Fixes a typo in the constructed URL of GitHub-hosted content, where a second (spurious) "/" is included in the URL.  When AstroPy goes to download the file, the extra slash is removed and the correct file is downloaded.  However, when the code attempts to locate the file, it cannot find it in the cache because of the slash mismatch.  For most users, the file is re-downloaded.  For offline uses (for instance, compute clusters), this causes a fatal error.

Fixes #1498.