### PR TITLE
Update ``numpydev`` tests to pre-release nightly wheel

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,6 @@ isolated_build = true
 # Suppress display of matplotlib plots generated during docs build
 setenv =
     MPLBACKEND=agg
-    numpydev: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scipy-wheels-nightly/simple
 
 # Pass through the following environment variables which may be needed for the CI
 passenv = HOME,WINDIR,LC_ALL,LC_CTYPE,CC,CI,PYPEIT_DEV
@@ -56,6 +55,7 @@ extras =
     alldeps: shapely,specutils,scikit-image
 
 commands =
+    numpydev: python -m pip install --pre --upgrade --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
     pip freeze
     !cov: pytest --pyargs pypeit {posargs}
     cov: pytest --pyargs pypeit --cov pypeit --cov-config={toxinidir}/pyproject.toml {posargs}


### PR DESCRIPTION
The ``numpydev`` tests currently test against the latest released version of NumPy (on 20-Oct-2025, that is ``numpy==2.3.4``), but with this change, the ``numpydev`` tests will actually download the latest nightly wheel (on 20-Oct-2025, that is ``numpy==2.4.0.dev0``).

We can discuss whether this is what we actually want to be doing, but this PR aligns the name of the test with actual functionality.
