### PR TITLE
Increase time limit for GTC-OSIRIS standards

### DIFF
--- a/pypeit/spectrographs/gtc_osiris.py
+++ b/pypeit/spectrographs/gtc_osiris.py
@@ -110,7 +110,7 @@ class GTCOSIRISPlusSpectrograph(spectrograph.Spectrograph):
         par['calibrations']['pinholeframe']['exprng'] = [999999, None]  # No pinhole frames
         par['calibrations']['arcframe']['exprng'] = [None, None]  # Long arc exposures
         par['calibrations']['arcframe']['process']['clip'] = False
-        par['calibrations']['standardframe']['exprng'] = [None, 180]
+        par['calibrations']['standardframe']['exprng'] = [None, 300]
         # Multiple arcs with different lamps, so can't median combine nor clip, also need to remove continuum
         par['calibrations']['arcframe']['process']['combine'] = 'mean'
         par['calibrations']['arcframe']['process']['subtract_continuum'] = True


### PR DESCRIPTION
Increased exposure time limit for GTC-OSIRIS standards to account for longer standards with high-res grisms. Without this change some standards are mis-typed as science,standard and lead to an error running pypeit_setup where they are associated with two different setups.