### PR TITLE
Remove ``__UTC__`` crutch for Python 3.10 support

### DIFF
--- a/doc/releases/1.18.1dev.rst
+++ b/doc/releases/1.18.1dev.rst
@@ -46,3 +46,5 @@ Under-the-hood Improvements
 Bug Fixes
 ---------
 
+- Removed last vestiges of support for Python 3.10 in the form of ``datetime.UTC``
+  crutches left over from the start of support of Python 3.12.

--- a/pypeit/calibrations.py
+++ b/pypeit/calibrations.py
@@ -221,7 +221,7 @@ class Calibrations:
         # Loop on the files
         for ii, ifile in enumerate(file_list):
             # Save the lamp status
-            headarr = copy.deepcopy(self.spectrograph.get_headarr(ifile))
+            headarr = [h.copy() for h in self.spectrograph.get_headarr(ifile)]
             lampstat[ii] = self.spectrograph.get_lamps_status(headarr)
 
         # Check that the lamps being combined are all the same

--- a/pypeit/calibrations.py
+++ b/pypeit/calibrations.py
@@ -4,25 +4,15 @@ Class for guiding calibration object generation in PypeIt.
 .. include common links, assuming primary doc root is up one directory
 .. include:: ../include/links.rst
 """
-import os
-from pathlib import Path
-from datetime import datetime
-from copy import deepcopy
 from abc import ABCMeta
 from collections import Counter
-import yaml
-
-# TODO: datetime.UTC is not defined in python 3.10.  Remove this when we decide
-# to no longer support it.
-try:
-    __UTC__ = datetime.UTC
-except AttributeError as e:
-    from datetime import timezone
-    __UTC__ = timezone.utc
-
-from IPython import embed
+import copy
+import datetime
+import os
+from pathlib import Path
 
 import numpy as np
+import yaml
 
 from pypeit import __version__
 from pypeit import msgs
@@ -39,13 +29,11 @@ from pypeit.metadata import PypeItMetaData
 from pypeit.core import framematch
 from pypeit.core import parse
 from pypeit.core import scattlight as core_scattlight
-from pypeit.core.mosaic import build_image_mosaic
 from pypeit.par import pypeitpar
 from pypeit.spectrographs.spectrograph import Spectrograph
-from pypeit import io
 from pypeit import utils
-from pypeit import cache
-from pypeit import dataPaths
+
+from IPython import embed
 
 
 class Calibrations:
@@ -233,7 +221,7 @@ class Calibrations:
         # Loop on the files
         for ii, ifile in enumerate(file_list):
             # Save the lamp status
-            headarr = deepcopy(self.spectrograph.get_headarr(ifile))
+            headarr = copy.deepcopy(self.spectrograph.get_headarr(ifile))
             lampstat[ii] = self.spectrograph.get_lamps_status(headarr)
 
         # Check that the lamps being combined are all the same
@@ -1569,7 +1557,7 @@ class Calibrations:
         # Iterate through each setup
         for setup in setups.keys():
             asn[setup] = {}
-            asn[setup]['--'] = deepcopy(setups[setup])
+            asn[setup]['--'] = copy.deepcopy(setups[setup])
             in_setup = fitstbl.find_configuration(setup) & subset
             if not any(in_setup):
                 continue
@@ -1589,7 +1577,7 @@ class Calibrations:
         with open(_ofile, 'w') as ff:
             ff.write('# Auto-generated calibration association file using PypeIt version: '
                      f' {__version__}\n')
-            ff.write(f'# UTC {datetime.now(__UTC__).isoformat(timespec="milliseconds")}\n')
+            ff.write(f'# UTC {datetime.datetime.now(datetime.UTC).isoformat(timespec="milliseconds")}\n')
             if det is None:
                 ff.write(f'# NOTE: {detname} is a placeholder for the reduced detectors/mosaics\n')
             ff.write(yaml.dump(utils.yamlify(asn)))

--- a/pypeit/inputfiles.py
+++ b/pypeit/inputfiles.py
@@ -2,27 +2,18 @@
 
 .. include:: ../include/links.rst
 """
+import datetime
+import glob
+import io
 from pathlib import Path
 import os
-import glob
-import numpy as np
-import yaml
-from datetime import datetime
-import io
 import warnings
-from collections.abc import Sequence
-import configobj
-
-# TODO: datetime.UTC is not defined in python 3.10.  Remove this when we decide
-# to no longer support it.
-try:
-    __UTC__ = datetime.UTC
-except AttributeError as e:
-    from datetime import timezone
-    __UTC__ = timezone.utc
 
 from astropy.table import Table, column
 from astropy.io import ascii
+import configobj
+import numpy as np
+import yaml
 
 from pypeit import utils
 from pypeit.io import files_from_extension
@@ -528,7 +519,7 @@ class InputFile:
                 documentation purposes only!**
         """
         _version = __version__ if version_override is None else version_override
-        _date = datetime.now(__UTC__).isoformat(timespec='milliseconds') \
+        _date = datetime.datetime.now(datetime.UTC).isoformat(timespec='milliseconds') \
                     if date_override is None else date_override
 
         # Here we go

--- a/pypeit/pypeit.py
+++ b/pypeit/pypeit.py
@@ -5,26 +5,15 @@ Main driver class for PypeIt run
 .. include:: ../include/links.rst
 
 """
+import copy
+import datetime
+import os
 from pathlib import Path
 import time
