### PR TITLE
Tox CI fix

### DIFF
--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python: ['3.9', '3.10', '3.11']
-        toxenv: [test-alldeps, test-numpydev, test-linetoolsdev, test-gingadev, test-astropydev, conda]
+        toxenv: [test-alldeps, test-numpydev, test-linetoolsdev, test-gingadev, test-astropydev]
     steps:
     - name: Check out repository
       uses: actions/checkout@v3

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -31,4 +31,4 @@ jobs:
         python -m pip install --upgrade pip tox
     - name: Test with tox
       run: |
-        tox -e ${{ matrix.toxenv }}
+        tox -e ${{ matrix.python }}-${{ matrix.toxenv }}

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -62,7 +62,7 @@ jobs:
         python -m pip install --upgrade pip tox
     - name: Test with tox
       run: |
-        tox -e ${{ matrix.toxenv }}
+        tox -e ${{ matrix.python }}-${{ matrix.toxenv }}
 
   conda:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -31,7 +31,7 @@ jobs:
         python -m pip install --upgrade pip tox
     - name: Test with tox
       run: |
-        tox -e ${{ matrix.toxenv }}
+        tox -e ${{ matrix.python }}-${{ matrix.toxenv }}
     - name: Upload coverage to codecov
       if: "contains(matrix.toxenv, '-cov')"
       uses: codecov/codecov-action@v3

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python: ['3.9', '3.10', '3.11']
-        toxenv: [test, test-alldeps-cov, test-linetoolsdev, test-gingadev, test-astropydev, conda]
+        toxenv: [test, test-alldeps-cov, test-linetoolsdev, test-gingadev, test-astropydev]
     steps:
     - name: Check out repository
       uses: actions/checkout@v3
@@ -63,6 +63,21 @@ jobs:
     - name: Test with tox
       run: |
         tox -e ${{ matrix.toxenv }}
+
+  conda:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Conda environment check
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+    - name: Install base dependencies
+      run: |
+        python -m pip install --upgrade pip tox
+    - name: Run pypeit tests from environment built with conda
+      run: |
+        tox -e conda
 
   codestyle:
     runs-on: ubuntu-latest

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    py{39,310,311}-test{,-alldeps,-shapely,-specutils}{,-cov}
-    py{39,310,311}-test-numpy{120,121,122,123}
-    py{39,310,311}-test-{numpy,astropy,linetools,ginga}dev
+    {3.9,3.10,3.11}-test{,-alldeps,-shapely,-specutils}{,-cov}
+    {3.9,3.10,3.11}-test-numpy{120,121,122,123}
+    {3.9,3.10,3.11}-test-{numpy,astropy,linetools,ginga}dev
     codestyle
 requires =
     setuptools >= 30.3.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     {3.9,3.10,3.11}-test{,-alldeps,-shapely,-specutils}{,-cov}
-    {3.9,3.10,3.11}-test-numpy{120,121,122,123}
+    {3.9,3.10,3.11}-test-numpy{122,123,124,125}
     {3.9,3.10,3.11}-test-{numpy,astropy,linetools,ginga}dev
     codestyle
 requires =
@@ -36,21 +36,19 @@ description =
     devdeps: with the latest developer version of key dependencies
     oldestdeps: with the oldest supported version of key dependencies
     cov: and test coverage
-    numpy120: with numpy 1.20.*
-    numpy121: with numpy 1.21.*
     numpy122: with numpy 1.22.*
     numpy123: with numpy 1.23.*
     numpy124: with numpy 1.24.*
+    numpy125: with numpy 1.25.*
 
 # The following provides some specific pinnings for key packages
 deps =
 
     cov: coverage
-    numpy120: numpy==1.20.*
-    numpy121: numpy==1.21.*
     numpy122: numpy==1.22.*
     numpy123: numpy==1.23.*
     numpy124: numpy==1.24.*
+    numpy125: numpy==1.25.*
 
     numpydev: numpy>=0.0.dev0
     astropydev: git+https://github.com/astropy/astropy.git#egg=astropy


### PR DESCRIPTION
It looks like `tox` became more pedantic about environment names exactly matching what's in `tox.ini`. Previously, one could leave off, say, the `py311-` at the beginning of an environment name and `tox` would assume the available python version is 3.11 and carry on. Now it only works if there is an exact match in `tox list`. This PR tweaks `tox.ini` and the CI workflows to use python version format that is consistent and create fully qualifies tox environments in the workflows.