### PR TITLE
JWST setup fix

### DIFF
--- a/pypeit/metadata.py
+++ b/pypeit/metadata.py
@@ -1095,7 +1095,8 @@ class PypeItMetaData:
         # The configuration must be present to determine the calibration
         # group
         if 'setup' not in self.keys():
-            msgs.error('Must have defined \'setup\' column first; try running set_configurations.')
+            msgs.error('CODING ERROR: Must have defined \'setup\' column first; try running '
+                       'set_configurations.')
         configs = np.unique(np.concatenate([_setup.split(',') for _setup in self['setup'].data])).tolist()
         if 'None' in configs:
             configs.remove('None')      # Ignore frames with undefined configurations
@@ -1108,7 +1109,9 @@ class PypeItMetaData:
         # any changes to the strings will be truncated at 4 characters.
         self.table['calib'] = np.full(len(self), 'None', dtype=object)
         for i in range(n_cfg):
-            in_cfg = np.array([configs[i] in _set for _set in self.table['setup']]) & (self['framebit'] > 0)
+            in_cfg = np.array([configs[i] in _set for _set in self.table['setup']]) # & (self['framebit'] > 0)
+            if not any(in_cfg):
+                continue
             icalibs = np.full(len(self['calib'][in_cfg]), 'None', dtype=object)
             for c in range(len(self['calib'][in_cfg])):
                 if self['calib'][in_cfg][c] == 'None':

--- a/pypeit/spectrographs/jwst_nirspec.py
+++ b/pypeit/spectrographs/jwst_nirspec.py
@@ -219,24 +219,26 @@ class JWSTNIRSpecSpectrograph(spectrograph.Spectrograph):
             `numpy.ndarray`_: Boolean array with the flags selecting the
             exposures in ``fitstbl`` that are ``ftype`` type frames.
         """
-        good_exp = framematch.check_frame_exptime(fitstbl['exptime'], exprng)
-        # TODO: Allow for 'sky' frame type, for now include sky in
-        # 'science' category
-        if ftype == 'science':
-            return good_exp & (fitstbl['idname'] == 'Object')
-        if ftype == 'standard':
-            return good_exp & (fitstbl['idname'] == 'Object')
-        if ftype == 'bias':
-            return good_exp & (fitstbl['idname'] == 'Bias')
-        if ftype == 'dark':
-            return good_exp & (fitstbl['idname'] == 'Dark')
-        if ftype in ['pixelflat', 'trace']:
-            # Flats and trace frames are typed together
-            return good_exp & (fitstbl['idname'] == 'IntFlat')
-        if ftype in ['arc', 'tilt']:
-            # Arc and tilt frames are typed together
-            return good_exp & (fitstbl['idname'] == 'Line')
+#        good_exp = framematch.check_frame_exptime(fitstbl['exptime'], exprng)
+#        # TODO: Allow for 'sky' frame type, for now include sky in
+#        # 'science' category
+#        if ftype == 'science':
+#            return good_exp & (fitstbl['idname'] == 'Object')
+#        if ftype == 'standard':
+#            return good_exp & (fitstbl['idname'] == 'Object')
+#        if ftype == 'bias':
+#            return good_exp & (fitstbl['idname'] == 'Bias')
+#        if ftype == 'dark':
+#            return good_exp & (fitstbl['idname'] == 'Dark')
+#        if ftype in ['pixelflat', 'trace']:
+#            # Flats and trace frames are typed together
+#            return good_exp & (fitstbl['idname'] == 'IntFlat')
+#        if ftype in ['arc', 'tilt']:
+#            # Arc and tilt frames are typed together
+#            return good_exp & (fitstbl['idname'] == 'Line')
 
+        if ftype == 'science':
+            return np.ones(len(fitstbl), dtype=bool)
         msgs.warn('Cannot determine if frames are of type {0}.'.format(ftype))
         return np.zeros(len(fitstbl), dtype=bool)
 


### PR DESCRIPTION
Fix for running `pypeit_setup` on JWST files.  The root of the failure mode was that PypeIt couldn't set the frametype for the JWST file, and that meant it couldn't assign them to a calibration group.  There are two possible fixes, either of which will fix the failure mode but I've actually implemented both:

1. The safest approach may be to fix the frame typing for JWST.  In `jwst_nirspec.py`, I just set everything to a science frame.

2. The more general fix is in `metadata.py`.  The existing code will only set the calibration group of a frame if it has been successfully typed.  I simply removed that requirement and that fixed the failure.  I'm a little worried about this fix, though, because I'm not sure why we required the frame to be successfully typed to add it to a default calibration group.  It makes sense to do this, but I don't think it's necessarily a programmatic requirement.

I'm fine with either or both fixes, but the 2nd one will require more testing to make sure we're not introducing other bugs.