### PR TITLE
Spatial flexure reorganisation

### DIFF
--- a/pypeit/calibrations.py
+++ b/pypeit/calibrations.py
@@ -771,8 +771,8 @@ class Calibrations:
 
         # get pixel flat frames
         pixel_frame = {'type': 'pixelflat', 'class': flatfield.FlatImages}
-        raw_pixel_files, pixel_cal_file, pixel_calib_key, pixel_setup, pixel_calib_id, detname \
-            = [], None, None, illum_setup, None, detname
+        raw_pixel_files, raw_pixel_index, pixel_cal_file, pixel_calib_key, pixel_setup, pixel_calib_id, detname \
+            = [], [], None, None, illum_setup, None, detname
         # read in the raw pixelflat frames only if the user has not provided a pixelflat_file
         if self.par['flatfield']['pixelflat_file'] is None:
             raw_pixel_files, raw_pixel_index, pixel_cal_file, pixel_calib_key, pixel_setup, pixel_calib_id, detname \

--- a/pypeit/calibrations.py
+++ b/pypeit/calibrations.py
@@ -392,7 +392,7 @@ class Calibrations:
         self.msarc = buildimage.buildimage_fromlist(self.spectrograph, self.det,
                                                     self.par['arcframe'], raw_files,
                                                     bias=self.msbias, bpm=self.msbpm,
-                                                    dark=self.msdark, calib_dir=self.calib_dir,
+                                                    dark=self.msdark, slits=self.slits, calib_dir=self.calib_dir,
                                                     setup=setup, calib_id=calib_id,
                                                     manual_spat_flexure=manual_spat_flexure)
         # Save the result

--- a/pypeit/calibrations.py
+++ b/pypeit/calibrations.py
@@ -270,6 +270,9 @@ class Calibrations:
         raw_files : :obj:`list`
             The list of raw files in :attr:`fitstbl` with the provided
             frametype.
+        rows : :obj:`numpy.ndarray`
+            The indices of the raw files in :attr:`fitstbl` with the provided
+            frametype.
         cal_file : `Path`_
             The path with/for the processed calibration frame
         calib_key : :obj:`str`
@@ -297,12 +300,12 @@ class Calibrations:
             setup = self.fitstbl['setup'][self.frame]
             cal_file = frameclass.glob(self.calib_dir, setup, self.calib_ID, detname=detname)
             if cal_file is None or len(cal_file) > 1:
-                return [], None, None, setup, None, detname
+                return [], rows, None, None, setup, None, detname
 
             cal_file = cal_file[0]
             calib_key = frameclass.parse_key_dir(str(cal_file), from_filename=True)[0]
             calib_id = frameclass.parse_calib_key(calib_key)[1]
-            return [], cal_file, calib_key, setup, frameclass.ingest_calib_id(calib_id), detname
+            return [], rows, cal_file, calib_key, setup, frameclass.ingest_calib_id(calib_id), detname
 
         # Otherwise, use the metadata for the raw frames to set the name of
         # the processed calibration frame.
@@ -312,7 +315,7 @@ class Calibrations:
         # Construct the expected calibration frame file name
         cal_file = Path(frameclass.construct_file_name(calib_key, calib_dir=self.calib_dir))
 
-        return self.fitstbl.frame_paths(rows), cal_file, calib_key, setup, \
+        return self.fitstbl.frame_paths(rows), rows, cal_file, calib_key, setup, \
                     frameclass.ingest_calib_id(calib_id), detname
 
     def set_config(self, frame, det, par=None):
@@ -360,7 +363,7 @@ class Calibrations:
 
         # Find the calibrations
         frame = {'type': 'arc', 'class': buildimage.ArcImage}
-        raw_files, cal_file, calib_key, setup, calib_id, detname \
+        raw_files, raw_index, cal_file, calib_key, setup, calib_id, detname \
                 = self.find_calibrations(frame['type'], frame['class'])
 
         if len(raw_files) == 0 and cal_file is None:
@@ -381,13 +384,17 @@ class Calibrations:
         # Perform a check on the files
         self.check_calibrations(raw_files)
 
+        # If a manual spatial flexure is requested for any of the frames, collect it now
+        manual_spat_flexure = self.fitstbl.get_shifts(raw_index)
+
         # Otherwise, create the processed file.
         msgs.info(f'Preparing a {frame["class"].calib_type} calibration frame.')
         self.msarc = buildimage.buildimage_fromlist(self.spectrograph, self.det,
                                                     self.par['arcframe'], raw_files,
                                                     bias=self.msbias, bpm=self.msbpm,
                                                     dark=self.msdark, calib_dir=self.calib_dir,
-                                                    setup=setup, calib_id=calib_id)
+                                                    setup=setup, calib_id=calib_id,
+                                                    manual_spat_flexure=manual_spat_flexure)
         # Save the result
         self.msarc.to_file()
         # Return it
