### PR TITLE
Hotfix for view_fits

### DIFF
--- a/pypeit/par/pypeitpar.py
+++ b/pypeit/par/pypeitpar.py
@@ -3771,7 +3771,7 @@ class FindObjPar(ParSet):
 
         defaults['find_min_max'] = None
         dtypes['find_min_max'] = list
-        descr['find_min_max'] = 'It defines the minimum and maximum of your object in the spectral direction on the ' \
+        descr['find_min_max'] = 'It defines the minimum and maximum of your object in pixels in the spectral direction on the ' \
                                 'detector. It only used for object finding. This parameter is helpful if your object only ' \
                                 'has emission lines or at high redshift and the trace only shows in part of the detector.'
 

--- a/pypeit/scripts/view_fits.py
+++ b/pypeit/scripts/view_fits.py
@@ -25,8 +25,7 @@ class ViewFits(scriptbase.ScriptBase):
                             help='List the extensions only?')
         parser.add_argument('--proc', default=False, action='store_true',
                             help='Process the image (i.e. orient, overscan subtract, multiply by '
-                                 'gain) using pypeit.images.buildimage. Note det=mosaic will not '
-                                 'work with this option')
+                                 'gain) using pypeit.images.buildimage.')
         parser.add_argument('--bkg_file', type=str, default=None, help='FITS file to be subtracted from the image in file.'
                             '--proc must be set in order for this option to work.')
 
@@ -66,9 +65,6 @@ class ViewFits(scriptbase.ScriptBase):
 
         if args.proc and args.exten is not None:
             msgs.error('You cannot specify --proc and --exten, since --exten shows the raw image')
-#        if args.proc and args.det == 'mosaic':
-#            msgs.error('You cannot specify --proc and --det mosaic, since --mosaic can only '
-#                       'display the raw image mosaic')
         if args.exten is not None and args.det == 'mosaic':
             msgs.error('You cannot specify --exten and --det mosaic, since --mosaic displays '
                        'multiple extensions by definition')
@@ -97,7 +93,6 @@ class ViewFits(scriptbase.ScriptBase):
                 mosaic = len(_det) > 1
                 if not mosaic:
                     _det = _det[0]
-
             if args.proc:
                 # Use the biasframe processing parameters because processing
                 # these frames is independent of any other frames (ie., does not


### PR DESCRIPTION
Documentation fixes for pypeit_view_fits and a minor doc change elsewhere in find objects parset. 

It appears that view_fits is still buggy, i.e. 

pypeit_view_fits gemini_gmos_north_ham N20190205S0035.fits --det mosaic

Only displays one detector. I'm not sure I follow what is going on here, but it seems that an unprocessed mosaic should be display. 