### PR TITLE
Sphinx RTD Theme version requirements (hotfix)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,10 @@
 
+1.12.1dev
+---------
+
+- (Hotfix) Specify sphinx versions to correctly work with
+  sphinx_rtd_theme
+
 1.12.0 (31 Jan 2023)
 --------------------
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -106,7 +106,7 @@ version = get_distribution(setup_cfg['name']).version
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+#language = None
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/doc/help/run_pypeit.rst
+++ b/doc/help/run_pypeit.rst
@@ -4,7 +4,7 @@
     usage: run_pypeit [-h] [-v VERBOSITY] [-r REDUX_PATH] [-m] [-s] [-o] [-c]
                       pypeit_file
     
-    ##  [1;37;42mPypeIt : The Python Spectroscopic Data Reduction Pipeline v1.11.1.dev409+g0d070dc01[0m
+    ##  [1;37;42mPypeIt : The Python Spectroscopic Data Reduction Pipeline v1.12.1.dev1+gee479d62d.d20230131[0m
     ##  
     ##  Available spectrographs include:
     ##   bok_bc, gemini_flamingos1, gemini_flamingos2, gemini_gmos_north_e2v,

--- a/doc/include/gemini_gnirs_A.pypeit.rst
+++ b/doc/include/gemini_gnirs_A.pypeit.rst
@@ -1,7 +1,7 @@
 .. code-block:: console
 
-    # Auto-generated PypeIt input file using PypeIt version: 1.11.1.dev409+g0d070dc01
-    # UTC 2023-01-31T16:50:56.302
+    # Auto-generated PypeIt input file using PypeIt version: 1.12.1.dev1+gee479d62d.d20230131
+    # UTC 2023-01-31T18:42:33.864
     
     # User-defined execution parameters
     [rdx]

--- a/doc/include/keck_deimos_A.pypeit.rst
+++ b/doc/include/keck_deimos_A.pypeit.rst
@@ -1,7 +1,7 @@
 .. code-block:: console
 
-    # Auto-generated PypeIt input file using PypeIt version: 1.11.1.dev409+g0d070dc01
-    # UTC 2023-01-31T16:50:55.778
+    # Auto-generated PypeIt input file using PypeIt version: 1.12.1.dev1+gee479d62d.d20230131
+    # UTC 2023-01-31T18:42:33.386
     
     # User-defined execution parameters
     [rdx]

--- a/doc/include/shane_kast_blue_A.pypeit.rst
+++ b/doc/include/shane_kast_blue_A.pypeit.rst
@@ -1,7 +1,7 @@
 .. code-block:: console
 
-    # Auto-generated PypeIt input file using PypeIt version: 1.11.1.dev409+g0d070dc01
-    # UTC 2023-01-31T16:50:50.129
+    # Auto-generated PypeIt input file using PypeIt version: 1.12.1.dev1+gee479d62d.d20230131
+    # UTC 2023-01-31T18:42:27.359
     
     # User-defined execution parameters
     [rdx]

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,9 +70,10 @@ test =
     coverage
     codecov
 docs =
-    sphinx
+    sphinx<6,>=1.6
+    docutils<0.18
     sphinx-automodapi
-    sphinx_rtd_theme
+    sphinx_rtd_theme==1.1.1
 dev =
     pytest>=6.0.0
     pytest-astropy


### PR DESCRIPTION
Fixes problems with the build of the documentation due to the `sphinx_rtd_theme` requiring an specific range of `sphinx` versions.