### PR TITLE
Hotfix: Platescale binning correction

### DIFF
--- a/doc/releases/1.14.1dev.rst
+++ b/doc/releases/1.14.1dev.rst
@@ -63,5 +63,8 @@ Bug Fixes
   the sigdetect parameter was a list of all orders, instead of a single value.
 - Fixed a bug with the GUI ``pypeit_skysub_regions``. Previously, the calib header
   information was not included, and this led to a calibration error.
+- Corrected the binning scaling for BOXCAR_RADIUS in the object-finding algorithm.
+  Previously, the platescale was multiplied by the *spectral* binning and not the
+  *spatial* binning.
 
 

--- a/pypeit/find_objects.py
+++ b/pypeit/find_objects.py
@@ -694,8 +694,8 @@ class MultiSlitFindObjects(FindObjects):
             :obj:`float`: plate scale in binned pixels
 
         """
-        bin_spec, bin_spat = parse.parse_binning(self.binning)
-        return self.sciImg.detector.platescale * bin_spec
+        _, bin_spat = parse.parse_binning(self.binning)
+        return self.sciImg.detector.platescale * bin_spat
 
     def find_objects_pypeline(self, image, ivar, std_trace=None,
                               manual_extract_dict=None,


### PR DESCRIPTION
In `pypeit.find_objects.MultiSlitFindObjects.get_platescale()`, the platescale is scaled by the binning -- but the code accidentally was using the *spectral* binning rather than the *spatial* binning.  This value is used to compute the BOXCAR RADIUS in the `pypeit.core.findobj_skymask.objs_in_slit()` function, which is then saved in the `SpecObj` object.

This PR corrects the binning scaling to use the SPATIAL binning.

	modified:   pypeit/find_objects.py