@@ -406,7 +413,7 @@ class Calibrations:
 
         # Find the calibrations
         frame = {'type': 'tilt', 'class':buildimage.TiltImage}
-        raw_files, cal_file, calib_key, setup, calib_id, detname \
+        raw_files, raw_index, cal_file, calib_key, setup, calib_id, detname \
                 = self.find_calibrations(frame['type'], frame['class'])
 
         if len(raw_files) == 0 and cal_file is None:
@@ -427,6 +434,9 @@ class Calibrations:
         # Perform a check on the files
         self.check_calibrations(raw_files)
 
+        # If a manual spatial flexure is requested for any of the frames, collect it now
+        manual_spat_flexure = self.fitstbl.get_shifts(raw_index)
+
         # Otherwise, create the processed file.
         msgs.info(f'Preparing a {frame["class"].calib_type} calibration frame.')
         self.mstilt = buildimage.buildimage_fromlist(self.spectrograph, self.det,
@@ -434,7 +444,8 @@ class Calibrations:
                                                      bias=self.msbias, bpm=self.msbpm,
                                                      dark=self.msdark, slits=self.slits,
                                                      calib_dir=self.calib_dir, setup=setup,
-                                                     calib_id=calib_id)
+                                                     calib_id=calib_id,
+                                                     manual_spat_flexure=manual_spat_flexure)
         # Save the result
         self.mstilt.to_file()
         # Return it
@@ -457,7 +468,7 @@ class Calibrations:
 
         # Find the calibrations
         frame = {'type': 'align', 'class': alignframe.Alignments}
-        raw_files, cal_file, calib_key, setup, calib_id, detname \
+        raw_files, raw_index, cal_file, calib_key, setup, calib_id, detname \
                 = self.find_calibrations(frame['type'], frame['class'])
 
         if len(raw_files) == 0 and cal_file is None:
@@ -479,13 +490,17 @@ class Calibrations:
         # Perform a check on the files
         self.check_calibrations(raw_files)
 
+        # If a manual spatial flexure is requested for any of the frames, collect it now
+        manual_spat_flexure = self.fitstbl.get_shifts(raw_index)
+
         # Otherwise, create the processed file.
         msgs.info(f'Preparing a {frame["class"].calib_type} calibration frame.')
         msalign = buildimage.buildimage_fromlist(self.spectrograph, self.det,
                                                  self.par['alignframe'], raw_files,
                                                  bias=self.msbias, bpm=self.msbpm,
                                                  dark=self.msdark, calib_dir=self.calib_dir,
-                                                 setup=setup, calib_id=calib_id)
+                                                 setup=setup, calib_id=calib_id,
+                                                 manual_spat_flexure=manual_spat_flexure)
 
         # Instantiate
         # TODO: From JFH: Do we need the bpm here?  Check that this was in the previous code.
@@ -511,7 +526,7 @@ class Calibrations:
 
         # Find the calibrations
         frame = {'type': 'bias', 'class': buildimage.BiasImage}
-        raw_files, cal_file, calib_key, setup, calib_id, detname \
+        raw_files, raw_index, cal_file, calib_key, setup, calib_id, detname \
                 = self.find_calibrations(frame['type'], frame['class'])
 
         if len(raw_files) == 0 and cal_file is None:
@@ -553,7 +568,7 @@ class Calibrations:
 
         # Find the calibrations
         frame = {'type': 'dark', 'class': buildimage.DarkImage}
-        raw_files, cal_file, calib_key, setup, calib_id, detname \
+        raw_files, raw_index, cal_file, calib_key, setup, calib_id, detname \
                 = self.find_calibrations(frame['type'], frame['class'])
 
         if len(raw_files) == 0 and cal_file is None:
@@ -632,7 +647,7 @@ class Calibrations:
 
         # Prep
         frame = {'type': 'scattlight', 'class': scattlight.ScatteredLight}
-        raw_scattlight_files, cal_file, calib_key, setup, calib_id, detname = \
+        raw_scattlight_files, raw_scattlight_index, cal_file, calib_key, setup, calib_id, detname = \
             self.find_calibrations(frame['type'], frame['class'])
         scatt_idx = self.fitstbl.find_frames(frame['type'], calib_ID=self.calib_ID, index=True)
 
@@ -659,13 +674,17 @@ class Calibrations:
         # Perform a check on the files
         self.check_calibrations(raw_scattlight_files)
 
+        # If a manual spatial flexure is requested for any of the frames, collect it now
+        manual_spat_flexure = self.fitstbl.get_shifts(raw_scattlight_index)
+
         binning = self.fitstbl[scatt_idx[0]]['binning']
         dispname = self.fitstbl[scatt_idx[0]]['dispname']
         scattlightImage = buildimage.buildimage_fromlist(self.spectrograph, self.det,
                                                          self.par['scattlightframe'], raw_scattlight_files,
                                                          bias=self.msbias, bpm=self.msbpm,
                                                          dark=self.msdark, calib_dir=self.calib_dir,
-                                                         setup=setup, calib_id=calib_id)
+                                                         setup=setup, calib_id=calib_id,
+                                                         manual_spat_flexure=manual_spat_flexure)
 
         spatbin = parse.parse_binning(binning)[1]
         pad = self.par['scattlight_pad'] // spatbin
