### PR TITLE
LDT/DeVeny: Adjust source for 'target' metadata item

### DIFF
--- a/doc/releases/1.14.1dev.rst
+++ b/doc/releases/1.14.1dev.rst
@@ -49,8 +49,8 @@ Instrument-specific Updates
 - Keck/KCWI and Keck/KCRM: Turned on polynomial correction for sky subtraction.
 - We now support the reduction of VLT/FORS2 data taken in MOS mode.
 - Fixed fluxing file format in the ``Keck-DEIMOS HOWTO`` documentation.
-- Various updates to default parameters for LDT/DeVeny, plus updated wavelength
-  templates and instrument-specific line lists.
+- LDT/DeVeny: default parameter & wavelength template updates, add instrument-
+  specific line lists, use SCITARG for target name if none entered in the LOUI.
 - Added support for NTT/EFOSC2 Gr#4
 
 Script Changes

--- a/pypeit/spectrographs/ldt_deveny.py
+++ b/pypeit/spectrographs/ldt_deveny.py
@@ -119,7 +119,7 @@ class LDTDeVenySpectrograph(spectrograph.Spectrograph):
         # Required (core)
         self.meta['ra'] = dict(ext=0, card='RA')
         self.meta['dec'] = dict(ext=0, card='DEC')
-        self.meta['target'] = dict(ext=0, card='OBJNAME')
+        self.meta['target'] = dict(card=None, compound=True)
         self.meta['dispname'] = dict(card=None, compound=True)
         self.meta['decker'] = dict(card=None, compound=True)
         self.meta['binning'] = dict(card=None, compound=True)
@@ -217,6 +217,15 @@ class LDTDeVenySpectrograph(spectrograph.Spectrograph):
             )
             # Round the wavelength to the nearest 5A
             return np.around(wavelen / 5, decimals=0) * 5
+
+        if meta_key == 'target':
+            # Revert to TCS's SCITARG if target not set in LOUI for OBJECT frames
+            return (
+                headarr[0]["SCITARG"].strip()
+                if (headarr[0]['IMAGETYP'].strip() == "OBJECT"
+                    and headarr[0]["OBJNAME"].strip() in ["UNKNOWN",""])
+                else headarr[0]["OBJNAME"].strip()
+            )
 
         msgs.error(f"Not ready for compound meta {meta_key} for LDT/DeVeny")
 


### PR DESCRIPTION
For long target lists, some observers do not type the individual object names into the LOUI, but rather rely upon the SCITARG keyword that comes from the TCS via the ObserverTargetList tool.  This results in the OBJECT/OBJNAME keywords being set to UNKNOWN.  When PypeIt tries to read in the metadata, this leaves all object frames with the same, unhelpful name.

Solution: Add a `compound_meta` case for 'target' that uses the SCITARG FITS keyword for OBJECT frames if the OBJNAME is "UNKNOWN" or blank. This means that only science frames could have the 'target' metadata pulled from SCITARG, leaving all calibration frames as before.

PypeIt repo unit tests pass, and LDT/DeVeny DevSuite tests pass (no changes elsewhere in the code, so no general DevSuite run):
```
Test Summary
--------------------------------------------------------
--- PYTEST PYPEIT UNIT TESTS PASSED  242 passed, 69 warnings in 480.89s (0:08:00) ---
--- PYPEIT DEVELOPMENT SUITE PASSED 13/13 TESTS  ---
Testing Started at 2023-12-04T10:22:37.830855
Testing Completed at 2023-12-04T10:46:47.808049
Total Time: 0:24:09.977194
```