### PR TITLE
CI updates and version bumps

### DIFF
--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -15,15 +15,15 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python: [3.8, 3.9]
+        python: ['3.9', '3.10']
         toxenv: [test-alldeps, test-numpydev, test-linetoolsdev, test-gingadev, test-astropydev, conda]
     steps:
     - name: Check out repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: develop
     - name: Set up Python ${{ matrix.python }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python }}
     - name: Install base dependencies

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -84,6 +84,7 @@ jobs:
     steps:
     - name: Install base CentOS dependencies
       run: |
+        yum install -y https://packages.endpointdev.com/rhel/7/os/x86_64/endpoint-repo.x86_64.rpm
         yum update -y && yum install -y wget git gcc
     - name: Check out repository
       uses: actions/checkout@v3

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -102,7 +102,7 @@ jobs:
         source ~/.bashrc && python -m pip install --upgrade pip tox && python --version
     - name: Test with tox
       run: |
-        source ~/.bashrc && pip install -e . && tox -e ${{ matrix.toxenv }}
+        source ~/.bashrc && tox -e --develop ${{ matrix.toxenv }}
 
   codestyle:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -6,9 +6,6 @@ on:
     - release
     - develop
   pull_request:
-  schedule:
-    # run every Monday at 6am UTC
-    - cron: '0 6 * * 1'
 
 env:
   SETUP_XVFB: True  # avoid issues if something tries to open a GUI window
@@ -20,13 +17,13 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python: [3.8, 3.9]
+        python: ['3.9', '3.10']
         toxenv: [test, test-alldeps-cov, test-linetoolsdev, test-gingadev, test-astropydev, conda]
     steps:
     - name: Check out repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python }}
     - name: Install base dependencies
@@ -37,7 +34,7 @@ jobs:
         tox -e ${{ matrix.toxenv }}
     - name: Upload coverage to codecov
       if: "contains(matrix.toxenv, '-cov')"
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV }}
         file: ./coverage.xml
@@ -51,13 +48,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, macos-latest]
-        python: [3.8, 3.9]
+        python: ['3.9', '3.10']
         toxenv: [test-alldeps]
     steps:
     - name: Check out repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python }}
     - name: Install base dependencies
@@ -89,7 +86,7 @@ jobs:
       run: |
         yum update -y && yum install -y wget git gcc
     - name: Check out repository
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - name: Install and configure miniconda
@@ -109,11 +106,11 @@ jobs:
   codestyle:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Python codestyle check
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: '3.10'
     - name: Install base dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -99,7 +99,7 @@ jobs:
         /conda/bin/conda init
     - name: Install base dependencies
       run: |
-        source ~/.bashrc && python -m pip install --upgrade pip tox && python --version
+        source ~/.bashrc && python -m pip install --upgrade pip tox setuptools_scm && python --version
     - name: Test with tox
       run: |
         source ~/.bashrc && tox -e ${{ matrix.toxenv }}

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -102,7 +102,7 @@ jobs:
         source ~/.bashrc && python -m pip install --upgrade pip tox && python --version
     - name: Test with tox
       run: |
-        source ~/.bashrc && tox -e --develop ${{ matrix.toxenv }}
+        source ~/.bashrc && tox -e ${{ matrix.toxenv }}
 
   codestyle:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -102,7 +102,7 @@ jobs:
         source ~/.bashrc && python -m pip install --upgrade pip tox && python --version
     - name: Test with tox
       run: |
-        source ~/.bashrc && tox -e ${{ matrix.toxenv }}
+        source ~/.bashrc && pip install -e . && tox -e ${{ matrix.toxenv }}
 
   codestyle:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -85,9 +85,11 @@ jobs:
     - name: Install base CentOS dependencies
       run: |
         yum install -y https://packages.endpointdev.com/rhel/7/os/x86_64/endpoint-repo.x86_64.rpm
-        yum update -y && yum install -y wget git gcc
+        yum update -y && yum install -y wget git gcc libgomp
     - name: Check out repository
       uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
     - name: Install and configure miniconda
       # Restrict to 3.9 until we migrate to 3.10
       run: |

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -87,8 +87,6 @@ jobs:
         yum update -y && yum install -y wget git gcc
     - name: Check out repository
       uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
     - name: Install and configure miniconda
       # Restrict to 3.9 until we migrate to 3.10
       run: |

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,6 +6,7 @@ include setup.cfg
 
 recursive-include pypeit *.pyx *.c *.pxd *.h
 recursive-include pypeit/data *
+recursive-include pypeit/tests *
 recursive-include docs *
 recursive-include licenses *
 recursive-include cextern *

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,7 +6,7 @@ include setup.cfg
 
 recursive-include pypeit *.pyx *.c *.pxd *.h
 recursive-include pypeit/data *
-# recursive-include pypeit/tests *
+recursive-include pypeit/tests *
 recursive-include docs *
 recursive-include licenses *
 recursive-include cextern *

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,7 +6,7 @@ include setup.cfg
 
 recursive-include pypeit *.pyx *.c *.pxd *.h
 recursive-include pypeit/data *
-recursive-include pypeit/tests *
+# recursive-include pypeit/tests *
 recursive-include docs *
 recursive-include licenses *
 recursive-include cextern *

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ classifiers =
 zip_safe = False
 use_2to3=False
 packages = find:
