### PR TITLE
Fix setup gui type annotations to be Python 3.9 compatible.

### DIFF
--- a/pypeit/setup_gui/dialog_helpers.py
+++ b/pypeit/setup_gui/dialog_helpers.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import enum
-from typing import Optional
+from typing import Optional,Union
 from pathlib import Path
 from dataclasses import dataclass
 
@@ -93,7 +93,7 @@ class FileDialog:
                  caption : str, 
                  file_mode : QFileDialog.FileMode, 
                  file_type : Optional[FileType] =None,
-                 default_file : Optional[str|Path] = None,
+                 default_file : Optional[Union[str,Path]] = None,
                  history : Optional[QStringListModel] = None, 
                  save : bool = False, 
                  ask_for_all : bool = False):

--- a/pypeit/setup_gui/model.py
+++ b/pypeit/setup_gui/model.py
@@ -14,6 +14,7 @@ import glob
 import numpy as np
 import astropy.table
 import io
+import typing
 from pathlib import Path
 from functools import partial
 from qtpy.QtCore import QAbstractTableModel, QAbstractProxyModel, QAbstractItemModel, QAbstractListModel, QModelIndex, Qt, Signal, QObject, QThread, QStringListModel
@@ -218,7 +219,7 @@ class PypeItMetadataModel(QAbstractTableModel):
         metadata: The PypeItMetaData object being wrapped. If this is None, the
                   model is in a "NEW" state.
     """
-    def __init__(self, metadata : PypeItMetaData | None):
+    def __init__(self, metadata : typing.Union[PypeItMetaData, None]):
         super().__init__()
 
         self.metadata = metadata
@@ -448,7 +449,7 @@ class PypeItMetadataModel(QAbstractTableModel):
         else:
             return ['filename', 'frametype', 'ra', 'dec', 'target', 'dispname', 'decker', 'binning', 'mjd', 'airmass', 'exptime']
 
-    def getStringColumnSize(self, colname: str) -> int | None:
+    def getStringColumnSize(self, colname: str) -> typing.Union[int,None]:
         """
         Return the maximum size of a string column.
 

--- a/pypeit/setup_gui/text_viewer.py
+++ b/pypeit/setup_gui/text_viewer.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 import io
-from typing import Optional
+from typing import Optional,Union
 
 from qtpy.QtWidgets import  QHBoxLayout, QVBoxLayout, QFileDialog, QWidget, QPlainTextEdit, QPushButton
 
@@ -29,7 +29,7 @@ class TextViewerWindow(QWidget):
     """Signal sent when the window is closed."""
 
 
-    def __init__(self, title : str, width : int, height : int, text_stream : io.TextIOBase, start_at_top : bool, filename: Optional[str|Path] = None, file_type : FileType = FileType("Text Files", ".txt")):
+    def __init__(self, title : str, width : int, height : int, text_stream : io.TextIOBase, start_at_top : bool, filename: Optional[Union[str,Path]] = None, file_type : FileType = FileType("Text Files", ".txt")):
         super().__init__()
         self._text_stream = text_stream
         self._file_type = file_type


### PR DESCRIPTION
The setup GUI was using type annotation stuff from python 3.10, but the docs are built under 3.9. This makes the annotations python 3.9 compatible.