### PR TITLE
Adds SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,25 @@
+
+# Security Policy
+
+## Supported Versions
+
+Security vulnerability reports will be accepted and acted upon only for the
+supported versions of PypeIt, listed in the table below.
+
+|  Version | Supported          |
+| -------- | ------------------ |
+|  1.17.x  | :white_check_mark: |
+| < 1.17.0 | :x:                |
+
+## Reporting a Vulnerability
+
+If you have found a security vulnerability, please report it as soon as possible
+either by [email](mailto:pypeit@ucolick.org) or via a direct message to a PypeIt
+developer using one of our Slack spaces.
+
+**Do not** report the issue on GitHub for confidentiality reasons.
+
+Vulnerabilities will be accepted and acted on based on an assessment of their
+severity and risk to our users.  We will always respond to vulnerability reports
+and explain our assessment and related action.
+

--- a/doc/dev/development.rst
+++ b/doc/dev/development.rst
@@ -498,6 +498,8 @@ branch.  The tagging process is as follows:
           ``1.14.1.rst`` or ``1.15.0.rst``).  The ``doc/whatsnew.rst`` should
           also be updated to reflect the file name change.
 
+        * Update the list of supported versions in the ``SECURITY.md`` file.
+
         * Update the documentation by executing ``cd doc ; make clean ; make
           html``, add any updated files, and correct all errors/warnings.
 


### PR DESCRIPTION
As titled.  These have a standard format, and I modeled ours after:

https://github.com/matplotlib/matplotlib/blob/main/SECURITY.md
https://github.com/astropy/astropy/blob/main/SECURITY.md

Many repos (notably numpy and scipy) do not have these...

I think the pypeit@ucolick.org e-mail not longer exists, but I'm planning to set it up again.