### PR TITLE
slitspatnum bug

### DIFF
--- a/pypeit/core/parse.py
+++ b/pypeit/core/parse.py
@@ -150,8 +150,6 @@ def parse_binning(binning:str):
     return binspectral, binspatial
 
 
-# TODO: Allow this to differentiate between detectors and mosaics.  Input syntax
-# likely to become, e.g., DET01:175,DET01:205.
 def parse_slitspatnum(slitspatnum):
     """
     Parse the ``slitspatnum`` into a list of detectors and SPAT_IDs.
@@ -170,17 +168,6 @@ def parse_slitspatnum(slitspatnum):
     _slitspatnum = np.concatenate([item.split(',') for item in _slitspatnum])
     _slitspatnum = np.array([item.split(':') for item in _slitspatnum])
     return _slitspatnum[:,0], _slitspatnum[:,1].astype(int)
-
-    dets = []
-    spat_ids = []
-    if isinstance(slitspatnum,list):
-        slitspatnum = ",".join(slitspatnum)
-    for item in slitspatnum.split(','):
-        spt = item.split(':')
-        dets.append(spt[0])
-        spat_ids.append(int(spt[1]))
-    # Return
-    return np.array(dets).astype(str), np.array(spat_ids).astype(int)
 
 
 def sec2slice(subarray, one_indexed=False, include_end=False, require_dim=None, binning=None):

--- a/pypeit/core/parse.py
+++ b/pypeit/core/parse.py
@@ -149,6 +149,7 @@ def parse_binning(binning:str):
     # Return
     return binspectral, binspatial
 
+
 # TODO: Allow this to differentiate between detectors and mosaics.  Input syntax
 # likely to become, e.g., DET01:175,DET01:205.
 def parse_slitspatnum(slitspatnum):
@@ -165,6 +166,11 @@ def parse_slitspatnum(slitspatnum):
         array is ``(nslits,)``, where ``nslits`` is the number of
         ``slitspatnum`` entries parsed (1 if only a single string is provided).
     """
+    _slitspatnum = slitspatnum if isinstance(slitspatnum,list) else [slitspatnum]
+    _slitspatnum = np.concatenate([item.split(',') for item in _slitspatnum])
+    _slitspatnum = np.array([item.split(':') for item in _slitspatnum])
+    return _slitspatnum[:,0], _slitspatnum[:,1].astype(int)
+
     dets = []
     spat_ids = []
     if isinstance(slitspatnum,list):

--- a/pypeit/spectrographs/keck_deimos.py
+++ b/pypeit/spectrographs/keck_deimos.py
@@ -30,7 +30,7 @@ from pypeit.core import framematch
 from pypeit.core import wave
 from pypeit import specobj, specobjs
 from pypeit.spectrographs import spectrograph
-from pypeit.images import detector_container
+from pypeit.images.detector_container import DetectorContainer
 from pypeit import data
 from pypeit.images.mosaic import Mosaic
 from pypeit.core.mosaic import build_image_mosaic_transform
@@ -251,7 +251,7 @@ class KeckDEIMOSSpectrograph(spectrograph.Spectrograph):
         detectors = [detector_dict1, detector_dict2, detector_dict3, detector_dict4,
                      detector_dict5, detector_dict6, detector_dict7, detector_dict8]
         # Return
-        return detector_container.DetectorContainer(**detectors[det-1])
+        return DetectorContainer(**detectors[det-1])
 
     @classmethod
     def default_pypeit_par(cls):
@@ -1524,11 +1524,8 @@ class KeckDEIMOSSpectrograph(spectrograph.Spectrograph):
             the array is 2D, there are detectors separated along the dispersion
             axis.
         """
-        if mosaic:
-            return np.array([self.get_det_name(_det) for _det in self.allowed_mosaics])
-        else:
-            return np.array([detector_container.DetectorContainer.get_name(i+1)
-                             for i in range(self.ndet)]).reshape(2,-1)
+        dets = super().list_detectors(mosaic=mosaic)
+        return dets if mosaic else dets.reshape(2,-1)
 
     def spec1d_match_spectra(self, sobjs):
         """
@@ -1549,7 +1546,7 @@ class KeckDEIMOSSpectrograph(spectrograph.Spectrograph):
         # MATCH RED TO BLUE VIA RA/DEC
 #        mb = sobjs['DET'] <=4
 #        mr = sobjs['DET'] >4
-        det = np.array([detector_container.DetectorContainer.parse_name(d) for d in sobjs.DET])
+        det = np.array([DetectorContainer.parse_name(d) for d in sobjs.DET])
         mb = det <= 4
         mr = det > 4
 

