### PR TITLE
Move lampstat check

### DIFF
--- a/pypeit/calibrations.py
+++ b/pypeit/calibrations.py
@@ -214,6 +214,7 @@ class Calibrations:
         """
         Check if the input calibration files are consistent with each other.
         This step is usually needed when combining calibration frames of a given type.
+        This routine currently only prints out warning messages if the calibration files are not consistent.
 
         Note: The exposure times are currently checked in the combine step, so they are not checked here.
 
@@ -224,6 +225,7 @@ class Calibrations:
         check_lamps : bool, optional
             Check if the lamp status is the same for all the files. Default is True.
         """
+
         lampstat = [None] * len(file_list)
         # Loop on the files
         for ii, ifile in enumerate(file_list):

--- a/pypeit/calibrations.py
+++ b/pypeit/calibrations.py
@@ -4,6 +4,7 @@ Class for guiding calibration object generation in PypeIt.
 .. include common links, assuming primary doc root is up one directory
 .. include:: ../include/links.rst
 """
+import os
 from pathlib import Path
 from datetime import datetime
 from copy import deepcopy
@@ -209,6 +210,44 @@ class Calibrations:
         self.success = False
         self.failed_step = None
 
+    def check_calibrations(self, file_list, check_lamps=True):
+        """
+        Check if the input calibration files are consistent with each other.
+        This step is usually needed when combining calibration frames of a given type.
+
+        Note: The exposure times are currently checked in the combine step, so they are not checked here.
+
+        Parameters
+        ----------
+        file_list : list
+            List of calibration files to check
+        check_lamps : bool, optional
+            Check if the lamp status is the same for all the files. Default is True.
+        """
+        lampstat = [None] * len(file_list)
+        # Loop on the files
+        for ii, ifile in enumerate(file_list):
+            # Save the lamp status
+            headarr = deepcopy(self.spectrograph.get_headarr(ifile))
+            lampstat[ii] = self.spectrograph.get_lamps_status(headarr)
+
+        # Check that the lamps being combined are all the same
+        if check_lamps:
+            if not lampstat[1:] == lampstat[:-1]:
+                msgs.warn("The following files contain different lamp status")
+                # Get the longest strings
+                maxlen = max([len("Filename")] + [len(os.path.split(x)[1]) for x in file_list])
+                maxlmp = max([len("Lamp status")] + [len(x) for x in lampstat])
+                strout = "{0:" + str(maxlen) + "}  {1:s}"
+                # Print the messages
+                print(msgs.indent() + '-' * maxlen + "  " + '-' * maxlmp)
+                print(msgs.indent() + strout.format("Filename", "Lamp status"))
+                print(msgs.indent() + '-' * maxlen + "  " + '-' * maxlmp)
+                for ff, file in enumerate(file_list):
+                    print(msgs.indent()
+                          + strout.format(os.path.split(file)[1], " ".join(lampstat[ff].split("_"))))
+                print(msgs.indent() + '-' * maxlen + "  " + '-' * maxlmp)
+
     def find_calibrations(self, frametype, frameclass):
         """
         Find calibration files and identifiers.
@@ -334,6 +373,9 @@ class Calibrations:
         # Reset the BPM
         self.get_bpm(frame=raw_files[0])
 
