### PR TITLE
Fix Reduction failiures trying to deep copy pypeit.images.mosaic.Mosaic

### DIFF
--- a/pypeit/images/detector_container.py
+++ b/pypeit/images/detector_container.py
@@ -228,14 +228,3 @@ class DetectorContainer(datamodel.DataContainer):
             gain = 1.
         return self.saturation * self.nonlinear * gain
     
-    def copy(self):
-        """
-        Return a (deep) copy of the object.
-        """
-        return DetectorContainer(self.dataext, self.specaxis, self.specflip, self.spatflip, self.platescale,
-                                 self.saturation, self.mincounts, self.nonlinear,
-                                 self.numamplifiers, self.gain.copy(), self.ronoise.copy(),
-                                 self.det, self.binning, xgap=self.xgap, ygap=self.ygap,
-                                 ysize=self.ysize, darkcurr=self.darkcurr,
-                                 datasec=None if self.datasec is None else self.datasec.copy(),
-                                 oscansec=None if self.oscansec is None else self.oscansec.copy())

--- a/pypeit/images/pypeitimage.py
+++ b/pypeit/images/pypeitimage.py
@@ -8,6 +8,7 @@ import inspect
 from IPython import embed
 
 import numpy as np
+import copy
 
 from astropy.io import fits
 
@@ -783,7 +784,7 @@ class PypeItImage(datamodel.DataContainer):
 
         # Create a copy of the detector, if it is defined, to be used when
         # creating the new pypeit image below
-        _detector = None if self.detector is None else self.detector.copy()
+        _detector = copy.deepcopy(self.detector)
 
         # Create the new image.
         new_pypeitImage = PypeItImage(newimg, ivar=new_ivar, nimg=new_nimg, rn2img=new_rn2,

--- a/pypeit/tests/test_detector.py
+++ b/pypeit/tests/test_detector.py
@@ -67,11 +67,20 @@ def test_io():
 
 
 def test_copy():
+    
+    # Double check that none of the DataContainer customization doesn't break
+    # doing a deepcopy of a detector
+
+    import copy
     detector = detector_container.DetectorContainer(**def_det)
-    detcopy = detector.copy()
+    detcopy = copy.deepcopy(detector)
 
     # Check that a couple of relevant attributes have different memory locations
     assert detector is not detcopy, 'Should not point to the same reference'
     assert detector.gain is not detcopy.gain, \
         'numpy array attributes should not point to the same reference'
-    
+
+    # make sure the copy is actually a copy
+    assert detector.det == detcopy.det, 'Detector number should be the same.'
+    assert np.array_equal(detector.gain,detcopy.gain), 'Detector gain should be the same'
+


### PR DESCRIPTION
PR  #1775  added a copy method to DetectorContainer and modified PypeItImage.sub() to use it when copying detectors. But mosaic images use a Mosaic object instead of a DetectorContainer, which has no copy method. Resulting in a `AttributeError: copy is not an attribute of Mosaic!` error message.

To fix this I decided to switch to using copy.deepcopy() instead of using  a copy method, to avoid having to create a new copy method for each DataContainer type object we create.