### PR TITLE
Docs (should now be) fixed on release

### DIFF
--- a/doc/api/pypeit.astrometry.rst
+++ b/doc/api/pypeit.astrometry.rst
@@ -1,8 +1,0 @@
-pypeit.astrometry module
-========================
-
-.. automodule:: pypeit.astrometry
-   :members:
-   :private-members:
-   :undoc-members:
-   :show-inheritance:

--- a/doc/api/pypeit.rst
+++ b/doc/api/pypeit.rst
@@ -27,7 +27,6 @@ Submodules
 
    pypeit.alignframe
    pypeit.archive
-   pypeit.astrometry
    pypeit.bitmask
    pypeit.calibframe
    pypeit.calibrations

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -11,6 +11,10 @@ What's New in PypeIt
 
 ----
 
+.. include:: releases/1.15.1dev.rst
+
+----
+
 .. include:: releases/1.15.0.rst
 
 ----


### PR DESCRIPTION
A rogue file was causing docs to fail. This short PR fixes it.