### PR TITLE
Hotfix for rebinning

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 1.13.1dev (6 June 2023)
 ------------------------
 
+- Hotfix for rebin (speed-up and conserves flux)
 - Hotfix for skysub regions GUI that used np.bool
 - Hotfix to stop pypeit_setup from crashing on data from lbt_luci1, lbt_luci2, magellan_fire,
   magellan_fire_long, p200_tspec, or vlt_sinfoni.

--- a/pypeit/core/arc.py
+++ b/pypeit/core/arc.py
@@ -319,11 +319,9 @@ def fit2darc_orders_qa(pypeitFit, nspec, outfile=None):
         plt.show()
 
 
-# JFH CAn we replace reasize with this simpler function:  rebin_factor
-# https://scipy-cookbook.readthedocs.io/items/Rebinning.html
 def resize_mask2arc(shape_arc, slitmask_orig):
     """
-    Resizes the input slitmask to a new shape.  Generally used
+    Rebin the input slitmask to a new shape.  Generally used
     for cases where the arc image has a different binning than 
     the science image. 
 
@@ -350,9 +348,7 @@ def resize_mask2arc(shape_arc, slitmask_orig):
             msgs.error('Problem with images sizes. arcimg size and calibration size need to be integer multiples of each other')
         else:
             msgs.info('Calibration images have different binning than the arcimg. Resizing calibs for arc spectrum extraction.')
-        slitmask = utils.rebinND(slitmask_orig, (nspec, nspat))
-        # Previous line using skimage
-        #slitmask = ((np.round(resize(slitmask_orig.astype(np.integer), (nspec, nspat), preserve_range=True, order=0))).astype(np.integer)).astype(slitmask_orig.dtype)
+        slitmask = utils.rebin_slice(slitmask_orig, (nspec, nspat))
     else:
         slitmask = slitmask_orig
 

--- a/pypeit/core/arc.py
+++ b/pypeit/core/arc.py
@@ -350,7 +350,7 @@ def resize_mask2arc(shape_arc, slitmask_orig):
             msgs.error('Problem with images sizes. arcimg size and calibration size need to be integer multiples of each other')
         else:
             msgs.info('Calibration images have different binning than the arcimg. Resizing calibs for arc spectrum extraction.')
-        slitmask = utils.rebin(slitmask_orig, (nspec, nspat))
+        slitmask = utils.rebinND(slitmask_orig, (nspec, nspat))
         # Previous line using skimage
         #slitmask = ((np.round(resize(slitmask_orig.astype(np.integer), (nspec, nspat), preserve_range=True, order=0))).astype(np.integer)).astype(slitmask_orig.dtype)
     else:

--- a/pypeit/core/datacube.py
+++ b/pypeit/core/datacube.py
@@ -454,30 +454,6 @@ def fitGaussian2D(image, norm=False):
     return popt, pcov
 
 
-def rebinND(img, shape):
-    """
-    Rebin a 2D image to a smaller shape. For example, if img.shape=(100,100),
-    then shape=(10,10) would take the mean of the first 10x10 pixels into a
-    single output pixel, then the mean of the next 10x10 pixels will be output
-    into the next pixel
-
-    Args:
-        img (`numpy.ndarray`_):
-            A 2D input image
-        shape (:obj:`tuple`):
-            The desired shape to be returned. The elements of img.shape
-            should be an integer multiple of the elements of shape.
-
-    Returns:
-        img_out (`numpy.ndarray`_): The input image rebinned to shape
-    """
-    # Convert input 2D image into a 4D array to make the rebinning easier
-    sh = shape[0], img.shape[0]//shape[0], shape[1], img.shape[1]//shape[1]
-    # Rebin to the 4D array and then average over the second and last elements.
-    img_out = img.reshape(sh).mean(-1).mean(1)
-    return img_out
-
-
 def extract_standard_spec(stdcube, subpixel=20, method='boxcar'):
     """ Extract a spectrum of a standard star from a datacube
 
@@ -522,7 +498,7 @@ def extract_standard_spec(stdcube, subpixel=20, method='boxcar'):
     nsig = 4  # 4 sigma should be far enough... Note: percentage enclosed for 2D Gaussian = 1-np.exp(-0.5 * nsig**2)
     ww = np.where((np.sqrt((xx - popt[1]) ** 2 + (yy - popt[2]) ** 2) < nsig * wid))
     mask[ww] = 1
-    mask = rebinND(mask, (flxcube.shape[0], flxcube.shape[1])).reshape(flxcube.shape[0], flxcube.shape[1], 1)
+    mask = utils.rebinND(mask, (flxcube.shape[0], flxcube.shape[1])).reshape(flxcube.shape[0], flxcube.shape[1], 1)
 
     # Generate a sky mask
     newshape = (flxcube.shape[0] * subpixel, flxcube.shape[1] * subpixel)
