### PR TITLE
Remove Spectrograph `idname()` method

### DIFF
--- a/pypeit/spectrographs/keck_deimos.py
+++ b/pypeit/spectrographs/keck_deimos.py
@@ -681,34 +681,6 @@ class KeckDEIMOSSpectrograph(spectrograph.Spectrograph):
         msgs.warn('Cannot determine if frames are of type {0}.'.format(ftype))
         return np.zeros(len(fitstbl), dtype=bool)
 
-    # TODO: We should aim to get rid of this... I'm not sure it's ever used...
-    def idname(self, ftype):
-        """
-        Return the ``idname`` for the selected frame type for this
-        instrument.
-
-        Args:
-            ftype (:obj:`str`):
-                Frame type, which should be one of the keys in
-                :class:`~pypeit.core.framematch.FrameTypeBitMask`.
-
-        Returns:
-            :obj:`str`: The value of ``idname`` that should be available in
-            the :class:`~pypeit.metadata.PypeItMetaData` instance that
-            identifies frames of this type.
-        """
-        # TODO: Fill in the rest of these.
-        name = { 'arc': 'Line',
-                 'tilt': None,
-                 'bias': None,
-                 'dark': None,
-                 'pinhole': None,
-                 'pixelflat': 'IntFlat',
-                 'science': 'Object',
-                 'standard': None,
-                 'trace': 'IntFlat' }
-        return name[ftype]
-
     def get_rawimage(self, raw_file, det):
         """
         Read raw images and generate a few other bits and pieces

--- a/pypeit/spectrographs/spectrograph.py
+++ b/pypeit/spectrographs/spectrograph.py
@@ -1735,28 +1735,6 @@ class Spectrograph:
 
         return type_bits
 
-    def idname(self, ftype):
-        """
-        Return the ``idname`` for the selected frame type for this
-        instrument.
-
-        Args:
-            ftype (:obj:`str`):
-                Frame type, which should be one of the keys in
-                :class:`~pypeit.core.framematch.FrameTypeBitMask`.
-
-        Returns:
-            :obj:`str`: The value of ``idname`` that should be available in
-            the :class:`~pypeit.metadata.PypeItMetaData` instance that
-            identifies frames of this type.
-
-        Raises:
-            NotImplementedError:
-                Raised by the base class to denote that any derived class has
-                not been properly defined.
-        """
-        raise NotImplementedError('Header keyword with frame type not defined for {0}.'.format(
-                                  self.name))
 
 #    JXP says -- LEAVE THIS HERE FOR NOW. WE MAY NEED IT
 #    def mm_per_pix(self, det=1):


### PR DESCRIPTION
The base class method raises a `NotImplementedError`, but only Keck/Deimos actually implements this method -- no other spectrograph does.

All frame types are defined in `pypeit/core/framematch.py`, and individual spectrograph classes now match raw frames with types from this list.

Since the `idname()` method is unused and unneeded, remove it from the base class and Keck/Deimos.