--- a/pypeit/spectrographs/keck_hires.py
+++ b/pypeit/spectrographs/keck_hires.py
@@ -509,7 +509,6 @@ class KECKHIRESSpectrograph(spectrograph.Spectrograph):
     def default_mosaic(self):
         return self.allowed_mosaics[0]
 
-
     def get_detector_par(self, det, hdu=None):
         """
         Return metadata for the selected detector.

--- a/pypeit/spectrographs/keck_mosfire.py
+++ b/pypeit/spectrographs/keck_mosfire.py
@@ -876,39 +876,40 @@ class KeckMOSFIRESpectrograph(spectrograph.Spectrograph):
         #    plt.show()
 
 
-    def list_detectors(self, mosaic=False):
-        """
-        List the *names* of the detectors in this spectrograph.
-
-        This is primarily used :func:`~pypeit.slittrace.average_maskdef_offset`
-        to measure the mean offset between the measured and expected slit
-        locations.
-
-        Detectors separated along the dispersion direction should be ordered
-        along the first axis of the returned array.  For example, Keck/DEIMOS
-        returns:
-        
-        .. code-block:: python
-        
-            dets = np.array([['DET01', 'DET02', 'DET03', 'DET04'],
-                             ['DET05', 'DET06', 'DET07', 'DET08']])
-
-        such that all the bluest detectors are in ``dets[0]``, and the slits
-        found in detectors 1 and 5 are just from the blue and red counterparts
-        of the same slit.
-
-        Args:
-            mosaic (:obj:`bool`, optional):
-                Is this a mosaic reduction?
-                It is used to determine how to list the detector, i.e., 'DET' or 'MSC'.
-
-        Returns:
-            `numpy.ndarray`_: The list of detectors in a `numpy.ndarray`_.  If
-            the array is 2D, there are detectors separated along the dispersion
-            axis.
-        """
-        return np.array([detector_container.DetectorContainer.get_name(i+1) 
-                            for i in range(self.ndet)])
+# NOTE: This now uses the base class function
+#    def list_detectors(self, mosaic=False):
+#        """
+#        List the *names* of the detectors in this spectrograph.
+#
+#        This is primarily used :func:`~pypeit.slittrace.average_maskdef_offset`
+#        to measure the mean offset between the measured and expected slit
+#        locations.
+#
+#        Detectors separated along the dispersion direction should be ordered
+#        along the first axis of the returned array.  For example, Keck/DEIMOS
+#        returns:
+#        
+#        .. code-block:: python
+#        
+#            dets = np.array([['DET01', 'DET02', 'DET03', 'DET04'],
+#                             ['DET05', 'DET06', 'DET07', 'DET08']])
+#
+#        such that all the bluest detectors are in ``dets[0]``, and the slits
+#        found in detectors 1 and 5 are just from the blue and red counterparts
+#        of the same slit.
+#
+#        Args:
+#            mosaic (:obj:`bool`, optional):
+#                Is this a mosaic reduction?
+#                It is used to determine how to list the detector, i.e., 'DET' or 'MSC'.
+#
+#        Returns:
+#            `numpy.ndarray`_: The list of detectors in a `numpy.ndarray`_.  If
+#            the array is 2D, there are detectors separated along the dispersion
+#            axis.
+#        """
+#        return np.array([detector_container.DetectorContainer.get_name(i+1) 
+#                            for i in range(self.ndet)])
 
     def get_slitmask(self, filename):
         """

--- a/pypeit/spectrographs/keck_mosfire.py
+++ b/pypeit/spectrographs/keck_mosfire.py
@@ -875,42 +875,6 @@ class KeckMOSFIRESpectrograph(spectrograph.Spectrograph):
         #    plt.legend()
         #    plt.show()
 
-
-# NOTE: This now uses the base class function
-#    def list_detectors(self, mosaic=False):
-#        """
-#        List the *names* of the detectors in this spectrograph.
-#
-#        This is primarily used :func:`~pypeit.slittrace.average_maskdef_offset`
-#        to measure the mean offset between the measured and expected slit
-#        locations.
-#
-#        Detectors separated along the dispersion direction should be ordered
-#        along the first axis of the returned array.  For example, Keck/DEIMOS
-#        returns:
-#        
-#        .. code-block:: python
-#        
-#            dets = np.array([['DET01', 'DET02', 'DET03', 'DET04'],
-#                             ['DET05', 'DET06', 'DET07', 'DET08']])
-#
-#        such that all the bluest detectors are in ``dets[0]``, and the slits
-#        found in detectors 1 and 5 are just from the blue and red counterparts
-#        of the same slit.
-#
-#        Args:
-#            mosaic (:obj:`bool`, optional):
-#                Is this a mosaic reduction?
-#                It is used to determine how to list the detector, i.e., 'DET' or 'MSC'.
-#
-#        Returns:
-#            `numpy.ndarray`_: The list of detectors in a `numpy.ndarray`_.  If
-#            the array is 2D, there are detectors separated along the dispersion
-#            axis.
-#        """
-#        return np.array([detector_container.DetectorContainer.get_name(i+1) 
-#                            for i in range(self.ndet)])
-
     def get_slitmask(self, filename):
         """
         Parse the slitmask data from a MOSFIRE file into :attr:`slitmask`, a

--- a/pypeit/spectrographs/lbt_mods.py
+++ b/pypeit/spectrographs/lbt_mods.py
@@ -310,7 +310,7 @@ class LBTMODS1RSpectrograph(LBTMODSSpectrograph):
 #            datasec         = np.atleast_1d('[:,:]'),
 #            oscansec        = np.atleast_1d('[:,:]')
             )
-        return detector_container.DetectorContainer(**detector_dict)
+        return DetectorContainer(**detector_dict)
 
     @classmethod
     def default_pypeit_par(cls):
@@ -474,7 +474,7 @@ class LBTMODS1BSpectrograph(LBTMODSSpectrograph):
 #            datasec         = np.atleast_1d('[:,:]'),
 #            oscansec        = np.atleast_1d('[:,:]')
             )
-        return detector_container.DetectorContainer(**detector_dict)
+        return DetectorContainer(**detector_dict)
 
     @classmethod
     def default_pypeit_par(cls):
@@ -631,7 +631,7 @@ class LBTMODS2RSpectrograph(LBTMODSSpectrograph):
 #            datasec         = np.atleast_1d('[:,:]'),
 #            oscansec        = np.atleast_1d('[:,:]')
             )
-        return detector_container.DetectorContainer(**detector_dict)
+        return DetectorContainer(**detector_dict)
 
     @classmethod
     def default_pypeit_par(cls):

--- a/pypeit/spectrographs/lbt_mods.py
+++ b/pypeit/spectrographs/lbt_mods.py
@@ -14,7 +14,7 @@ from pypeit.core import framematch
 from pypeit.par import pypeitpar
 from pypeit.spectrographs import spectrograph
 from pypeit.core import parse
-from pypeit.images import detector_container
+from pypeit.images.detector_container import DetectorContainer
 
 # TODO: FW: test MODS1B and MODS2B
 
@@ -793,7 +793,7 @@ class LBTMODS2BSpectrograph(LBTMODSSpectrograph):
 #            datasec         = np.atleast_1d('[:,:]'),
 #            oscansec        = np.atleast_1d('[:,:]')
             )
-        return detector_container.DetectorContainer(**detector_dict)
+        return DetectorContainer(**detector_dict)
 
     @classmethod
     def default_pypeit_par(cls):

--- a/pypeit/spectrographs/spectrograph.py
+++ b/pypeit/spectrographs/spectrograph.py
@@ -40,7 +40,7 @@ from pypeit.core import parse
 from pypeit.core import procimg
 from pypeit.core import meta
 from pypeit.par import pypeitpar
-from pypeit.images import detector_container
+from pypeit.images.detector_container import DetectorContainer
 from pypeit.images.mosaic import Mosaic
 
 
@@ -611,11 +611,10 @@ class Spectrograph:
             the array is 2D, there are detectors separated along the dispersion
             axis.
         """