@@ -747,7 +766,7 @@ class Calibrations:
 
         # get illumination flat frames
         illum_frame = {'type': 'illumflat', 'class': flatfield.FlatImages}
-        raw_illum_files, illum_cal_file, illum_calib_key, illum_setup, illum_calib_id, detname \
+        raw_illum_files, raw_illum_index, illum_cal_file, illum_calib_key, illum_setup, illum_calib_id, detname \
                 = self.find_calibrations(illum_frame['type'], illum_frame['class'])
 
         # get pixel flat frames
@@ -756,11 +775,12 @@ class Calibrations:
             = [], None, None, illum_setup, None, detname
         # read in the raw pixelflat frames only if the user has not provided a pixelflat_file
         if self.par['flatfield']['pixelflat_file'] is None:
-            raw_pixel_files, pixel_cal_file, pixel_calib_key, pixel_setup, pixel_calib_id, detname \
+            raw_pixel_files, raw_pixel_index, pixel_cal_file, pixel_calib_key, pixel_setup, pixel_calib_id, detname \
                 = self.find_calibrations(pixel_frame['type'], pixel_frame['class'])
 
         # get lamp off flat frames
         raw_lampoff_files = self.fitstbl.find_frame_files('lampoffflats', calib_ID=self.calib_ID)
+        raw_lampoff_index = self.fitstbl.find_frames('lampoffflats', calib_ID=self.calib_ID, index=True)
 
         # Check if we have any calibration frames to work with
         if len(raw_pixel_files) == 0 and pixel_cal_file is None \
@@ -819,6 +839,9 @@ class Calibrations:
             # Perform a check on the files
             self.check_calibrations(raw_pixel_files)
 
+            # If a manual spatial flexure is requested for any of the frames, collect it now
+            manual_spat_flexure = self.fitstbl.get_shifts(raw_pixel_index)
+
             msgs.info('Creating pixel-flat calibration frame using files: ')
             for f in raw_pixel_files:
                 msgs.prindent(f'{Path(f).name}')
@@ -827,13 +850,17 @@ class Calibrations:
                                                         raw_pixel_files, dark=self.msdark,
                                                         slits=self.slits,
                                                         bias=self.msbias, bpm=self.msbpm,
-                                                        scattlight=self.msscattlight)
+                                                        scattlight=self.msscattlight,
+                                                        manual_spat_flexure=manual_spat_flexure)
             if len(raw_lampoff_files) > 0:
                 # Reset the BPM
                 self.get_bpm(frame=raw_lampoff_files[0])
 
                 # Perform a check on the files
                 self.check_calibrations(raw_lampoff_files)
+
+                # If a manual spatial flexure is requested for any of the frames, collect it now
+                manual_spat_flexure = self.fitstbl.get_shifts(raw_lampoff_index)
 
                 msgs.info('Subtracting lamp off flats using files: ')
                 for f in raw_lampoff_files:
@@ -843,7 +870,8 @@ class Calibrations:
                                                               raw_lampoff_files,
                                                               slits=self.slits,
                                                               dark=self.msdark, bias=self.msbias,
-                                                              bpm=self.msbpm, scattlight=self.msscattlight)
+                                                              bpm=self.msbpm, scattlight=self.msscattlight,
+                                                              manual_spat_flexure=manual_spat_flexure)
                 pixel_flat = pixel_flat.sub(lampoff_flat)
 
             # Initialise the pixel flat
@@ -865,6 +893,9 @@ class Calibrations:
             # Perform a check on the files
             self.check_calibrations(raw_illum_files)
 
+            # If a manual spatial flexure is requested for any of the frames, collect it now
+            manual_spat_flexure = self.fitstbl.get_shifts(raw_illum_index)
+
             msgs.info('Creating slit-illumination flat calibration frame using files: ')
             for f in raw_illum_files:
                 msgs.prindent(f'{Path(f).name}')
@@ -872,7 +903,8 @@ class Calibrations:
             illum_flat = buildimage.buildimage_fromlist(self.spectrograph, self.det,
                                                         self.par['illumflatframe'], raw_illum_files,
                                                         dark=self.msdark, bias=self.msbias, scattlight=self.msscattlight,
-                                                        slits=self.slits, flatimages=self.flatimages, bpm=self.msbpm)
+                                                        slits=self.slits, flatimages=self.flatimages, bpm=self.msbpm,
+                                                        manual_spat_flexure=manual_spat_flexure)
             if len(raw_lampoff_files) > 0:
                 msgs.info('Subtracting lamp off flats using files: ')
                 for f in raw_lampoff_files:
@@ -880,6 +912,9 @@ class Calibrations:
                 if lampoff_flat is None:
                     # Perform a check on the files
                     self.check_calibrations(raw_lampoff_files)
+
+                    # If a manual spatial flexure is requested for any of the frames, collect it now
+                    manual_spat_flexure = self.fitstbl.get_shifts(raw_lampoff_index)
 
                     # Build the image
                     lampoff_flat = buildimage.buildimage_fromlist(self.spectrograph, self.det,
@@ -889,7 +924,8 @@ class Calibrations:
                                                                   bias=self.msbias,
                                                                   slits=self.slits,
                                                                   scattlight=self.msscattlight,
-                                                                  bpm=self.msbpm)
+                                                                  bpm=self.msbpm,
+                                                                  manual_spat_flexure=manual_spat_flexure)
                 illum_flat = illum_flat.sub(lampoff_flat)
 
             # Initialise the illum flat
@@ -953,9 +989,10 @@ class Calibrations:
 
         # Prep
         frame = {'type': 'trace', 'class': slittrace.SlitTraceSet}
-        raw_trace_files, cal_file, calib_key, setup, calib_id, detname \
-                = self.find_calibrations(frame['type'], frame['class'])
+        raw_trace_files, raw_trace_index, cal_file, calib_key, setup, calib_id, detname \
+            = self.find_calibrations(frame['type'], frame['class'])
         raw_lampoff_files = self.fitstbl.find_frame_files('lampoffflats', calib_ID=self.calib_ID)
+        raw_lampoff_index = self.fitstbl.find_frames('lampoffflats', calib_ID=self.calib_ID, index=True)
 
         if len(raw_trace_files) == 0 and cal_file is None:
             msgs.warn(f'No raw {frame["type"]} frames found and unable to identify a relevant '
@@ -998,12 +1035,16 @@ class Calibrations:
         # Perform a check on the files
         self.check_calibrations(raw_trace_files)
 
+        # If a manual spatial flexure is requested for any of the frames, collect it now
+        manual_spat_flexure = self.fitstbl.get_shifts(raw_trace_index)
+
         traceImage = buildimage.buildimage_fromlist(self.spectrograph, self.det,
                                                     self.par['traceframe'], raw_trace_files,
                                                     bias=self.msbias, bpm=self.msbpm,
                                                     scattlight=self.msscattlight,
                                                     dark=self.msdark, calib_dir=self.calib_dir,
-                                                    setup=setup, calib_id=calib_id)
+                                                    setup=setup, calib_id=calib_id,
+                                                    manual_spat_flexure=manual_spat_flexure)
         if len(raw_lampoff_files) > 0:
             msgs.info('Subtracting lamp off flats using files: ')
             for f in raw_lampoff_files:
@@ -1015,11 +1056,15 @@ class Calibrations:
             # Perform a check on the files
             self.check_calibrations(raw_lampoff_files)
 