@@ -530,7 +506,7 @@ def extract_standard_spec(stdcube, subpixel=20, method='boxcar'):
     nsig = 8  # 8 sigma should be far enough
     ww = np.where((np.sqrt((xx - popt[1]) ** 2 + (yy - popt[2]) ** 2) < nsig * wid))
     smask[ww] = 1
-    smask = rebinND(smask, (flxcube.shape[0], flxcube.shape[1])).reshape(flxcube.shape[0], flxcube.shape[1], 1)
+    smask = utils.rebinND(smask, (flxcube.shape[0], flxcube.shape[1])).reshape(flxcube.shape[0], flxcube.shape[1], 1)
     smask -= mask
 
     # Subtract the residual sky

--- a/pypeit/core/procimg.py
+++ b/pypeit/core/procimg.py
@@ -217,7 +217,7 @@ def lacosmic(sciframe, saturation=None, nonlinear=1., bpm=None, varframe=None, m
         msgs.info("Convolving image with Laplacian kernel")
         deriv = convolve(boxcar_replicate(_sciframe, 2), laplkernel, normalize_kernel=False,
                          boundary='extend')
-        s = utils.rebin_evlist(np.clip(deriv, 0, None), _sciframe.shape) * _inv_err / 2.0 
+        s = utils.rebinND(np.clip(deriv, 0, None), _sciframe.shape) * _inv_err / 2.0
 
         # Remove the large structures
         sp = s - scipy.ndimage.median_filter(s, size=5, mode='mirror')

--- a/pypeit/deprecated/procimg.py
+++ b/pypeit/deprecated/procimg.py
@@ -50,7 +50,7 @@ def lacosmic(sciframe, saturation, nonlinear, varframe=None, maxiter=1, grow=1.5
         subsam = utils.subsample(scicopy)
         conved = signal.convolve2d(subsam, laplkernel, mode="same", boundary="symm")
         cliped = conved.clip(min=0.0)
-        lplus = utils.rebin_evlist(cliped, np.array(cliped.shape)/2.0)
+        lplus = utils.rebinND(cliped, np.array(cliped.shape)/2.0)
 
         msgs.info("Creating noise model")
         # Build a custom noise map, and compare  this to the laplacian

--- a/pypeit/spectrographs/gemini_gnirs.py
+++ b/pypeit/spectrographs/gemini_gnirs.py
@@ -82,6 +82,9 @@ class GeminiGNIRSSpectrograph(spectrograph.Spectrograph):
         par['calibrations']['flatfield']['tweak_slits_thresh'] = 0.90
         par['calibrations']['flatfield']['tweak_slits_maxfrac'] = 0.10
 
+        # Relatively short slit, so keep the spatial tilt order low
+        par['calibrations']['tilts']['spat_order'] = 1
+
         # Reduce parameters
         #par['reduce']['findobj']['snr_thresh'] = 5.0          # Object finding threshold
         par['reduce']['findobj']['find_trim_edge'] = [2,2]    # Slit is too short to trim 5,5 especially
@@ -167,6 +170,7 @@ class GeminiGNIRSSpectrograph(spectrograph.Spectrograph):
             par['calibrations']['tilts']['tracethresh'] = [5.0, 10, 10, 10, 10, 10]
             par['calibrations']['tilts']['sig_neigh'] = 5.0
             par['calibrations']['tilts']['nfwhm_neigh'] = 2.0
+
         # 10/mmLBSX_G5532 setup, covering YJHK with the long blue camera and SXD prism
         elif '10/mmLBSX' in self.dispname:
             # Edges

--- a/pypeit/spectrographs/gemini_gnirs.py
+++ b/pypeit/spectrographs/gemini_gnirs.py
@@ -160,7 +160,7 @@ class GeminiGNIRSSpectrograph(spectrograph.Spectrograph):
             # JFH This is provisional these IDs should be checked.
             par['calibrations']['wavelengths']['echelle'] = True
             par['calibrations']['wavelengths']['ech_nspec_coeff'] = 3
-            par['calibrations']['wavelengths']['ech_norder_coeff'] = 5
+            par['calibrations']['wavelengths']['ech_norder_coeff'] = 4
             par['calibrations']['wavelengths']['ech_sigrej'] = 3.0
 
             # Tilts

--- a/pypeit/spectrographs/gemini_gnirs.py
+++ b/pypeit/spectrographs/gemini_gnirs.py
@@ -160,7 +160,7 @@ class GeminiGNIRSSpectrograph(spectrograph.Spectrograph):
             # JFH This is provisional these IDs should be checked.
             par['calibrations']['wavelengths']['echelle'] = True
             par['calibrations']['wavelengths']['ech_nspec_coeff'] = 3
-            par['calibrations']['wavelengths']['ech_norder_coeff'] = 4
+            par['calibrations']['wavelengths']['ech_norder_coeff'] = 5
             par['calibrations']['wavelengths']['ech_sigrej'] = 3.0
 
             # Tilts

--- a/pypeit/tests/test_procimg.py
+++ b/pypeit/tests/test_procimg.py
@@ -143,5 +143,5 @@ def test_boxcar():
     a = np.arange(100).reshape(10,10).astype(float)
     arep = procimg.boxcar_replicate(a, 2)
     assert np.array_equal(procimg.boxcar_average(arep, 2), a), 'Bad replicate/average'
-    assert np.array_equal(utils.rebin_evlist(arep, a.shape), a), 'Bad replicate/rebin'
+    assert np.array_equal(utils.rebinND(arep, a.shape), a), 'Bad replicate/rebin'
 

--- a/pypeit/utils.py
+++ b/pypeit/utils.py
@@ -477,7 +477,8 @@ def rebinND(img, shape):
     Rebin a 2D image to a smaller shape. For example, if img.shape=(100,100),
     then shape=(10,10) would take the mean of the first 10x10 pixels into a
     single output pixel, then the mean of the next 10x10 pixels will be output
-    into the next pixel
+    into the next pixel. Note that img.shape must be an integer multiple of the
+    elements in the new shape.
 
     Args:
         img (`numpy.ndarray`_):

--- a/pypeit/utils.py
+++ b/pypeit/utils.py
@@ -519,7 +519,7 @@ def rebinND(img, shape):
             should be an integer multiple of the elements of shape.
 
     Returns:
-        img_out (`numpy.ndarray`_): The input image rebinned to shape
+        `numpy.ndarray`_: The input image rebinned to shape
     """
     # First check that the old shape is an integer multiple of the new shape
     rem0, rem1 = img.shape[0] % shape[0], img.shape[1] % shape[1]

--- a/pypeit/utils.py
+++ b/pypeit/utils.py
@@ -479,8 +479,9 @@ def rebin_slice(a, newshape):
     from: https://scipy-cookbook.readthedocs.io/items/Rebinning.html.
     The image shapes need not be integer multiples of each other, but in
     this regime the transformation will not be reversible, i.e. if
-    a_orig = rebin(rebin(a,newshape), a.shape) then a_orig will not be
-    everywhere equal to a (but it will be equal in most places).
+    a_orig = rebin_slice(rebin_slice(a,newshape), a.shape) then a_orig will not be
+    everywhere equal to a (but it will be equal in most places). To rebin and
+    conserve flux, use the `pypeit.utils.rebinND()` function (see below).
 
     Args:
         a (ndarray, any dtype):

--- a/pypeit/utils.py
+++ b/pypeit/utils.py
@@ -472,6 +472,36 @@ def index_of_x_eq_y(x, y, strict=False):
     return x2y
 
 
+def rebin_slice(a, newshape):
+    """
+
+    Rebin an array to a new shape using slicing. This routine is taken
+    from: https://scipy-cookbook.readthedocs.io/items/Rebinning.html.
+    The image shapes need not be integer multiples of each other, but in
+    this regime the transformation will not be reversible, i.e. if
+    a_orig = rebin(rebin(a,newshape), a.shape) then a_orig will not be
+    everywhere equal to a (but it will be equal in most places).
+
+    Args:
+        a (ndarray, any dtype):
+            Image of any dimensionality and data type
+        newshape (tuple):
+            Shape of the new image desired. Dimensionality must be the
+            same as a.
+
+    Returns:
+        ndarray: same dtype as input Image with same values as a
+        rebinning to shape newshape
+    """
+    if not len(a.shape) == len(newshape):
+        msgs.error('Dimension of a image does not match dimension of new requested image shape')
+
+    slices = [slice(0, old, float(old) / new) for old, new in zip(a.shape, newshape)]
+    coordinates = np.mgrid[slices]
+    indices = coordinates.astype('i')  # choose the biggest smaller integer index
+    return a[tuple(indices)]
+
+
 def rebinND(img, shape):
     """
     Rebin a 2D image to a smaller shape. For example, if img.shape=(100,100),
@@ -490,6 +520,12 @@ def rebinND(img, shape):
     Returns:
         img_out (`numpy.ndarray`_): The input image rebinned to shape
     """
+    # First check that the old shape is an integer multiple of the new shape
+    rem0, rem1 = img.shape[0] % shape[0], img.shape[1] % shape[1]
+    if rem0 != 0 or rem1 != 0:
+        # In this case, the shapes are not an integer multiple... need to slice
+        msgs.warn("Input image shape is not an integer multiple of the requested shape. Flux is not conserved.")
+        return rebin_slice(img, shape)
     # Convert input 2D image into a 4D array to make the rebinning easier
     sh = shape[0], img.shape[0]//shape[0], shape[1], img.shape[1]//shape[1]
     # Rebin to the 4D array and then average over the second and last elements.


### PR DESCRIPTION
This PR offers a hotfix for rebinning. It cleans up the ugly evlist version of rebinning (with a speedup - see timings below) and removes the old "rebin" function which is really just slicing, and not rebinning (i.e. the old version doesn't conserve flux).

<img width="552" alt="image" src="https://github.com/pypeit/PypeIt/assets/12585758/7cc204c4-bd95-4191-9ff3-b88f671a8e85">