-
-        if mosaic:
-            return np.array([self.get_det_name(_det) for _det in self.allowed_mosaics])
-        else:
-            return np.array([detector_container.DetectorContainer.get_name(i + 1) for i in range(self.ndet)])
+        if mosaic and len(self.allowed_mosaics) == 0:
+            msgs.error(f'Spectrograph {self.name} does not have any defined detector mosaics.')
+        dets = self.allowed_mosaics if mosaic else range(1,self.ndet+1)
+        return np.array([self.get_det_name(det) for det in dets])
 
 
     def get_lamps(self, fitstbl):
@@ -993,7 +992,7 @@ class Spectrograph:
         # Single detector
         if det <= 0 or det > self.ndet:
             msgs.error(f'{det} is not a valid detector for {self.name}.')
-        return detector_container.DetectorContainer.get_name(det)
+        return DetectorContainer.get_name(det)
 
     def get_det_id(self, det):
         """

--- a/pypeit/spectrographs/spectrograph.py
+++ b/pypeit/spectrographs/spectrograph.py
@@ -40,7 +40,7 @@ from pypeit.core import parse
 from pypeit.core import procimg
 from pypeit.core import meta
 from pypeit.par import pypeitpar
-from pypeit.images.detector_container import DetectorContainer
+from pypeit.images import detector_container
 from pypeit.images.mosaic import Mosaic
 
 
@@ -586,7 +586,7 @@ class Spectrograph:
 
         This is primarily used :func:`~pypeit.slittrace.average_maskdef_offset`
         to measure the mean offset between the measured and expected slit
-        locations.  **This method is not defined for all spectrographs.**
+        locations.
 
         Detectors separated along the dispersion direction should be ordered
         along the first axis of the returned array.  For example, Keck/DEIMOS
@@ -611,7 +611,12 @@ class Spectrograph:
             the array is 2D, there are detectors separated along the dispersion
             axis.
         """
