### PR TITLE
Hotfix arc/tilt frame-typing for KCWI

### DIFF
--- a/doc/releases/1.14.1dev.rst
+++ b/doc/releases/1.14.1dev.rst
@@ -52,6 +52,8 @@ Instrument-specific Updates
 - Various updates to default parameters for LDT/DeVeny, plus updated wavelength
   templates and instrument-specific line lists.
 - Added support for NTT/EFOSC2 Gr#4
+- Keck/KCWI: FeAr are used for wavelength calibration, while the ThAr lamp is used
+  to determine the wavelength tilt.
 
 Script Changes
 --------------

--- a/doc/spectrographs/keck_kcwi.rst
+++ b/doc/spectrographs/keck_kcwi.rst
@@ -22,19 +22,26 @@ supported in PypeIt.
 Taking Calibrations for KCWI
 ++++++++++++++++++++++++++++
 
-Arcs
-----
+Arcs and tilts
+--------------
 
 We recommend that you only use the FeAr lamp to wavelength
 calibrate your data. Note that some FeAr calibration frames
 were contaminated due to a leaking ThAr lamp for observations
 up to the end of 2019. If your data are affected, you will
 need to request a new arc calibration. If there is a small
-offset, this is compensated for by default using a spectral
-flexure correction to the sky emission lines.
+offset in the wavelength calibration, this is compensated for
+by default using a spectral flexure correction to the sky
+emission lines. We also recommend that you use the ThAr lamp
+to determine the tilt of the spectra. This is done by default.
+If a ThAr exposure is not available, you can use the FeAr lamp,
+or you can use the sky emission lines if you are using KCRM and
+cover red wavelengths.
 
-The archived wavelength calibration solution only contains
-the FeAr spectrum.
+NOTE: The archived wavelength calibration solution only contains
+the FeAr spectrum. If you want to use the ThAr spectrum for the
+wavelength calibration, you will need to manually calibrate the
+data using the :ref:`pypeit_identify` task.
 
 Pixel Flat
 ----------

--- a/pypeit/spectrographs/keck_kcwi.py
+++ b/pypeit/spectrographs/keck_kcwi.py
@@ -286,6 +286,7 @@ class KeckKCWIKCRMSpectrograph(spectrograph.Spectrograph):
         # LACosmics parameters
         par['scienceframe']['process']['sigclip'] = 4.0
         par['scienceframe']['process']['objlim'] = 1.5
+        # Illumination corrections
         par['scienceframe']['process']['use_illumflat'] = True  # illumflat is applied when building the relative scale image in reduce.py, so should be applied to scienceframe too.
         par['scienceframe']['process']['use_specillum'] = True  # apply relative spectral illumination
         par['scienceframe']['process']['spat_flexure_correct'] = False  # don't correct for spatial flexure - varying spatial illumination profile could throw this correction off. Also, there's no way to do astrometric correction if we can't correct for spatial flexure of the contbars frames
@@ -371,9 +372,19 @@ class KeckKCWIKCRMSpectrograph(spectrograph.Spectrograph):
                 msgs.warn('Alignment frames have both the continuum and arc lamps on (although '
                           'arc-lamp shutter might be closed)!')
             return is_align
-        if ftype in ['arc', 'tilt']:
+        if ftype == 'arc':
+            # PypeIt is only setup to wavelength calibrate using the FeAr lamp.
             return good_exp & (fitstbl['idname'] == 'ARCLAMP') & (fitstbl['calpos'] == 'Mirror') \
                     & self.lamps(fitstbl, 'arcs')
+        if ftype == 'tilt':
+            # Check to see if ThAr frames are available. If so, use them. Otherwise, use the FeAr lamp.
+            tmp = good_exp & (fitstbl['idname'] == 'ARCLAMP') & (fitstbl['calpos'] == 'Mirror') \
+                    & self.lamps(fitstbl, 'tilts')
+            if np.any(tmp):
+                return tmp
+            # No ThAr frames, so use the FeAr lamp
+            return good_exp & (fitstbl['idname'] == 'ARCLAMP') & (fitstbl['calpos'] == 'Mirror') \
+                   & self.lamps(fitstbl, 'arcs')
         if ftype == 'pinhole':
             # Don't type pinhole frames
             return np.zeros(len(fitstbl), dtype=bool)
@@ -405,14 +416,18 @@ class KeckKCWIKCRMSpectrograph(spectrograph.Spectrograph):
             lampstat = np.array([np.isin(fitstbl[k], ['0', 'None', 'off'])
                                     for k in fitstbl.keys() if 'lampstat' in k])
             return np.all(lampstat, axis=0)  # Lamp has to be off
-        if status == 'arcs':
-            # Check if any arc lamps are on (FeAr | ThAr)
-            arc_lamp_stat = ['lampstat{0:02d}'.format(i) for i in range(1, 3)]
-            arc_lamp_shst = ['lampshst{0:02d}'.format(i) for i in range(1, 3)]
-            lamp_stat = np.array([fitstbl[k] == '1' for k in fitstbl.keys()
-                                  if k in arc_lamp_stat])
-            lamp_shst = np.array([fitstbl[k] == '1' for k in fitstbl.keys()
-                                  if k in arc_lamp_shst])
+        if status in ['arcs', 'tilts']:
+            # Check if any arc/tilt lamps are on
+            if status == 'arcs':
+                # Only FeAr is used for wavelength calibration
+                arc_lamp_stat = ['lampstat{0:02d}'.format(1)]
+                arc_lamp_shst = ['lampshst{0:02d}'.format(1)]
+            else:
+                # Only ThAr is used to calculate the tilt
+                arc_lamp_stat = ['lampstat{0:02d}'.format(2)]
+                arc_lamp_shst = ['lampshst{0:02d}'.format(2)]
+            lamp_stat = np.array([fitstbl[k] == '1' for k in fitstbl.keys() if k in arc_lamp_stat])
+            lamp_shst = np.array([fitstbl[k] == '1' for k in fitstbl.keys() if k in arc_lamp_shst])
             # Make sure the continuum frames are off
             dome_lamps = ['lampstat{0:02d}'.format(i) for i in range(4, 5)]
             dome_lamp_stat = np.array([fitstbl[k] == '0' for k in fitstbl.keys()


### PR DESCRIPTION
This hotfix ensures that only FeAr frames are typed as `arc`. ThAr frames are preferred for the `tilt`, but if none of these are available, the FeAr frames will be used.