+        # Perform a check on the files
+        self.check_calibrations(raw_files)
+
         # Otherwise, create the processed file.
         msgs.info(f'Preparing a {frame["class"].calib_type} calibration frame.')
         self.msarc = buildimage.buildimage_fromlist(self.spectrograph, self.det,
@@ -376,6 +418,9 @@ class Calibrations:
 
         # Reset the BPM
         self.get_bpm(frame=raw_files[0])
+
+        # Perform a check on the files
+        self.check_calibrations(raw_files)
 
         # Otherwise, create the processed file.
         msgs.info(f'Preparing a {frame["class"].calib_type} calibration frame.')
@@ -426,6 +471,9 @@ class Calibrations:
         # Reset the BPM
         self.get_bpm(frame=raw_files[0])
 
+        # Perform a check on the files
+        self.check_calibrations(raw_files)
+
         # Otherwise, create the processed file.
         msgs.info(f'Preparing a {frame["class"].calib_type} calibration frame.')
         msalign = buildimage.buildimage_fromlist(self.spectrograph, self.det,
@@ -472,6 +520,9 @@ class Calibrations:
         if cal_file.exists() and self.reuse_calibs:
             self.msbias = frame['class'].from_file(cal_file, chk_version=self.chk_version)
             return self.msbias
+
+        # Perform a check on the files
+        self.check_calibrations(raw_files)
 
         # Otherwise, create the processed file.
         msgs.info(f'Preparing a {frame["class"].calib_type} calibration frame.')
@@ -522,6 +573,9 @@ class Calibrations:
         # calling get_dark then get_bpm unnecessarily creates the bpm twice.  Is
         # there any reason why creation of the bpm should come after the dark,
         # or can we change the order?
+
+        # Perform a check on the files
+        self.check_calibrations(raw_files)
 
         # Otherwise, create the processed file.
         self.msdark = buildimage.buildimage_fromlist(self.spectrograph, self.det,
@@ -596,6 +650,9 @@ class Calibrations:
 
         # Reset the BPM
         self.get_bpm(frame=raw_scattlight_files[0])
+
+        # Perform a check on the files
+        self.check_calibrations(raw_scattlight_files)
 
         binning = self.fitstbl[scatt_idx[0]]['binning']
         dispname = self.fitstbl[scatt_idx[0]]['dispname']
@@ -725,6 +782,10 @@ class Calibrations:
         if len(raw_pixel_files) > 0:
             # Reset the BPM
             self.get_bpm(frame=raw_pixel_files[0])
+
+            # Perform a check on the files
+            self.check_calibrations(raw_pixel_files)
+
             msgs.info('Creating pixel-flat calibration frame using files: ')
             for f in raw_pixel_files:
                 msgs.prindent(f'{Path(f).name}')
@@ -737,6 +798,10 @@ class Calibrations:
             if len(raw_lampoff_files) > 0:
                 # Reset the BPM
                 self.get_bpm(frame=raw_lampoff_files[0])
+
+                # Perform a check on the files
+                self.check_calibrations(raw_lampoff_files)
+
                 msgs.info('Subtracting lamp off flats using files: ')
                 for f in raw_lampoff_files:
                     msgs.prindent(f'{Path(f).name}')
@@ -763,6 +828,10 @@ class Calibrations:
         if not pix_is_illum and len(raw_illum_files) > 0:
             # Reset the BPM
             self.get_bpm(frame=raw_illum_files[0])
+
+            # Perform a check on the files
+            self.check_calibrations(raw_illum_files)
+
             msgs.info('Creating slit-illumination flat calibration frame using files: ')
             for f in raw_illum_files:
                 msgs.prindent(f'{Path(f).name}')
@@ -775,6 +844,10 @@ class Calibrations:
                 for f in raw_lampoff_files:
                     msgs.prindent(f'{Path(f).name}')
                 if lampoff_flat is None:
+                    # Perform a check on the files
+                    self.check_calibrations(raw_lampoff_files)
+
+                    # Build the image
                     lampoff_flat = buildimage.buildimage_fromlist(self.spectrograph, self.det,
                                                                   self.par['lampoffflatsframe'],
                                                                   raw_lampoff_files,
@@ -889,6 +962,9 @@ class Calibrations:
         # Reset the BPM
         self.get_bpm(frame=raw_trace_files[0])
 
+        # Perform a check on the files
+        self.check_calibrations(raw_trace_files)
+
         traceImage = buildimage.buildimage_fromlist(self.spectrograph, self.det,
                                                     self.par['traceframe'], raw_trace_files,
                                                     bias=self.msbias, bpm=self.msbpm,
@@ -902,6 +978,9 @@ class Calibrations:
 
             # Reset the BPM
             self.get_bpm(frame=raw_trace_files[0])
+
+            # Perform a check on the files
+            self.check_calibrations(raw_lampoff_files)
 
             lampoff_flat = buildimage.buildimage_fromlist(self.spectrograph, self.det,
                                                           self.par['lampoffflatsframe'],

--- a/pypeit/images/buildimage.py
+++ b/pypeit/images/buildimage.py
@@ -4,8 +4,6 @@
 .. include:: ../include/links.rst
 """
 
-import os
-
 from IPython import embed
 
 import numpy as np
@@ -255,7 +253,6 @@ def buildimage_fromlist(spectrograph, det, frame_par, file_list, bias=None, bpm=
         mosaic = isinstance(det, tuple) and frame_par['frametype'] not in ['bias', 'dark']
         
     rawImage_list = []
-    lampstat = [None] * len(file_list)
     # Loop on the files
     for ii, ifile in enumerate(file_list):
         # Load raw image
@@ -264,26 +261,6 @@ def buildimage_fromlist(spectrograph, det, frame_par, file_list, bias=None, bpm=
         rawImage_list.append(rawImage.process(
             frame_par['process'], scattlight=scattlight, bias=bias, 
             bpm=bpm, dark=dark, flatimages=flatimages, slits=slits, mosaic=mosaic))
-
-        # Save the lamp status
-        # TODO: Is there a way we can get this from fitstbl instead?
-        lampstat[ii] = spectrograph.get_lamps_status(rawImage_list[ii].rawheadlist)
-
-    # Check that the lamps being combined are all the same:
-    if not lampstat[1:] == lampstat[:-1]:
-        msgs.warn("The following files contain different lamp status")
-        # Get the longest strings
-        maxlen = max([len("Filename")]+[len(os.path.split(x)[1]) for x in file_list])
-        maxlmp = max([len("Lamp status")]+[len(x) for x in lampstat])
-        strout = "{0:" + str(maxlen) + "}  {1:s}"
-        # Print the messages
-        print(msgs.indent() + '-'*maxlen + "  " + '-'*maxlmp)
-        print(msgs.indent() + strout.format("Filename", "Lamp status"))
-        print(msgs.indent() + '-'*maxlen + "  " + '-'*maxlmp)
-        for ff, file in enumerate(file_list):
-            print(msgs.indent()
-                  + strout.format(os.path.split(file)[1], " ".join(lampstat[ff].split("_"))))
-        print(msgs.indent() + '-'*maxlen + "  " + '-'*maxlmp)
 
     # Do it
     combineImage = combineimage.CombineImage(rawImage_list, spectrograph, frame_par['process'])

--- a/pypeit/images/buildimage.py
+++ b/pypeit/images/buildimage.py
@@ -4,6 +4,8 @@
 .. include:: ../include/links.rst
 """
 
+import os
+
 from IPython import embed
 
 import numpy as np
@@ -253,15 +255,36 @@ def buildimage_fromlist(spectrograph, det, frame_par, file_list, bias=None, bpm=
         mosaic = isinstance(det, tuple) and frame_par['frametype'] not in ['bias', 'dark']
         
     rawImage_list = []
+    lampstat = [None] * len(file_list)
     # Loop on the files
-    for ifile in file_list:
+    for ii, ifile in enumerate(file_list):
         # Load raw image
         rawImage = rawimage.RawImage(ifile, spectrograph, det)
         # Process
         rawImage_list.append(rawImage.process(
             frame_par['process'], scattlight=scattlight, bias=bias, 
             bpm=bpm, dark=dark, flatimages=flatimages, slits=slits, mosaic=mosaic))
-    
+
+        # Save the lamp status
+        # TODO: Is there a way we can get this from fitstbl instead?
+        lampstat[ii] = spectrograph.get_lamps_status(rawImage_list[ii].rawheadlist)
+
+    # Check that the lamps being combined are all the same:
+    if not lampstat[1:] == lampstat[:-1]:
+        msgs.warn("The following files contain different lamp status")
+        # Get the longest strings
+        maxlen = max([len("Filename")]+[len(os.path.split(x)[1]) for x in file_list])
+        maxlmp = max([len("Lamp status")]+[len(x) for x in lampstat])
+        strout = "{0:" + str(maxlen) + "}  {1:s}"
+        # Print the messages
+        print(msgs.indent() + '-'*maxlen + "  " + '-'*maxlmp)
+        print(msgs.indent() + strout.format("Filename", "Lamp status"))
+        print(msgs.indent() + '-'*maxlen + "  " + '-'*maxlmp)
+        for ff, file in enumerate(file_list):
+            print(msgs.indent()
+                  + strout.format(os.path.split(file)[1], " ".join(lampstat[ff].split("_"))))
+        print(msgs.indent() + '-'*maxlen + "  " + '-'*maxlmp)
+
     # Do it
     combineImage = combineimage.CombineImage(rawImage_list, spectrograph, frame_par['process'])
     pypeitImage = combineImage.run(maxiters=maxiters, ignore_saturation=ignore_saturation)

--- a/pypeit/images/buildimage.py
+++ b/pypeit/images/buildimage.py
@@ -254,7 +254,7 @@ def buildimage_fromlist(spectrograph, det, frame_par, file_list, bias=None, bpm=
         
     rawImage_list = []
     # Loop on the files
-    for ii, ifile in enumerate(file_list):
+    for ifile in file_list:
         # Load raw image
         rawImage = rawimage.RawImage(ifile, spectrograph, det)
         # Process

--- a/pypeit/images/combineimage.py
+++ b/pypeit/images/combineimage.py
@@ -4,8 +4,6 @@
 .. include:: ../include/links.rst
 """
 
-import os
-
 from IPython import embed
 
 import numpy as np
@@ -17,6 +15,7 @@ from pypeit.par import pypeitpar
 from pypeit import utils
 from pypeit.images import pypeitimage
 from pypeit.images import imagebitmask
+
 
 class CombineImage:
     """
@@ -165,13 +164,8 @@ class CombineImage:
                 rn2img_stack = np.zeros(shape, dtype=float)
                 basev_stack = np.zeros(shape, dtype=float)
                 gpm_stack = np.zeros(shape, dtype=bool)
-                lampstat = [None]*self.nimgs
                 exptime = np.zeros(self.nimgs, dtype=float)
 
-            # Save the lamp status
-            # TODO: As far as I can tell, this is the *only* place rawheadlist
-            # is used.  Is there a way we can get this from fitstbl instead?
-            lampstat[kk] = self.spectrograph.get_lamps_status(rawImage.rawheadlist)
             # Save the exposure time to check if it's consistent for all images.
             exptime[kk] = rawImage.exptime
             # Processed image
@@ -195,25 +189,7 @@ class CombineImage:
             gpm_stack[kk] = rawImage.select_flag(invert=True)
             file_list.append(rawImage.filename)
 
-        # TODO JFH: This should not be here, but rather should be done in the Calibrations class. Putting in calibration specific
-        # lamp checking in an image combining class is not ideal. 
-        # Check that the lamps being combined are all the same:
-        if not lampstat[1:] == lampstat[:-1]:
-            msgs.warn("The following files contain different lamp status")
-            # Get the longest strings
-            maxlen = max([len("Filename")]+[len(os.path.split(x)[1]) for x in self.files])
-            maxlmp = max([len("Lamp status")]+[len(x) for x in lampstat])
-            strout = "{0:" + str(maxlen) + "}  {1:s}"
-            # Print the messages
-            print(msgs.indent() + '-'*maxlen + "  " + '-'*maxlmp)
-            print(msgs.indent() + strout.format("Filename", "Lamp status"))
-            print(msgs.indent() + '-'*maxlen + "  " + '-'*maxlmp)
-            for ff, file in enumerate(self.files):
-                print(msgs.indent()
-                      + strout.format(os.path.split(file)[1], " ".join(lampstat[ff].split("_"))))
-            print(msgs.indent() + '-'*maxlen + "  " + '-'*maxlmp)
-
-        # Do a similar check for exptime
+        # Check that all exposure times are consistent
         if np.any(np.absolute(np.diff(exptime)) > 0):
             # TODO: This should likely throw an error instead!
             msgs.warn('Exposure time is not consistent for all images being combined!  '

--- a/pypeit/images/combineimage.py
+++ b/pypeit/images/combineimage.py
@@ -190,6 +190,7 @@ class CombineImage:
             file_list.append(rawImage.filename)
 
         # Check that all exposure times are consistent
+        # TODO: JFH suggests that we move this to calibrations.check_calibrations
         if np.any(np.absolute(np.diff(exptime)) > 0):
             # TODO: This should likely throw an error instead!
             msgs.warn('Exposure time is not consistent for all images being combined!  '

--- a/pypeit/spectrographs/jwst_nirspec.py
+++ b/pypeit/spectrographs/jwst_nirspec.py
@@ -254,22 +254,6 @@ class JWSTNIRSpecSpectrograph(spectrograph.Spectrograph):
             ``PypeIt``.
         """
         return [(1,2)]
-
-
-
-    def get_lamps_status(self, headarr):
-        """
-        Return a string containing the information on the lamp status.
-
-        Args:
-            headarr (:obj:`list`):
-                A list of 1 or more `astropy.io.fits.Header`_ objects.
-
-        Returns:
-            :obj:`str`: A string that uniquely represents the lamp status.
-        """
-        # TODO: JFH This is a hack to deal with the usage of this method in combineimage, which is not where it should be. 
-        return None
     
     def get_rawimage(self, raw_file, det):
         """


### PR DESCRIPTION
Moving the lamp check to outside the `CombineImage` task. Unit tests are good on my machine.