-        return None
+
+        if mosaic:
+            return np.array([self.get_det_name(_det) for _det in self.allowed_mosaics])
+        else:
+            return np.array([detector_container.DetectorContainer.get_name(i + 1) for i in range(self.ndet)])
+
 
     def get_lamps(self, fitstbl):
         """
@@ -988,7 +993,7 @@ class Spectrograph:
         # Single detector
         if det <= 0 or det > self.ndet:
             msgs.error(f'{det} is not a valid detector for {self.name}.')
-        return DetectorContainer.get_name(det)
+        return detector_container.DetectorContainer.get_name(det)
 
     def get_det_id(self, det):
         """
@@ -1059,7 +1064,10 @@ class Spectrograph:
             for ss in subset_list:
                 parsed_det = parse.parse_slitspatnum(ss)[0][0]
                 if 'DET' in parsed_det:
-                    idx = np.where(self.list_detectors().flatten() == parsed_det)[0][0]
+                    try:
+                        idx = np.where(self.list_detectors().flatten() == parsed_det)[0][0]
+                    except:
+                        embed()
                     new_dets.append(idx+1)
                 elif 'MSC' in parsed_det:
                     idx = np.where(self.list_detectors(mosaic=True) == parsed_det)[0][0]

--- a/pypeit/spectrographs/spectrograph.py
+++ b/pypeit/spectrographs/spectrograph.py
@@ -1064,10 +1064,7 @@ class Spectrograph:
             for ss in subset_list:
                 parsed_det = parse.parse_slitspatnum(ss)[0][0]
                 if 'DET' in parsed_det:
-                    try:
-                        idx = np.where(self.list_detectors().flatten() == parsed_det)[0][0]
-                    except:
-                        embed()
+                    idx = np.where(self.list_detectors().flatten() == parsed_det)[0][0]
                     new_dets.append(idx+1)
                 elif 'MSC' in parsed_det:
                     idx = np.where(self.list_detectors(mosaic=True) == parsed_det)[0][0]

--- a/pypeit/tests/test_parse.py
+++ b/pypeit/tests/test_parse.py
@@ -1,8 +1,8 @@
 """
 Module to run tests on arparse
 """
+from IPython import embed
 import numpy as np
-import pytest
 
 from pypeit.core import parse
 
@@ -39,5 +39,20 @@ def test_str2list():
     assert np.array_equal(parse.str2list('3:5,8:', length=10), [3,4,8,9])
     assert np.array_equal(parse.str2list('3,1:5,6', length=10), [1,2,3,4,6])
     assert np.array_equal(parse.str2list('3,1:5,8:', length=10), [1,2,3,4,8,9])
+
+
+def test_parse_slitspatnum():
+    assert [x[0] for x in parse.parse_slitspatnum('DET01:224')] == ['DET01', 224], \
+        'Bad parsing for single pair'
+    assert [x[0] for x in parse.parse_slitspatnum(['DET01:224'])]  == ['DET01', 224], \
+        'Bad parsing for single list pair'
+    assert [x.tolist() for x in parse.parse_slitspatnum('DET01:224,DET02:331')] \
+        == [['DET01', 'DET02'], [224, 331]], 'Bad parsing of comma-separated pairs'
+    assert [x.tolist() for x in parse.parse_slitspatnum(['DET01:224,DET02:331'])] \
+        == [['DET01', 'DET02'], [224, 331]], 'Bad parsing of comma-separated pairs list'
+    assert [x.tolist() for x in parse.parse_slitspatnum(['DET01:224', 'DET02:331'])] \
+        == [['DET01', 'DET02'], [224, 331]], 'Bad parsing of list of pairs'
+    assert [x.tolist() for x in parse.parse_slitspatnum(['DET01:224,DET02:331', 'DET03:442'])] \
+        == [['DET01', 'DET02', 'DET03'], [224, 331, 442]], 'Bad mixed parsing'
 
     

