### PR TITLE
Air2vac correction for XShooter standards

### DIFF
--- a/pypeit/core/flux_calib.py
+++ b/pypeit/core/flux_calib.py
@@ -27,6 +27,7 @@ from pypeit import io
 from pypeit.wavemodel import conv2res
 from pypeit.core.wavecal import wvutils
 from pypeit.core import fitting
+from pypeit.core import wave
 from pypeit import data
 
 
@@ -199,6 +200,8 @@ def find_standard_file(ra, dec, toler=20.*units.arcmin, check=False):
                 std_dict['wave'] = std_spec['col1'] * units.AA
                 std_dict['flux'] = std_spec['col2'] / PYPEIT_FLUX_SCALE * \
                                    units.erg / units.s / units.cm ** 2 / units.AA
+                # Xshooter standard files use air wavelengths, convert them to vacuum
+                std_dict['wave'] = wave.airtovac(std_dict['wave'])
             elif sset == 'calspec':
                 std_dict['std_source'] = sset
                 std_spec = io.fits_open(fil)[1].data

--- a/pypeit/data/standards/xshooter/xshooter_info.txt
+++ b/pypeit/data/standards/xshooter/xshooter_info.txt
@@ -10,6 +10,7 @@
 #The flux distribution over the full X-shooter range 3000 – 25000A is tabulated.
 #The fluxes are sampled (at 0.1A [< 1000A] and 0.2A [>10000A]).
 #The flux tabluations are in units of (ergs cm-2 s-1 A-1).
+#NOTE: The wavelengths are in air, as output by the ESO pipeline.
 #http://www.eso.org/sci/observing/tools/standards/spectra/Xshooterspec.html
   File                Name        RA_2000    DEC_2000	 V_MAG   TYPE
 fGD71.dat            GD71      05:52:27.61 +15:53:13.8	 13.03	  DA1


### PR DESCRIPTION
Finally addressing (at least one part of) https://github.com/pypeit/PypeIt/issues/941, as the issue has become even more obvious for the UVB arm of XShooter. 

Might be worth checking whether any of the other standard files also need this fix...