+            # If a manual spatial flexure is requested for any of the frames, collect it now
+            manual_spat_flexure = self.fitstbl.get_shifts(raw_lampoff_index)
+
             lampoff_flat = buildimage.buildimage_fromlist(self.spectrograph, self.det,
                                                           self.par['lampoffflatsframe'],
                                                           raw_lampoff_files, dark=self.msdark,
                                                           bias=self.msbias, scattlight=self.msscattlight,
-                                                          bpm=self.msbpm)
+                                                          bpm=self.msbpm,
+                                                          manual_spat_flexure=manual_spat_flexure)
             traceImage = traceImage.sub(lampoff_flat)
 
         edges = edgetrace.EdgeTraceSet(traceImage, self.spectrograph, self.par['slitedges'],
@@ -1076,7 +1121,7 @@ class Calibrations:
 
         # Find the calibrations
         frame = {'type': 'arc', 'class': wavecalib.WaveCalib}
-        raw_files, cal_file, calib_key, setup, calib_id, detname \
+        raw_files, raw_index, cal_file, calib_key, setup, calib_id, detname \
                 = self.find_calibrations(frame['type'], frame['class'])
 
         if len(raw_files) == 0 and cal_file is None:
@@ -1155,7 +1200,7 @@ class Calibrations:
 
         # Find the calibrations
         frame = {'type': 'tilt', 'class': wavetilts.WaveTilts}
-        raw_files, cal_file, calib_key, setup, calib_id, detname \
+        raw_files, raw_index, cal_file, calib_key, setup, calib_id, detname \
                 = self.find_calibrations(frame['type'], frame['class'])
 
         if len(raw_files) == 0 and cal_file is None:

--- a/pypeit/images/buildimage.py
+++ b/pypeit/images/buildimage.py
@@ -160,7 +160,7 @@ All of these **must** subclass from
 
 def buildimage_fromlist(spectrograph, det, frame_par, file_list, bias=None, bpm=None, dark=None,
                         scattlight=None, flatimages=None, maxiters=5, ignore_saturation=True,
-                        slits=None, mosaic=None, calib_dir=None, setup=None, calib_id=None):
+                        slits=None, mosaic=None, manual_spat_flexure=None, calib_dir=None, setup=None, calib_id=None):
     """
     Perform basic image processing on a list of images and combine the results. All
     core processing steps for each image are handled by :class:`~pypeit.images.rawimage.RawImage` and
@@ -254,13 +254,14 @@ def buildimage_fromlist(spectrograph, det, frame_par, file_list, bias=None, bpm=
 
     rawImage_list = []
     # Loop on the files
-    for ifile in file_list:
+    for ii, ifile in enumerate(file_list):
         # Load raw image
         rawImage = rawimage.RawImage(ifile, spectrograph, det)
         # Process
         rawImage_list.append(rawImage.process(
             frame_par['process'], scattlight=scattlight, bias=bias,
-            bpm=bpm, dark=dark, flatimages=flatimages, slits=slits, mosaic=mosaic))
+            bpm=bpm, dark=dark, flatimages=flatimages, slits=slits, mosaic=mosaic,
+            manual_spat_flexure=manual_spat_flexure[ii]))
 
     # Do it
     combineImage = combineimage.CombineImage(rawImage_list, frame_par['process'])

--- a/pypeit/images/buildimage.py
+++ b/pypeit/images/buildimage.py
@@ -247,6 +247,7 @@ def buildimage_fromlist(spectrograph, det, frame_par, file_list, bias=None, bpm=
         # NOTE: This should not be necessary because FrameGroupPar explicitly
         # requires frametype to be valid
         msgs.error(f'{frame_par["frametype"]} is not a valid PypeIt frame type.')
+    manual_spatflex = manual_spat_flexure if manual_spat_flexure is not None else [np.ma.masked]*len(file_list)
 
     # Should the detectors be reformatted into a single image mosaic?
     if mosaic is None:
@@ -261,7 +262,7 @@ def buildimage_fromlist(spectrograph, det, frame_par, file_list, bias=None, bpm=
         rawImage_list.append(rawImage.process(
             frame_par['process'], scattlight=scattlight, bias=bias,
             bpm=bpm, dark=dark, flatimages=flatimages, slits=slits, mosaic=mosaic,
-            manual_spat_flexure=manual_spat_flexure[ii]))
+            manual_spat_flexure=manual_spatflex[ii]))
 
     # Do it
     combineImage = combineimage.CombineImage(rawImage_list, frame_par['process'])

--- a/pypeit/images/buildimage.py
+++ b/pypeit/images/buildimage.py
@@ -222,6 +222,9 @@ def buildimage_fromlist(spectrograph, det, frame_par, file_list, bias=None, bpm=
             Flag processed image will be a mosaic of multiple detectors.  By
             default, this is determined by the format of ``det`` and whether or
             not this is a bias or dark frame.  *Only used for testing purposes.*
+        manual_spat_flexure (:obj:`list`, `numpy.ndarray`_, optional):
+            A list of the spatial flexures for each image in file_list.  This is only
+            used to manually correct the slit traces for spatial flexure of each image.
         calib_dir (:obj:`str`, `Path`_, optional):
             The directory for processed calibration files.  Required for
             elements of :attr:`frame_image_classes`, ignored otherwise.

--- a/pypeit/images/rawimage.py
+++ b/pypeit/images/rawimage.py
@@ -672,7 +672,8 @@ class RawImage:
         # function checks that the slits exist if running the spatial flexure
         # correction, so no need to do it again here.
         self.spat_flexure_shift = None
-        if self.par['spat_flexure_method'] != "skip" or not np.ma.is_masked(manual_spat_flexure):
+        if slits is not None and \
+                (self.par['spat_flexure_method'] != "skip" or not np.ma.is_masked(manual_spat_flexure)):
             self.spat_flexure_shift = self.spatial_flexure_shift(slits, method=self.par['spat_flexure_method'],
                                                                  manual_spat_flexure=manual_spat_flexure,
                                                                  maxlag=self.par['spat_flexure_maxlag'])
@@ -820,12 +821,12 @@ class RawImage:
 
         # Print the flexure values
         if np.all(spat_flexure == spat_flexure[0, 0]):
-            msgs.info(f'Spatial flexure is: {spat_flexure[0, 0]}')
+            msgs.info(f'Spatial flexure is: {spat_flexure[0, 0]} pixels')
         else:
             # Print the flexure values for each slit separately
             for slit in range(spat_flexure.shape[0]):
                 msgs.info(
-                    f'Spatial flexure for slit {slits.spat_id[slit]} is: left={spat_flexure[slit, 0]} right={spat_flexure[slit, 1]}')
+                    f'Spatial flexure for slit {slits.spat_id[slit]} is: left={spat_flexure[slit, 0]} pixels; right={spat_flexure[slit, 1]} pixels')
 
         self.steps[step] = True
         # Return

--- a/pypeit/images/rawimage.py
+++ b/pypeit/images/rawimage.py
@@ -672,8 +672,7 @@ class RawImage:
         # function checks that the slits exist if running the spatial flexure
         # correction, so no need to do it again here.
         self.spat_flexure_shift = None
-        if slits is not None and \
-                (self.par['spat_flexure_method'] != "skip" or not np.ma.is_masked(manual_spat_flexure)):
+        if self.par['spat_flexure_method'] != "skip" or not np.ma.is_masked(manual_spat_flexure):
             self.spat_flexure_shift = self.spatial_flexure_shift(slits, method=self.par['spat_flexure_method'],
                                                                  manual_spat_flexure=manual_spat_flexure,
                                                                  maxlag=self.par['spat_flexure_maxlag'])
@@ -777,7 +776,7 @@ class RawImage:
         :func:`~pypeit.core.flexure.spat_flexure_shift`.
 
         Args:
-            slits (:class:`~pypeit.slittrace.SlitTraceSet`, optional):
+            slits (:class:`~pypeit.slittrace.SlitTraceSet`):
                 Slit edge traces
             force (:obj:`bool`, optional):
                 Force the image to be field flattened, even if the step log
@@ -811,6 +810,14 @@ class RawImage:
         if self.nimg > 1:
             msgs.error('CODING ERROR: Must use a single image (single detector or detector '
                        'mosaic) to determine spatial flexure.')
+
+        # Check if the slits are provided
+        if slits is None:
+            if not np.ma.is_masked(manual_spat_flexure):
+                msgs.warn('Manual spatial flexure provided without slits - assuming no spatial flexure.')
+            else:
+                msgs.warn('Cannot calculate spatial flexure without slits - assuming no spatial flexure.')
+            return
 
         # First check for manual flexure
         if not np.ma.is_masked(manual_spat_flexure):

--- a/pypeit/images/rawimage.py
+++ b/pypeit/images/rawimage.py
@@ -519,6 +519,9 @@ class RawImage:
                 mosaic.  If flats or slits are provided (and used), this *must*
                 be true because these objects are always defined in the mosaic
                 frame.
+            manual_spat_flexure (:obj:`float`, optional):
+                The spatial flexure of the image. This is only set if the user wishes to
+                manually correct the slit traces of this image for spatial flexure.
             debug (:obj:`bool`, optional):
                 Run in debug mode.
 

--- a/pypeit/inputfiles.py
+++ b/pypeit/inputfiles.py
@@ -481,20 +481,21 @@ class InputFile:
         ## Build full paths to file and set frame types
         data_files = []
         for row in self.data:
+            rowkey = '' if np.ma.is_masked(row[key]) else row[key]
 
             # Skip Empty entries?
-            if skip_blank and row[key].strip() in ['', 'none', 'None']:
+            if skip_blank and rowkey.strip() in ['', 'none', 'None']:
                 continue
 
             # Skip commented out entries
-            if row[key].strip().startswith("#"):
+            if rowkey.strip().startswith("#"):
                 if not include_commented_out:
                     continue
                 # Strip the comment character and any whitespace following it
                 # from the filename
-                name = row[key].strip("# ")
+                name = rowkey.strip("# ")
             else:
-                name = row[key]
+                name = rowkey
 
             # Searching..
             if len(self.file_paths) > 0:
@@ -503,7 +504,7 @@ class InputFile:
                     if os.path.isfile(filename):
                         break
             else:
-                filename = row[key]
+                filename = rowkey
 
             # Check we got a good hit
             if check_exists and not os.path.isfile(filename):

--- a/pypeit/metadata.py
+++ b/pypeit/metadata.py
@@ -497,8 +497,9 @@ class PypeItMetaData:
         _obstime = self.construct_obstime(row) if obstime is None else obstime
         tiso = time.Time(_obstime, format='isot')
         dtime = datetime.datetime.strptime(tiso.value, '%Y-%m-%dT%H:%M:%S.%f')
+        this_target = "TargetName" if np.ma.is_masked(self['target'][row]) else self['target'][row].replace(" ", "")
         return '{0}-{1}_{2}_{3}{4}'.format(self['filename'][row].split('.fits')[0],
-                                           self['target'][row].replace(" ", ""),
+                                           this_target,
                                            self.spectrograph.camera,
                                            datetime.datetime.strftime(dtime, '%Y%m%dT'),
                                            tiso.value.split("T")[1].replace(':',''))

--- a/pypeit/metadata.py
+++ b/pypeit/metadata.py
@@ -1596,7 +1596,7 @@ class PypeItMetaData:
 
         """
         if 'manual' not in self.keys():
