### PR TITLE
Hotfix: use mask in specutils loader

### DIFF
--- a/pypeit/specutils/pypeit_loaders.py
+++ b/pypeit/specutils/pypeit_loaders.py
@@ -197,6 +197,9 @@ def pypeit_spec1d_loader(filename, extract=None, fluxed=True, strict=True, **kwa
                                         else sobj.get_opt_ext(fluxed=_cal)
         if not np.all(_gpm):
             msgs.warn(f'Ignoring {np.sum(np.logical_not(_gpm))} masked pixels.')
+        if not np.any(_gpm):
+            msgs.warn(f'Spectrum {sobj.NAME} is fully masked and will be ignored!')
+            continue
         _wave, _flux, _ivar = _enforce_monotonic_wavelengths(_wave[_gpm], _flux[_gpm], _ivar[_gpm],
                                                              strict=strict)
         flux_unit = astropy.units.Unit("1e-17 erg/(s cm^2 Angstrom)" if _cal else "electron")

--- a/pypeit/specutils/pypeit_loaders.py
+++ b/pypeit/specutils/pypeit_loaders.py
@@ -195,7 +195,10 @@ def pypeit_spec1d_loader(filename, extract=None, fluxed=True, strict=True, **kwa
         _ext, _cal = sobj.best_ext_match(extract=extract, fluxed=fluxed)
         _wave, _flux, _ivar, _gpm = sobj.get_box_ext(fluxed=_cal) if _ext == 'BOX' \
                                         else sobj.get_opt_ext(fluxed=_cal)
-        _wave, _flux, _ivar = _enforce_monotonic_wavelengths(_wave, _flux, _ivar, strict=strict)
+        if not np.all(_gpm):
+            msgs.warn(f'Ignoring {np.sum(np.logical_not(_gpm))} masked pixels.')
+        _wave, _flux, _ivar = _enforce_monotonic_wavelengths(_wave[_gpm], _flux[_gpm], _ivar[_gpm],
+                                                             strict=strict)
         flux_unit = astropy.units.Unit("1e-17 erg/(s cm^2 Angstrom)" if _cal else "electron")
         spec += \
             [Spectrum1D(flux=astropy.units.Quantity(_flux * flux_unit),


### PR DESCRIPTION
As titled.  The new check on a monotonically increasing wavelength vector caused problems for some spectrographs that have wavelengths set to 0.  This is avoided by using the mask.