### PR TITLE
Specify `remote_host` in call to PypeItDataPath

### DIFF
--- a/pypeit/scripts/cache_github_data.py
+++ b/pypeit/scripts/cache_github_data.py
@@ -130,7 +130,7 @@ class CacheGithubData(scriptbase.ScriptBase):
             files = np.array(contents[path])[to_download[path]]
             if len(files) == 0:
                 continue
-            data_path = PypeItDataPath(path)
+            data_path = PypeItDataPath(path, remote_host="github")
             # NOTE: I'm using POSIX path here because I'm unsure what will
             # happen on Windows if the file is in a subdirectory.
             root = pathlib.PurePosixPath(f'pypeit/data/{path}')


### PR DESCRIPTION
When caching from GitHub using the script `pypeit_cache_github_data`, an error was kicked complaining about "Remote host type None is not supported for package data caching."  This commit corrects the issue by specifying the `remote_host` in the instantiation of PypeItDataPath.

	modified:   pypeit/scripts/cache_github_data.py