-            self['manual'] = ''
+            self['manual'] = np.ma.array(np.zeros(len(self)), mask=np.ones(len(self), dtype=bool))
         if 'shift' not in self.keys():
             # Instantiate a masked array
             self['shift'] = np.ma.array(np.zeros(len(self)), mask=np.ones(len(self), dtype=bool))

--- a/pypeit/metadata.py
+++ b/pypeit/metadata.py
@@ -1309,9 +1309,30 @@ class PypeItMetaData:
         Returns:
             list: List of the full paths of one or more frames.
         """
-        if isinstance(indx, (int,np.integer)):
+        if isinstance(indx, (int, np.integer)):
             return os.path.join(self['directory'][indx], self['filename'][indx])
         return [os.path.join(d,f) for d,f in zip(self['directory'][indx], self['filename'][indx])]
+
+    def get_shifts(self, indx):
+        """
+        Return the shifts for the provided rows.
+
+        Args:
+            indx (:obj:`int`, array-like):
+                One or more 0-indexed rows in the table with the frames
+                to return.  Can be an array of indices or a boolean
+                array of the correct length.
+
+        Returns:
+            `numpy.ndarray`_: Array with the shifts.
+        """
+        # Make indx an array
+        _indx = np.atleast_1d(indx)
+        # Check if shifts are defined, if not, return a masked array
+        if 'shift' not in self.keys():
+            return np.ma.array(np.zeros(_indx.shape), mask=np.ones(_indx.shape, dtype=bool))
+        # Otherwise, return the shifts
+        return self['shift'][indx]
 
     def set_frame_types(self, type_bits, merge=True):
         """

