### PR TITLE
Reduce nsnippet for R2500U grating

### DIFF
--- a/pypeit/spectrographs/gtc_osiris.py
+++ b/pypeit/spectrographs/gtc_osiris.py
@@ -374,6 +374,7 @@ class GTCOSIRISPlusSpectrograph(spectrograph.Spectrograph):
         elif self.get_meta_value(scifile, 'dispname') == 'R2500U':
             par['calibrations']['wavelengths']['lamps'] = ['XeI','HgI']
             par['calibrations']['wavelengths']['reid_arxiv'] = 'gtc_osiris_R2500U.fits'
+            par['calibrations']['wavelengths']['nsippet'] = 1
         elif self.get_meta_value(scifile, 'dispname') == 'R2500V':
             par['calibrations']['wavelengths']['lamps'] = ['HgI','NeI','XeI']
             par['calibrations']['wavelengths']['reid_arxiv'] = 'gtc_osiris_R2500V.fits'
@@ -952,6 +953,7 @@ class GTCOSIRISSpectrograph(spectrograph.Spectrograph):
         elif self.get_meta_value(scifile, 'dispname') == 'R2500U':
             par['calibrations']['wavelengths']['lamps'] = ['XeI','HgI']
             par['calibrations']['wavelengths']['reid_arxiv'] = 'gtc_osiris_R2500U.fits'
+            par['calibrations']['wavelengths']['nsippet'] = 1
         elif self.get_meta_value(scifile, 'dispname') == 'R2500V':
             par['calibrations']['wavelengths']['lamps'] = ['HgI','NeI','XeI']
             par['calibrations']['wavelengths']['reid_arxiv'] = 'gtc_osiris_R2500V.fits'


### PR DESCRIPTION
The R2500U grating has very few lines at the blue end. Using the default nsnippet=2 leads to those lines not being identified and a wavelength solution that is out by as much as 10A.