### PR TITLE
Fix port 9000 blockage issue with Ginga

### DIFF
--- a/pypeit/display/display.py
+++ b/pypeit/display/display.py
@@ -26,7 +26,8 @@ from pypeit import msgs
 from pypeit import io
 from pypeit import utils
 
-def connect_to_ginga(host='localhost', port=9000, raise_err=False, allow_new=False):
+def connect_to_ginga(host='localhost', port=grc.default_rc_port,
+                     raise_err=False, allow_new=False):
     """
     Connect to a RC Ginga.
 
@@ -34,7 +35,7 @@ def connect_to_ginga(host='localhost', port=9000, raise_err=False, allow_new=Fal
         host (:obj:`str`, optional):
             Host name.
         port (:obj:`int`, optional):
-            Probably should remain at 9000
+            Probably should remain at Ginga default
         raise_err (:obj:`bool`, optional):
             Raise an error if no connection is made, otherwise just
             raise a warning and continue
@@ -53,7 +54,8 @@ def connect_to_ginga(host='localhost', port=9000, raise_err=False, allow_new=Fal
         tmp = sh.get_current_workspace()
     except:
         if allow_new:
-            subprocess.Popen(['ginga', '--modules=RC,SlitWavelength'])
+            subprocess.Popen(['ginga', f'--rcport={port}',
+                              '--modules=RC,SlitWavelength'])
 
             # NOTE: time.sleep(3) is now insufficient. The loop below
             # continues to try to connect with the ginga viewer that
@@ -72,7 +74,7 @@ def connect_to_ginga(host='localhost', port=9000, raise_err=False, allow_new=Fal
                     break
             if i == maxiter-1:
                 msgs.error('Timeout waiting for ginga to start.  If window does not appear, type '
-                           '`ginga --modules=RC,SlitWavelength` on the command line.  In either '
+                           f'`ginga --rcport={port} --modules=RC,SlitWavelength` on the command line.  In either '
                            'case, wait for the ginga viewer to open and try the pypeit command '
                            'again.')
             return viewer
@@ -81,7 +83,7 @@ def connect_to_ginga(host='localhost', port=9000, raise_err=False, allow_new=Fal
             raise ValueError
         else:
             msgs.warn('Problem connecting to Ginga.  Launch an RC Ginga viewer and '
-                      'then continue: \n    ginga --modules=RC,SlitWavelength')
+                      f'then continue: \n    ginga --rcport={port} --modules=RC,SlitWavelength')
 
     # Return
     return viewer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "configobj>=5.0.6",
     "scikit-learn>=1.2",
     "IPython>=8.0.0",
-    "ginga>=5.2.0",
+    "ginga>=5.4.0",
     "linetools>=0.3.2",
     "qtpy>=2.2.0",
     "pygithub",


### PR DESCRIPTION
Change the default port of 9000 for Ginga remote control interaction to a new Ginga default port number.  Also makes it possible to pass a custom port number to the `connect_to_ginga` function and it will configure Ginga to use that port dynamically.

- bumps Ginga requirement to v5.4.0