--- a/pypeit/pypeit.py
+++ b/pypeit/pypeit.py
@@ -823,7 +823,7 @@ class PypeIt:
         # Deal with manual extraction
         row = self.fitstbl[frames[0]]
         manual_obj = ManualExtractionObj.by_fitstbl_input(
-            row['filename'], row['manual'], self.spectrograph) if len(row['manual'].strip()) > 0 else None
+            row['filename'], row['manual'], self.spectrograph) if not np.ma.is_masked(row['manual']) else None
 
         # Instantiate Reduce object
         # Required for pypeline specific object

--- a/pypeit/pypeit.py
+++ b/pypeit/pypeit.py
@@ -776,6 +776,7 @@ class PypeIt:
 
         # Build Science image
         sci_files = self.fitstbl.frame_paths(frames)
+        manual_spat_flexure = self.fitstbl.get_shifts(frames)
         sciImg = buildimage.buildimage_fromlist(
             self.spectrograph, det, frame_par,
             sci_files, bias=self.caliBrate.msbias, bpm=self.caliBrate.msbpm,
@@ -783,7 +784,8 @@ class PypeIt:
             scattlight=self.caliBrate.msscattlight,
             flatimages=self.caliBrate.flatimages,
             slits=self.caliBrate.slits,  # For flexure correction
-            ignore_saturation=False)
+            ignore_saturation=False,
+            manual_spat_flexure=manual_spat_flexure)
 
         # get no bkg subtracted sciImg to generate a global sky model without bkg subtraction.
         # it's a dictionary with only `image` and `ivar` keys if bkg_redux=False, otherwise it's None
@@ -795,6 +797,7 @@ class PypeIt:
             bkg_redux_sciimg = sciImg
             # Build the background image
             bg_file_list = self.fitstbl.frame_paths(bg_frames)
+            bg_manual_spat_flexure = self.fitstbl.get_shifts(bg_frames)
             # TODO I think we should create a separate self.par['bkgframe'] parameter set to hold the image
             # processing parameters for the background frames.  This would allow the user to specify different
             # parameters for the background frames than for the science frames.  
@@ -805,45 +808,17 @@ class PypeIt:
                                                    scattlight=self.caliBrate.msscattlight,
                                                    flatimages=self.caliBrate.flatimages,
                                                    slits=self.caliBrate.slits,
-                                                   ignore_saturation=False)
+                                                   ignore_saturation=False,
+                                                   manual_spat_flexure=bg_manual_spat_flexure)
 
             # NOTE: If the spatial flexure exists for sciImg, the subtraction
             # function propagates that to the subtracted image, ignoring any
             # spatial flexure determined for the background image.
             sciImg = bkg_redux_sciimg.sub(bgimg)
 
