### PR TITLE
Hotfix : pypeit_identify echelle

### DIFF
--- a/doc/releases/1.14.1dev.rst
+++ b/doc/releases/1.14.1dev.rst
@@ -45,5 +45,7 @@ Bug Fixes
   and then later overwritten. The new routine is faster and more accurate.
 - Fixed a bug associated with an incorrect date for the transition to the Mark4
   detector for Keck/LRIS RED.
+- Fixed a bug with the ``pypeit_identify`` script when using echelle data. Previously,
+  the sigdetect parameter was a list of all orders, instead of a single value.
 
 

--- a/pypeit/core/gui/identify.py
+++ b/pypeit/core/gui/identify.py
@@ -247,6 +247,8 @@ class Identify:
 
         if sigdetect is None:
             sigdetect = par['sigdetect']
+            if isinstance(sigdetect, list):
+                sigdetect = sigdetect[slit]
         print(f"Using {sigdetect} for sigma detection")
 
         # If a wavelength calibration has been performed already, load it:
@@ -264,6 +266,7 @@ class Identify:
             msgs.warn("No wavelength calibration supplied!")
             msgs.info("No wavelength solution will be loaded.")
             wv_calib = None
+
         # Extract the lines that are detected in arccen
         thisarc = arccen[:, slit]
         if nonlinear_counts is None:


### PR DESCRIPTION
A user identified a bug using `pypeit_identify` with echelle data. Here is the fix.