### PR TITLE
Slitmask matching error

### DIFF
--- a/pypeit/edgetrace.py
+++ b/pypeit/edgetrace.py
@@ -839,6 +839,10 @@ class EdgeTraceSet(calibframe.CalibFrame):
             msgs.info('{0:^50}'.format('Matching traces to the slit-mask design'))
             msgs.info('-' * 50)
             self.maskdesign_matching(debug=debug)
+            if show_stages:
+                self.show(title='After matching to slit-mask design metadata.')
+            if np.all(self.bitmask.flagged(self.edge_msk, self.bitmask.bad_flags)):
+                msgs.error('All traces masked!  Problem with mask-design matching.')
 
         if self.par['auto_pca'] and not self.can_pca() and not self.is_empty and self.par['sync_predict'] == 'pca':
             # TODO: This causes the code to fault. Maybe there's a way

--- a/pypeit/edgetrace.py
+++ b/pypeit/edgetrace.py
@@ -842,7 +842,10 @@ class EdgeTraceSet(calibframe.CalibFrame):
             if show_stages:
                 self.show(title='After matching to slit-mask design metadata.')
             if np.all(self.bitmask.flagged(self.edge_msk, self.bitmask.bad_flags)):
-                msgs.error('All traces masked!  Problem with mask-design matching.')
+                msgs.error('All traces masked!  Problem with mask-design matching, which may be '
+                           'due to spurious edges.  Try changing the edge detection threshold '
+                           '(edge_thresh) and troubleshooting the problem using the '
+                           'pypeit_trace_edges script.')
 
         if self.par['auto_pca'] and not self.can_pca() and not self.is_empty and self.par['sync_predict'] == 'pca':
             # TODO: This causes the code to fault. Maybe there's a way

--- a/pypeit/spectrographs/slitmask.py
+++ b/pypeit/spectrographs/slitmask.py
@@ -102,7 +102,7 @@ class SlitMask:
     Attributes:
         corners (`numpy.ndarray`_):
             See above.
-        id (`numpy.ndarray`_):
+        slitid (`numpy.ndarray`_):
             See `slitid` above.
         mask (`numpy.ndarray`_):
             Mask bits selecting the type of slit.
@@ -1028,20 +1028,18 @@ def load_keck_deimoslris(filename:str, instr:str):
     for index in indices:
         for cdim in ['X', 'Y']:
             slit_list.append(hdu['BluSlits'].data[f'slit{cdim}{index}'])
-    slitmask = SlitMask(numpy.array(slit_list).T.reshape(-1,4,2),
-                                slitid=hdu['BluSlits'].data['dSlitId'],
-                                align=hdu['DesiSlits'].data['slitTyp'][indx] == 'A',
-                                science=hdu['DesiSlits'].data['slitTyp'][indx] == 'P',
-                                onsky=numpy.array([hdu['DesiSlits'].data['slitRA'][indx],
-                                                hdu['DesiSlits'].data['slitDec'][indx],
-                                                hdu['DesiSlits'].data['slitLen'][indx],
-                                                hdu['DesiSlits'].data['slitWid'][indx],
-                                                slit_pas]).T,
-                                objects=objects,
-                                #object_names=hdu['ObjectCat'].data['OBJECT'],
-                                mask_radec=(hdu['MaskDesign'].data['RA_PNT'][0], 
-                                            hdu['MaskDesign'].data['DEC_PNT'][0]),
-                                posx_pa=posx_pa)
-    # Return
-    return slitmask
+
+    return SlitMask(numpy.array(slit_list).T.reshape(-1,4,2),
+                    slitid=hdu['BluSlits'].data['dSlitId'],
+                    align=hdu['DesiSlits'].data['slitTyp'][indx] == 'A',
+                    science=hdu['DesiSlits'].data['slitTyp'][indx] == 'P',
+                    onsky=numpy.array([hdu['DesiSlits'].data['slitRA'][indx],
+                                       hdu['DesiSlits'].data['slitDec'][indx],
+                                       hdu['DesiSlits'].data['slitLen'][indx],
+                                       hdu['DesiSlits'].data['slitWid'][indx],
+                                       slit_pas]).T,
+                    objects=objects,
+                    mask_radec=(hdu['MaskDesign'].data['RA_PNT'][0], 
+                                hdu['MaskDesign'].data['DEC_PNT'][0]),
+                    posx_pa=posx_pa)
 


### PR DESCRIPTION
Adds a display command used for debugging and throws an error if all of the slit edges are masked after the slit-design matching.  This catches an error from one of @SunilSimha's DEIMOS datasets.  The solution was to change the `edge_thresh`.  This improved error message hopefully points users in the right direction, compared to the old obscure one that was completely unrelated.

Changes to `slitmask.py` are due to an unrelated OCD moment.