--- a/pypeit/tests/test_spectrographs.py
+++ b/pypeit/tests/test_spectrographs.py
@@ -90,6 +90,16 @@ def test_list_detectors_mods():
         mosaics = mods.list_detectors(mosaic=True)
 
 
+def test_list_detectors_hires():
+    hires = load_spectrograph('keck_hires')
+    dets = hires.list_detectors()
+    assert dets.ndim == 1, 'HIRES has a 1D array of detectors'
+    assert dets.size == 3, 'HIRES has 1 detector'
+    mosaics = hires.list_detectors(mosaic=True)
+    assert mosaics.ndim == 1, 'Mosaics are listed as 1D arrays'
+    assert mosaics.size == 1, 'HIRES has 1 predefined mosaic'
+
+
 def test_configs():
 
     spec = load_spectrograph('keck_deimos')

--- a/pypeit/tests/test_spectrographs.py
+++ b/pypeit/tests/test_spectrographs.py
@@ -94,7 +94,7 @@ def test_list_detectors_hires():
     hires = load_spectrograph('keck_hires')
     dets = hires.list_detectors()
     assert dets.ndim == 1, 'HIRES has a 1D array of detectors'
-    assert dets.size == 3, 'HIRES has 1 detector'
+    assert dets.size == 3, 'HIRES has 3 detectors'
     mosaics = hires.list_detectors(mosaic=True)
     assert mosaics.ndim == 1, 'Mosaics are listed as 1D arrays'
     assert mosaics.size == 1, 'HIRES has 1 predefined mosaic'

--- a/pypeit/tests/test_spectrographs.py
+++ b/pypeit/tests/test_spectrographs.py
@@ -62,6 +62,34 @@ def test_select_detectors_mosaic():
     assert spec.select_detectors(subset=[3,(1,2,3)]) == [3,(1,2,3)], 'Bad detector selection'
 
 
+def test_list_detectors_deimos():
+    deimos = load_spectrograph('keck_deimos')
+    dets = deimos.list_detectors()
+    assert dets.ndim == 2, 'DEIMOS has a 2D array of detectors'
+    assert dets.size == 8, 'DEIMOS has 8 detectors'
+    mosaics = deimos.list_detectors(mosaic=True)
+    assert mosaics.ndim == 1, 'Mosaics are listed as 1D arrays'
+    assert mosaics.size == 4, 'DEIMOS has 4 predefined mosaics'
+
+
+def test_list_detectors_mosfire():
+    mosfire = load_spectrograph('keck_mosfire')
+    dets = mosfire.list_detectors()
+    assert dets.ndim == 1, 'MOSFIRE has a 1D array of detectors'
+    assert dets.size == 1, 'MOSFIRE has 1 detector'
+    with pytest.raises(PypeItError):
+        mosaics = mosfire.list_detectors(mosaic=True)
+
+
+def test_list_detectors_mods():
+    mods = load_spectrograph('lbt_mods1r')
+    dets = mods.list_detectors()
+    assert dets.ndim == 1, 'MODS1R has a 1D array of detectors'
+    assert dets.size == 1, 'MODS1R has 1 detector'
+    with pytest.raises(PypeItError):
+        mosaics = mods.list_detectors(mosaic=True)
+
+
 def test_configs():
 
     spec = load_spectrograph('keck_deimos')


### PR DESCRIPTION
It looks like the functionality to reduce specific slits was never properly implemented. It apparently will fail on any instrument that does not have the spectrograph.list_detectors() method overloaded which is all instruments except gemini_gmos, keck_deimos, and keck_mosfire.

[rdx]
  slitspatnum = DET01:1557

The current PR attempts to fix this using the specific case of LBT mods where the failure was identified.  I need help with Keck hires, since the mosaic hooks are not there and I'm confused with how this function is supposed to behave since the list_detectors function is different for the no mosaic case for deimos and mosfire (I'm not sure why). 

See the dev-suite PR of the same name for a test example.  I'm handing off this PR to @kbwestfall and @debora-pe who I think are in a better position to understand whether my changes are correct. Also, please note that I think that list_detectors should maybe be overloaded for keck_hires which also has mosaics, but I'm a bit unclear on that.

It would also be a good idea to add tests.  

