### PR TITLE
Fix bug when reading mosaic data in files from previous pypeit versions.

### DIFF
--- a/doc/releases/1.16.1dev.rst
+++ b/doc/releases/1.16.1dev.rst
@@ -150,6 +150,8 @@ Bug Fixes
   the 'BOXSLIT' flag.
 - Fix a bug in `pypeit_coadd_2d` related to how the binning was taken into account
   in the mask definition, and in the calculation of the offset between frames.
+- Fix bug when trying to open mosaic data from previous versions; version
+  checking flag was not being propagated. 
 
 
 

--- a/pypeit/images/mosaic.py
+++ b/pypeit/images/mosaic.py
@@ -173,11 +173,6 @@ class Mosaic(datamodel.DataContainer):
             type_passed &= tp
         d['detectors'] = np.array(d['detectors'], dtype=object)
 
-#        d['detectors'] = np.array([DetectorContainer.from_hdu(
-#                                        fits.BinTableHDU(data=table.Table(tbl[i]),
-#                                                         name='DETECTOR', header=hdr))
-#                                    for i in range(ndet)])
-
         return d, version_passed, type_passed, parsed_hdus
 
 

--- a/pypeit/specobjs.py
+++ b/pypeit/specobjs.py
@@ -113,7 +113,7 @@ class SpecObjs:
                 # from_hdu method, and the name of the HDU must have a known format
                 # (e.g., 'DET01-DETECTOR').
                 _det = hdu.name.split('-')[0]
-                detector_hdus[_det] = dmodcls.from_hdu(hdu)
+                detector_hdus[_det] = dmodcls.from_hdu(hdu, chk_version=chk_version)
 
             # Now the objects
             for hdu in hdul[1:]:

--- a/pypeit/tests/test_mosaic.py
+++ b/pypeit/tests/test_mosaic.py
@@ -34,3 +34,7 @@ def test_io():
 
     # Should not fail because skipping the version check    
     _mpar = Mosaic.from_file(ofile, chk_version=False)
+
+    # Remove file
+    ofile = Path(ofile)
+    ofile.unlink()

--- a/pypeit/tests/test_mosaic.py
+++ b/pypeit/tests/test_mosaic.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+from IPython import embed
+
+import pytest
+
+from astropy.io import fits
+
+from pypeit.pypmsgs import PypeItDataModelError
+from pypeit.tests.tstutils import data_output_path
+from pypeit.images.mosaic import Mosaic
+from pypeit.spectrographs.util import load_spectrograph
+
+
+def test_io():
+    # Create the mosaic
+    spec = load_spectrograph('keck_deimos')
+    mpar = spec.get_mosaic_par((1,5))
+
+    # Write it
+    ofile = data_output_path('tmp_mosaic.fits')
+    mpar.to_file(ofile, overwrite=True)
+
+    # Try to read it
+    _mpar = Mosaic.from_file(ofile)
+
+    # Change the version
+    with fits.open(ofile) as hdu:
+        hdu['MOSAIC'].header['DMODVER'] = '1.0.0'
+        hdu.writeto(ofile, overwrite=True)
+
+    # Reading should fail because version is checked by default
+    with pytest.raises(PypeItDataModelError):
+        _mpar = Mosaic.from_file(ofile)
+
+    # Should not fail because skipping the version check    
+    _mpar = Mosaic.from_file(ofile, chk_version=False)

--- a/pypeit/tests/test_mosaic.py
+++ b/pypeit/tests/test_mosaic.py
@@ -24,17 +24,18 @@ def test_io():
     _mpar = Mosaic.from_file(ofile)
 
     # Change the version
+    _ofile = data_output_path('tmp_mosaic_wrongver.fits')
     with fits.open(ofile) as hdu:
         hdu['MOSAIC'].header['DMODVER'] = '1.0.0'
-        hdu.writeto(ofile, overwrite=True)
+        hdu.writeto(_ofile, overwrite=True)
 
     # Reading should fail because version is checked by default
     with pytest.raises(PypeItDataModelError):
-        _mpar = Mosaic.from_file(ofile)
+        _mpar = Mosaic.from_file(_ofile)
 
     # Should not fail because skipping the version check    
-    _mpar = Mosaic.from_file(ofile, chk_version=False)
+    _mpar = Mosaic.from_file(_ofile, chk_version=False)
 
-    # Remove file
-    ofile = Path(ofile)
-    ofile.unlink()
+    # Remove files
+    Path(ofile).unlink()
+    Path(_ofile).unlink()


### PR DESCRIPTION
As titled.  Addresses #1856 .

I added a Mosaic test and changed the code a bit, but the main fix is just from the one-line change in `specobjs.py`.

