### PR TITLE
Indexing bugfix in match_orders

### DIFF
--- a/pypeit/edgetrace.py
+++ b/pypeit/edgetrace.py
@@ -5507,8 +5507,15 @@ class EdgeTraceSet(calibframe.CalibFrame):
         for u in uniq[cnts > 1]:
             # Find the unmasked and multiply-matched indices
             indx = (slit_indx.data == u) & np.logical_not(np.ma.getmaskarray(slit_indx))
+            
+            # we need a masked version of min_sep array with only relevant indices
+            # as the below masking of slit_indx needs to be in correct shape
+            min_sep_mask = np.ones_like(min_sep, dtype = bool)
+            min_sep_mask[indx] = False
+            min_sep_masked = np.ma.masked_array(min_sep, min_sep_mask)
+
             # Keep the one with the smallest separation and mask the rest
-            slit_indx[np.setdiff1d(np.where(indx), [np.argmin(min_sep[indx])])] = np.ma.masked
+            slit_indx[np.setdiff1d(np.where(indx), [np.argmin(min_sep_masked)])] = np.ma.masked
 
         # Flag orders separated by more than the provided threshold
         if self.par['order_match'] is not None:


### PR DESCRIPTION
Fixed indexing bug when multiple traces are matched to same order. 

VET TESTS ARE MISSING. Tests only done for shane_kast_blue (all tests except vet), rest of the tests will be run in cloud by the dev-team in agreement with Kyle Westfall.


Test Summary
--------------------------------------------------------
--- PYTEST PYPEIT UNIT TESTS PASSED  242 passed, 67 warnings in 555.48s (0:09:15) ---
--- PYTEST UNIT TESTS PASSED  131 passed, 2 skipped, 170 warnings in 1083.33s (0:18:03) ---
--- PYPEIT DEVELOPMENT SUITE PASSED 13/13 TESTS  ---
Testing Started at 2023-12-06T22:35:52.058871
Testing Completed at 2023-12-06T23:15:35.458485
Total Time: 0:39:43.399614