-python_requires = >=3.8,<3.10
+python_requires = >=3.8,<=3.11
 setup_requires = setuptools_scm
 include_package_data = True
 install_requires =

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ classifiers =
 zip_safe = False
 use_2to3=False
 packages = find:
-python_requires = >=3.8,<=3.11
+python_requires = >=3.8,<3.12
 setup_requires = setuptools_scm
 include_package_data = True
 install_requires =

--- a/tox.ini
+++ b/tox.ini
@@ -9,12 +9,12 @@ requires =
     setuptools >= 30.3.0
     pip >= 19.3.1
 isolated_build = true
-indexserver =
-    NIGHTLY = https://pypi.anaconda.org/scipy-wheels-nightly/simple
 
 [testenv]
 # Suppress display of matplotlib plots generated during docs build
-setenv = MPLBACKEND=agg
+setenv =
+    MPLBACKEND=agg
+    numpydev: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scipy-wheels-nightly/simple
 
 # Pass through the following environment variables which may be needed for the CI
 passenv = HOME,WINDIR,LC_ALL,LC_CTYPE,CC,CI,PYPEIT_DEV
@@ -56,7 +56,7 @@ deps =
 
     astropylts: astropy==5.0.*
 
-    numpydev: :NIGHTLY:numpy
+    numpydev: numpy>=0.0.dev0
     astropydev: git+https://github.com/astropy/astropy.git#egg=astropy
 
     linetoolsdev: git+https://github.com/linetools/linetools.git#egg=linetools

--- a/tox.ini
+++ b/tox.ini
@@ -41,6 +41,7 @@ description =
     numpy121: with numpy 1.21.*
     numpy122: with numpy 1.22.*
     numpy123: with numpy 1.23.*
+    numpy124: with numpy 1.24.*
     astropylts: with the latest astropy LTS
 
 # The following provides some specific pinnings for key packages
@@ -51,6 +52,7 @@ deps =
     numpy121: numpy==1.21.*
     numpy122: numpy==1.22.*
     numpy123: numpy==1.23.*
+    numpy124: numpy==1.24.*
 
     astropylts: astropy==5.0.*
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
-    py{37,38,39}-test{,-alldeps,-pyside2,-pyqt5,-shapely}{,-cov}
-    py{37,38,39}-test-numpy{118,119}
-    py{37,38,39}-test-astropy{lts,42}
-    py{37,38,39}-test-{numpy,astropy,linetools,ginga}dev
+    py{38,39,310,311}-test{,-alldeps,-pyside2,-pyqt5,-shapely}{,-cov}
+    py{38,39,310,311}-test-numpy{118,119,120,121,122,123}
+    py{38,39,310,311}-test-astropylts
+    py{38,39,310,311}-test-{numpy,astropy,linetools,ginga}dev
     codestyle
 requires =
     setuptools >= 30.3.0
@@ -39,7 +39,10 @@ description =
     cov: and test coverage
     numpy118: with numpy 1.18.*
     numpy119: with numpy 1.19.*
-    astropy42: with astropy 4.2.*
+    numpy120: with numpy 1.20.*
+    numpy121: with numpy 1.21.*
+    numpy122: with numpy 1.22.*
+    numpy123: with numpy 1.23.*
     astropylts: with the latest astropy LTS
 
 # The following provides some specific pinnings for key packages
@@ -48,9 +51,12 @@ deps =
     cov: coverage
     numpy118: numpy==1.18.*
     numpy119: numpy==1.19.*
+    numpy120: numpy==1.20.*
+    numpy121: numpy==1.21.*
+    numpy122: numpy==1.22.*
+    numpy123: numpy==1.23.*
 
-    astropy42: astropy==4.2.*
-    astropylts: astropy==4.0.*
+    astropylts: astropy==5.0.*
 
     numpydev: :NIGHTLY:numpy
     astropydev: git+https://github.com/astropy/astropy.git#egg=astropy

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py{38,39,310,311}-test{,-alldeps,-pyside2,-pyqt5,-shapely}{,-cov}
-    py{38,39,310,311}-test-numpy{118,119,120,121,122,123}
+    py{38,39,310,311}-test-numpy{120,121,122,123}
     py{38,39,310,311}-test-astropylts
     py{38,39,310,311}-test-{numpy,astropy,linetools,ginga}dev
     codestyle
@@ -37,8 +37,6 @@ description =
     devdeps: with the latest developer version of key dependencies
     oldestdeps: with the oldest supported version of key dependencies
     cov: and test coverage
-    numpy118: with numpy 1.18.*
-    numpy119: with numpy 1.19.*
     numpy120: with numpy 1.20.*
     numpy121: with numpy 1.21.*
     numpy122: with numpy 1.22.*
@@ -49,8 +47,6 @@ description =
 deps =
 
     cov: coverage
-    numpy118: numpy==1.18.*
-    numpy119: numpy==1.19.*
     numpy120: numpy==1.20.*
     numpy121: numpy==1.21.*
     numpy122: numpy==1.22.*


### PR DESCRIPTION
This PR does some version bumps and updates to the `tox` configuration and the github actions workflows:

- Deprecate `py37` and add `py310` and `py311` support to `tox.ini`. Also bump `astropylts` to the current LTS release and flesh in more `numpy`back-versions.
- Update matrix of python versions in the CI workflows from 3.8 and 3.9 to 3.9 and 3.10.
- Update versions of the actions used in those workflows to the latest stable one for each action.
- Remove the `schedule` section from `ci_tests.yml` since it's redundant with `ci_cron.yml`.