### PR TITLE
Avoid extension checks for spec2d (PypeIt) files

### DIFF
--- a/pypeit/display/display.py
+++ b/pypeit/display/display.py
@@ -26,7 +26,7 @@ from pypeit import msgs
 from pypeit import io
 from pypeit import utils
 
-def connect_to_ginga(host='localhost', port=grc.default_rc_port,
+def connect_to_ginga(host='localhost', port=9000,
                      raise_err=False, allow_new=False):
     """
     Connect to a RC Ginga.

--- a/pypeit/display/display.py
+++ b/pypeit/display/display.py
@@ -26,7 +26,7 @@ from pypeit import msgs
 from pypeit import io
 from pypeit import utils
 
-def connect_to_ginga(host='localhost', port=9000,
+def connect_to_ginga(host='localhost', port=grc.default_rc_port,
                      raise_err=False, allow_new=False):
     """
     Connect to a RC Ginga.

--- a/pypeit/spectrographs/spectrograph.py
+++ b/pypeit/spectrographs/spectrograph.py
@@ -320,6 +320,16 @@ class Spectrograph:
         """
         if self.allowed_extensions is not None:
             _filename = Path(filename).absolute()
+            # Don't check PypeIt spec2d files
+            if _filename.name.startswith("spec2d_"):
+                # Double check that it is a PypeIt spec2d file
+                try:
+                    tsthdr = fits.getheader(_filename, ext=0)
+                except IOError:
+                    msgs.error("Cannot open the file: {0}".format(_filename))
+                if 'PIPELINE' in tsthdr and tsthdr['PIPELINE'] == 'PYPEIT':
+                    return
+            # Perform the extensions check
             if not any([_filename.name.endswith(ext) for ext in self.allowed_extensions]):
                 msgs.error(f'The input file ({_filename.name}) does not have a recognized '
                            f'extension.  The allowed extensions for '


### PR DESCRIPTION
As titled. Addresses an issue with SOAR/Goodman highlighted on the Users Slack.