-        # Flexure
-        spat_flexure = np.zeros((self.caliBrate.slits.nslits, 2))  # No spatial flexure, unless we find it below
-        # use the flexure correction in the "shift" column
-        manual_flexure = self.fitstbl[frames[0]]['shift']
-        if (self.objtype == 'science' and self.par['scienceframe']['process']['spat_flexure_method'] != "skip") or \
-                (self.objtype == 'standard' and self.par['calibrations']['standardframe']['process']['spat_flexure_method'] != "skip") or \
-                not np.ma.is_masked(manual_flexure):
-            # First check for manual flexure
-            if not np.ma.is_masked(manual_flexure):
-                msgs.info(f'Implementing manual spatial flexure of {manual_flexure} pixels')
-                spat_flexure = np.full((self.caliBrate.slits.nslits, 2), np.float64(manual_flexure))
-                sciImg.spat_flexure = spat_flexure
-            else:
-                if sciImg.spat_flexure is not None:
-                    msgs.info(f'Using auto-computed spatial flexure')
-                    spat_flexure = sciImg.spat_flexure
-                else:
-                    msgs.info('Assuming no spatial flexure correction')
-        else:
-            msgs.info('Assuming no spatial flexure correction')
-
-        # Print the flexure values
-        if np.all(spat_flexure == spat_flexure[0, 0]):
-            msgs.info(f'Spatial flexure is: {spat_flexure[0, 0]}')
-        else:
-            # Print the flexure values for each slit separately
-            for slit in range(spat_flexure.shape[0]):
-                msgs.info(
-                    f'Spatial flexure for slit {self.caliBrate.slits.spat_id[slit]} is: left={spat_flexure[slit, 0]} right={spat_flexure[slit, 1]}')
         # Build the initial sky mask
         initial_skymask = self.load_skyregions(initial_slits=self.spectrograph.pypeline != 'SlicerIFU',
-                                               scifile=sciImg.files[0], frame=frames[0], spat_flexure=spat_flexure)
+                                               scifile=sciImg.files[0], frame=frames[0], spat_flexure=sciImg.spat_flexure)
 
         # Deal with manual extraction
         row = self.fitstbl[frames[0]]

--- a/pypeit/spec2dobj.py
+++ b/pypeit/spec2dobj.py
@@ -580,7 +580,15 @@ class AllSpec2DObj:
         # Add the spectrograph-specific sub-header
         if subheader is not None:
             for key in subheader.keys():
-                hdr[key.upper()] = subheader[key]
+                # Find the value and check if it is masked
+                if isinstance(subheader[key], (tuple, list)):
+                    # value + comment
+                    _value = ('', subheader[key][1]) if np.ma.is_masked(subheader[key][0]) else subheader[key]
+                else:
+                    # value only
+                    _value = '' if np.ma.is_masked(subheader[key]) else subheader[key]
+                # Update the header card with the corresponding value
+                hdr[key.upper()] = _value
 
         # PYPEIT
         # TODO Should the spectrograph be written to the header?

--- a/pypeit/specobjs.py
+++ b/pypeit/specobjs.py
@@ -811,10 +811,8 @@ class SpecObjs:
                     for line in str(subheader[key.upper()]).split('\n'):
                         header[key.upper()] = line
             else:
-                try:
-                    header[key.upper()] = subheader[key]
-                except:
-                    embed()
+                _value = ('', subheader[key][1]) if np.ma.is_masked(subheader[key][0]) else subheader[key]
+                header[key.upper()] = _value
                 # Also store the datetime in ISOT format
                 if key.upper() == 'MJD':
                     if isinstance(subheader[key], (list, tuple)):

--- a/pypeit/specobjs.py
+++ b/pypeit/specobjs.py
@@ -811,6 +811,7 @@ class SpecObjs:
                     for line in str(subheader[key.upper()]).split('\n'):
                         header[key.upper()] = line
             else:
+                # Find the value and check if it is masked
                 if isinstance(subheader[key], (tuple, list)):
                     # value + comment
                     _value = ('', subheader[key][1]) if np.ma.is_masked(subheader[key][0]) else subheader[key]

--- a/pypeit/specobjs.py
+++ b/pypeit/specobjs.py
@@ -811,7 +811,10 @@ class SpecObjs:
                     for line in str(subheader[key.upper()]).split('\n'):
                         header[key.upper()] = line
             else:
-                header[key.upper()] = subheader[key]
+                try:
+                    header[key.upper()] = subheader[key]
+                except:
+                    embed()
                 # Also store the datetime in ISOT format
                 if key.upper() == 'MJD':
                     if isinstance(subheader[key], (list, tuple)):

--- a/pypeit/specobjs.py
+++ b/pypeit/specobjs.py
@@ -811,7 +811,13 @@ class SpecObjs:
                     for line in str(subheader[key.upper()]).split('\n'):
                         header[key.upper()] = line
             else:
-                _value = ('', subheader[key][1]) if np.ma.is_masked(subheader[key][0]) else subheader[key]
+                if isinstance(subheader[key], (tuple, list)):
+                    # value + comment
+                    _value = ('', subheader[key][1]) if np.ma.is_masked(subheader[key][0]) else subheader[key]
+                else:
+                    # value only
+                    _value = '' if np.ma.is_masked(subheader[key]) else subheader[key]
+                # Update the header card with the corresponding value
                 header[key.upper()] = _value
                 # Also store the datetime in ISOT format
                 if key.upper() == 'MJD':


### PR DESCRIPTION
This delta PR moves the manual spatial flexure correction to the `RawImage`. The benefit of this approach is that manual spatial flexure can now be assigned for any frame (including calibrations). Previously, it was only science/standard/background frames that could have a manual flexure. Tests pass:

<img width="643" alt="image" src="https://github.com/user-attachments/assets/6903e803-0b07-4cbe-ba2d-8bdc63e43054">