### PR TITLE
`pypeit_show2dspec` HOTFIX

### DIFF
--- a/pypeit/scripts/show_2dspec.py
+++ b/pypeit/scripts/show_2dspec.py
@@ -107,7 +107,7 @@ class Show2DSpec(scriptbase.ScriptBase):
         parser.add_argument('--no_clear', dest='clear', default=True, 
                             action='store_false',
                             help='Do *not* clear all existing tabs')
-        parser.add_argument('-v', '--verbosity', type=int, default=2,
+        parser.add_argument('-v', '--verbosity', type=int, default=1,
                             help='Verbosity level between 0 [none] and 2 [all]')
         return parser
 

--- a/pypeit/spectrographs/ldt_deveny.py
+++ b/pypeit/spectrographs/ldt_deveny.py
@@ -408,7 +408,7 @@ class LDTDeVenySpectrograph(spectrograph.Spectrograph):
                 & (fitstbl['idname'] == 'DARK')
                 & (fitstbl['lampstat01'] == 'off')
             )
-        if ftype in ['pinhole', 'align', 'sky', 'lampoffflats']:
+        if ftype in ['pinhole', 'align', 'sky', 'lampoffflats', 'scattlight']:
             # DeVeny doesn't have any of these types of frames
             return np.zeros(len(fitstbl), dtype=bool)
         msgs.warn(f"Cannot determine if frames are of type {ftype}")


### PR DESCRIPTION
Change the default verbosity for `pypeit_show_2dspec` to 1 (which is where all the other scripts -- save `run_pypeit` -- are).  This was an oversight in #1712.

Also, add new "scattlight" frametype to list of ignored frametypes for LDT/DeVeny.

	modified:   pypeit/scripts/show_2dspec.py
	modified:   pypeit/spectrographs/ldt_deveny.py