### PR TITLE
HOTFIX: pyqt6 version and ginga connection timeout

### DIFF
--- a/pypeit/display/display.py
+++ b/pypeit/display/display.py
@@ -60,7 +60,7 @@ def connect_to_ginga(host='localhost', port=9000, raise_err=False, allow_new=Fal
             # was just instantiated for a maximum number of iterations.
             # If the connection is remains unsuccessful, an error is
             # thrown stating that the connection timed out.
-            maxiter = int(1e6)
+            maxiter = int(3e4)
             for i in range(maxiter):
                 try:
                     viewer = grc.RemoteClient(host, port)
@@ -72,8 +72,9 @@ def connect_to_ginga(host='localhost', port=9000, raise_err=False, allow_new=Fal
                     break
             if i == maxiter-1:
                 msgs.error('Timeout waiting for ginga to start.  If window does not appear, type '
-                           '`ginga --modules=RC,SlitWavelength` on the command line.  In either case, wait for '
-                           'the ginga viewer to open and try the pypeit command again.')
+                           '`ginga --modules=RC,SlitWavelength` on the command line.  In either '
+                           'case, wait for the ginga viewer to open and try the pypeit command '
+                           'again.')
             return viewer
 
         if raise_err:

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ python_requires = >=3.10,<3.13
 setup_requires = setuptools_scm
 include_package_data = True
 install_requires =
-    numpy<2.0.0
+    numpy>=1.23,<2.0.0
     astropy>=6.0
     extension-helpers>=0.1
     packaging>=0.19

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ install_requires =
     qtpy>=2.0.1
     pygithub
     bottleneck
-    pyqt6
+    pyqt6<=6.7.0
 scripts =
     bin/pypeit_c_enabled
     bin/pypeit_chk_plugins

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ python_requires = >=3.10,<3.13
 setup_requires = setuptools_scm
 include_package_data = True
 install_requires =
-    numpy>=1.23
+    numpy<2.0.0
     astropy>=6.0
     extension-helpers>=0.1
     packaging>=0.19


### PR DESCRIPTION
As titled.  Note this is going straight to `release`.