-import os
-import copy
-from datetime import datetime
-
-# TODO: datetime.UTC is not defined in python 3.10.  Remove this when we decide
-# to no longer support it.
-try:
-    __UTC__ = datetime.UTC
-except AttributeError as e:
-    from datetime import timezone
-    __UTC__ = timezone.utc
-
-from IPython import embed
-
-import numpy as np
 
 from astropy.io import fits
 from astropy.table import Table
+import numpy as np
 
 from pypeit import io
 from pypeit import inputfiles
@@ -49,6 +38,8 @@ from pypeit.manual_extract import ManualExtractionObj
 from pypeit.core import skysub
 
 from linetools import utils as ltu
+
+from IPython import embed
 
 
 class PypeIt:
@@ -119,7 +110,7 @@ class PypeIt:
         # Write the full parameter set here
         # --------------------------------------------------------------
         par_file = pypeit_file.replace(
-            '.pypeit', f"_UTC_{datetime.now(__UTC__).date()}.par")
+            '.pypeit', f"_UTC_{datetime.datetime.now(datetime.UTC).date()}.par")
         self.par.to_config(par_file, include_descr=False)
 
         # --------------------------------------------------------------

--- a/pypeit/pypmsgs.py
+++ b/pypeit/pypmsgs.py
@@ -5,26 +5,18 @@ Module for terminal and file logging.
     Why not use pythons native logging package?
 
 """
-from datetime import datetime
-import sys
-import os
+import datetime
 import inspect
 import io
-
-# TODO: datetime.UTC is not defined in python 3.10.  Remove this when we decide
-# to no longer support it.
-try:
-    __UTC__ = datetime.UTC
-except AttributeError as e:
-    from datetime import timezone
-    __UTC__ = timezone.utc
+import os
+import sys
 
 # Imported for versioning
-import scipy
-import numpy
 import astropy
-import pypeit
+import numpy
+import scipy
 
+import pypeit
 from pypeit.core.qa import close_qa
 from pypeit import pypeit_user
 
@@ -410,7 +402,7 @@ class Messages:
                 Verbosity level between 0 [none] and 2 [all]
         """
         # Create a UT timestamp (to the minute) for the log filename
-        timestamp = datetime.now(__UTC__).strftime("%Y%m%d-%H%M")
+        timestamp = datetime.datetime.now(datetime.UTC).strftime("%Y%m%d-%H%M")
         # Create a logfile only if verbosity == 2
         logname = f"{scriptname}_{timestamp}.log" if verbosity == 2 else None
         # Set the verbosity in msgs

--- a/pypeit/scripts/chk_for_calibs.py
+++ b/pypeit/scripts/chk_for_calibs.py
@@ -42,7 +42,9 @@ class ChkForCalibs(scriptbase.ScriptBase):
 
         """
 
+        from pathlib import Path
         import os
+        import time
 
         from IPython import embed
 
@@ -167,7 +169,7 @@ class ChkForCalibs(scriptbase.ScriptBase):
             # the calib file,
             calib_file = sorted_file.with_suffix('.calib')
             caldir = calib_file.parent / ps.par['calibrations']['calib_dir']
-            Calibrations.association_summary(calib_file, ps.fitstbl, ps.spectrograph, caldir,
+            calibrations.Calibrations.association_summary(calib_file, ps.fitstbl, ps.spectrograph, caldir,
                                              overwrite=True)
             # and the obslog file
             obslog_file = sorted_file.with_suffix('.obslog')

--- a/pypeit/setup_gui/controller.py
+++ b/pypeit/setup_gui/controller.py
@@ -7,7 +7,6 @@ acting on user input, running background tasks, and returning information to the
 """
 import traceback
 import sys
-from datetime import datetime
 import re
 import io
 from pathlib import Path
@@ -16,13 +15,6 @@ from contextlib import contextmanager
 from qtpy.QtCore import QCoreApplication, Signal, QMutex, QTimer
 from qtpy.QtGui import QIcon
 
-# TODO: datetime.UTC is not defined in python 3.10.  Remove this when we decide
-# to no longer support it.
-try:
-    __UTC__ = datetime.UTC
-except AttributeError as e:
-    from datetime import timezone
-    __UTC__ = timezone.utc
 
 from qtpy.QtCore import QObject, Qt, QThread
 from qtpy.QtGui import QKeySequence


### PR DESCRIPTION
When ``datetime.datetime.utcnow()`` was deprecated in Python 3.12, we needed some crutches (#1785) to be able to successfully transition to the new ``datetime.UTC`` constant (introduced in Python 3.11).  Since PypeIt no longer supports Python 3.10 (#1854), we can safely remove these crutches to provide for cleaner code relying solely on the ``datetime.UTC`` constant.

DevSuite tests pass (Nautilus report ``tbowers-py310-sep19.report``):

```
Test Summary
--------------------------------------------------------
--- PYTEST PYPEIT UNIT TESTS PASSED  261 passed, 443 warnings in 508.66s (0:08:28) ---
--- PYTEST UNIT TESTS PASSED  157 passed, 93167 warnings in 959.23s (0:15:59) ---
--- PYTEST VET TESTS PASSED  69 passed, 135631 warnings in 4766.40s (1:19:26) ---
--- PYPEIT DEVELOPMENT SUITE PASSED 280/280 TESTS  ---
Testing Started at 2025-09-19T17:10:25.540237
Testing Completed at 2025-09-20T11:39:28.966919
Total Time: 18:29:03.426682
```