### PR TITLE
Hotfix for parset

### DIFF
--- a/pypeit/par/parset.py
+++ b/pypeit/par/parset.py
@@ -488,8 +488,10 @@ class ParSet:
             except:
                 pass
             if not exclude_defaults or par[k] != par.default[k]:
-                lines += [ component_indent + k + ' = ' + ParSet._data_string(par[k]) ]
-
+                argvalue = ParSet._data_string(par[k])
+                if isinstance(par[k], list):
+                    argvalue += ','
+                lines += [ component_indent + k + ' = ' + argvalue ]
         # Then add the items that are ParSets as subsections
         for k in parset_keys:
             section_comment = None

--- a/pypeit/par/pypeitpar.py
+++ b/pypeit/par/pypeitpar.py
@@ -939,7 +939,7 @@ class AlignPar(ParSet):
         # Fill out parameter specifications.  Only the values that are
         # *not* None (i.e., the ones that are defined) need to be set
 
-        defaults['locations'] = [0.0, 0.5, 1.0]
+        defaults['locations'] = [0.0, 1.0]
         dtypes['locations'] = [list, np.ndarray]
         descr['locations'] = 'Locations of the bars, in a list, specified as a fraction of the slit width'
 

--- a/pypeit/tests/test_pypeitpar.py
+++ b/pypeit/tests/test_pypeitpar.py
@@ -8,6 +8,7 @@ from IPython import embed
 import pytest
 
 from pypeit.par import pypeitpar
+from pypeit.par import parset
 from pypeit.par import util
 from pypeit.spectrographs.util import load_spectrograph
 from pypeit.tests.tstutils import data_path
@@ -173,3 +174,20 @@ def test_fail_badlevel():
                                                 merge_with=(cfg_lines,))  #Once as tuple
 
 
+def test_lists():
+    test_parset = pypeitpar.AlignPar()
+    test_parset['locations'] = [0.0]
+
+    _p = pypeitpar.PypeItPar.from_cfg_lines(cfg_lines=p.to_config(),
+                                            merge_with=(cfg_lines,))  # Once as tuple
+    assert(isinstance(_p['calibrations']['alignment']['locations'], list))
+    assert(len(_p['calibrations']['alignment']['locations']) == 1)
+    assert (_p['calibrations']['alignment']['locations'][0] == 0.5)
+
+    cfg_lines = ['[calibrations]', '[[alignment]]', 'locations = [0.0, 1.0]']
+    _p = pypeitpar.PypeItPar.from_cfg_lines(cfg_lines=p.to_config(),
+                                            merge_with=(cfg_lines,))  # Once as tuple
+    assert(isinstance(_p['calibrations']['alignment']['locations'], list))
+    assert(len(_p['calibrations']['alignment']['locations']) == 2)
+    assert (_p['calibrations']['alignment']['locations'][0] == 0.0)
+    assert (_p['calibrations']['alignment']['locations'][1] == 1.0)

--- a/pypeit/tests/test_pypeitpar.py
+++ b/pypeit/tests/test_pypeitpar.py
@@ -175,19 +175,25 @@ def test_fail_badlevel():
 
 
 def test_lists():
-    test_parset = pypeitpar.AlignPar()
-    test_parset['locations'] = [0.0]
+    # Initialise the parset
+    p = load_spectrograph('keck_kcwi').default_pypeit_par()
 
-    _p = pypeitpar.PypeItPar.from_cfg_lines(cfg_lines=p.to_config(),
-                                            merge_with=(cfg_lines,))  # Once as tuple
+    # Test with a single element list
+    p['calibrations']['alignment']['locations'] = [0.5]
+    _p = pypeitpar.PypeItPar.from_cfg_lines(cfg_lines=p.to_config())  # Once as tuple
     assert(isinstance(_p['calibrations']['alignment']['locations'], list))
     assert(len(_p['calibrations']['alignment']['locations']) == 1)
     assert (_p['calibrations']['alignment']['locations'][0] == 0.5)
 
-    cfg_lines = ['[calibrations]', '[[alignment]]', 'locations = [0.0, 1.0]']
-    _p = pypeitpar.PypeItPar.from_cfg_lines(cfg_lines=p.to_config(),
-                                            merge_with=(cfg_lines,))  # Once as tuple
+    # Test with a multi-element list
+    p['calibrations']['alignment']['locations'] = [0.0, 1.0]
+    _p = pypeitpar.PypeItPar.from_cfg_lines(cfg_lines=p.to_config())  # Once as tuple
     assert(isinstance(_p['calibrations']['alignment']['locations'], list))
     assert(len(_p['calibrations']['alignment']['locations']) == 2)
     assert (_p['calibrations']['alignment']['locations'][0] == 0.0)
     assert (_p['calibrations']['alignment']['locations'][1] == 1.0)
+
+    # Test something that should fail
+    with pytest.raises(TypeError):
+        p['calibrations']['alignment']['locations'] = 0.0
+        _p = pypeitpar.PypeItPar.from_cfg_lines(cfg_lines=p.to_config())  # Once as tuple


### PR DESCRIPTION
This hotfix fixes the single element list error in the parset. For further details, see Issue #842...