### PR TITLE
Enhance ginga spec1d

### DIFF
--- a/pypeit/display/spec1dview.py
+++ b/pypeit/display/spec1dview.py
@@ -378,6 +378,8 @@ class Spec1dView(GingaPlugin.LocalPlugin):
                              x_axis="Wavelength (Ang)", y_axis="Flux")
         self.plot.set_grid(True)
 
+        self.plot_lines()
+
     def range_changed_cb(self, viewer, ranges):
         if not self.plot_shelf.is_blocked():
             self.plot_lines()

--- a/pypeit/display/spec1dview.py
+++ b/pypeit/display/spec1dview.py
@@ -76,6 +76,7 @@ from ginga.gw import Widgets
 from ginga.table.AstroTable import AstroTable
 from ginga.plot.Plotable import Plotable
 from ginga.canvas.CanvasObject import get_canvas_types
+from ginga.util.syncops import Shelf
 
 from pypeit import specobjs
 from pypeit import utils
@@ -128,6 +129,11 @@ class Spec1dView(GingaPlugin.LocalPlugin):
         # dictionary of plotable types
         self.dc = get_canvas_types()
         self.plot = None
+        self.plot_shelf = Shelf()
+        self.plot_stocker = self.plot_shelf.get_stocker()
+
+        viewer = self.channel.get_viewer('Ginga Plot')
+        viewer.add_callback('range-set', self.range_changed_cb)
         self.gui_up = False
 
     def build_gui(self, container):
@@ -290,6 +296,8 @@ class Spec1dView(GingaPlugin.LocalPlugin):
         Lines are made into a single compound object so that it is easier
         to remove them as a group if the line list is changed.
         """
+        if self.plot is None:
+            return
         canvas = self.plot.get_canvas()
         canvas.delete_object_by_tag('lines', redraw=False)
 
@@ -304,10 +312,23 @@ class Spec1dView(GingaPlugin.LocalPlugin):
             ylbl_pos = y_max - 0.2 * (y_max - y_min)
             gdwv = np.where((wvobs > x_min) & (wvobs < x_max))[0]
 
+            viewer = self.channel.get_viewer('Ginga Plot')
+            ranges = viewer.get_ranges()
+            x_lo, x_hi = ranges[0]
+            y_lo, y_hi = ranges[1]
+            # make label always sit about 3/4 up the Y range
+            y_lbl = y_lo + (y_hi - y_lo) * 0.75
+            # line should reach to the label at least
+            y_max = max(y_lbl, y_max)
+
             for kk in range(len(gdwv)):
                 jj = gdwv[kk]
                 wrest = self.llist['wrest'][jj]
-                lbl = self.llist['name'][jj]
+                x_lbl = wrest * (z + 1)
+                if not (x_lo < x_lbl < x_hi):
+                    # skip plotting lines that are not visible
+                    continue
+
                 # Plot
                 x_data = wrest * np.array([z + 1, z + 1])
                 y_data = (y_min, y_max)
@@ -318,8 +339,9 @@ class Spec1dView(GingaPlugin.LocalPlugin):
                                        linestyle='solid',
                                        color='blue'), redraw=False)
                 # Label
-                x, y = wrest * (z + 1), ylbl_pos
-                lines.add(self.dc.Text(x, y, text=lbl, rot_deg=90,
+                lbl = self.llist['name'][jj]
+                lines.add(self.dc.Text(x_lbl, y_lbl, text=lbl, rot_deg=90,
+                                       bgcolor='white', bgalpha=1.0,
                                        color='blue', fontsize=10),
                           redraw=False)
 
@@ -327,7 +349,8 @@ class Spec1dView(GingaPlugin.LocalPlugin):
         canvas.add(lines, tag='lines', redraw=False)
 
         # this causes the plot viewer to redraw itself
-        self.plot.make_callback('modified')
+        with self.plot_stocker:
+            self.plot.make_callback('modified')
 
     def replot(self):
         """Replot the plot and line list.
@@ -355,8 +378,9 @@ class Spec1dView(GingaPlugin.LocalPlugin):
                              x_axis="Wavelength (Ang)", y_axis="Flux")
         self.plot.set_grid(True)
 
-        self.plot_lines()
-
+    def range_changed_cb(self, viewer, ranges):
+        if not self.plot_shelf.is_blocked():
+            self.plot_lines()
 
     def process_file(self, filepath):
         """Process `filepath` creating `SpecObjs` (a series of extensions),
@@ -380,7 +404,6 @@ class Spec1dView(GingaPlugin.LocalPlugin):
         self.plot = Plotable(logger=self.logger)
         self.plot.set(name="plot-{}".format(str(time.time())),
                       path=None, nothumb=True)
-
         self.recalc()
 
         # add the plot to this channel
@@ -459,6 +482,8 @@ class Spec1dView(GingaPlugin.LocalPlugin):
         Clean up instance variables so we don't hang on to any large data
         structures.
         """
+        viewer = self.channel.get_viewer('Ginga Plot')
+        viewer.clear()
         self.sobjs = 0
         self.exten = 0
         self.ext_name = ''

--- a/pypeit/scripts/show_1dspec.py
+++ b/pypeit/scripts/show_1dspec.py
@@ -4,7 +4,7 @@ Wrapper to the linetools XSpecGUI
 .. include common links, assuming primary doc root is up one directory
 .. include:: ../include/links.rst
 """
-import os.path
+from pathlib import Path
 from IPython import embed
 
 from pypeit.scripts import scriptbase
@@ -123,7 +123,7 @@ class Show1DSpec(scriptbase.ScriptBase):
             from pypeit.display.display import show_1dspec
 
             # in case Ginga is invoked in another directory
-            file_path = os.path.abspath(args.file)
+            file_path = str(Path(args.file).absolute())
             show_1dspec(file_path, ext=exten,
                         masked=args.masked, extraction=args.extract,
                         fluxed=args.flux)

--- a/pypeit/scripts/show_1dspec.py
+++ b/pypeit/scripts/show_1dspec.py
@@ -4,6 +4,7 @@ Wrapper to the linetools XSpecGUI
 .. include common links, assuming primary doc root is up one directory
 .. include:: ../include/links.rst
 """
+import os.path
 from IPython import embed
 
 from pypeit.scripts import scriptbase
@@ -121,7 +122,9 @@ class Show1DSpec(scriptbase.ScriptBase):
             # show the 1d spectrum in Ginga
             from pypeit.display.display import show_1dspec
 
-            show_1dspec(args.file, ext=exten,
+            # in case Ginga is invoked in another directory
+            file_path = os.path.abspath(args.file)
+            show_1dspec(file_path, ext=exten,
                         masked=args.masked, extraction=args.extract,
                         fluxed=args.flux)
             return


### PR DESCRIPTION
Enhances the Ginga 1Dspec viewer plugin

- plots labels on lines so that they are always visible when the line itself is visible
- plot updates when zooming or panning changes the range of the plot
- requires Ginga v5.4.0
