### PR TITLE
Temporarily skip ``astropydev`` tests

### DIFF
--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python: ['3.11', '3.12', '3.13']
-        toxenv: [test, test-alldeps-cov, test-numpydev, test-linetoolsdev, test-gingadev, test-astropydev]
+        toxenv: [test, test-alldeps-cov, test-numpydev, test-linetoolsdev, test-gingadev] #, test-astropydev]
     steps:
     - name: Check out repository
       uses: actions/checkout@v3

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python: ['3.11', '3.12', '3.13']
-        toxenv: [test, test-alldeps-cov, test-numpydev, test-linetoolsdev, test-gingadev, test-astropydev]
+        toxenv: [test, test-alldeps-cov, test-numpydev, test-linetoolsdev, test-gingadev] #, test-astropydev]
     steps:
     - name: Check out repository
       uses: actions/checkout@v3


### PR DESCRIPTION
Skip the ``astropydev`` CI tests until the heap checksum bug in the ``main`` branch of AstroPy is fixed: https://github.com/astropy/astropy/issues/18735

Once that bug is fixed, we can revert this change and continue testing PypeIt against the bleeding edge of AstroPy development.

	modified:   .github/workflows/ci_cron.yml
	modified:   .github/workflows/ci_tests.yml