### PR TITLE
Add spec1d keyboard mode for PypeIt special bindings in Ginga

### DIFF
--- a/pypeit/display/pypeit_modes.py
+++ b/pypeit/display/pypeit_modes.py
@@ -1,0 +1,121 @@
+#
+# pypeid_modes.py -- keyboard modes for manipulating PypeIt plots in Ginga
+#
+#
+from ginga.gw.PlotView import PlotViewBase
+from ginga.misc import Bunch
+from ginga.modes.mode_base import Mode
+from ginga.modes.plot2d import Plot2DMode
+
+
+class Spec1DMode(Plot2DMode):
+    """
+    Spec1DMode enables special bindings for viewing PypeIt spec1d files.
+
+    Enter the mode by
+    -----------------
+    * Space, then "1"
+
+    Exit the mode by
+    ----------------
+    * Esc
+
+    Default bindings in mode
+    ------------------------
+    * Shift + left click : set pan position
+    * middle click : set pan position
+    * scroll : zoom in/out
+    * ctrl + scroll : zoom in/out X axis only
+    * shift + scroll : zoom in/out Y axis only
+    * alt + scroll : zoom in/out Y axis only
+    * meta + scroll : zoom in/out at cursor
+    * equals : zoom in one zoom level
+    * ctrl + equals : zoom in X axis one zoom level
+    * shift + equals (plus) : zoom in Y axis one zoom level
+    * minus : zoom out one zoom level
+    * ctrl + minus : zoom out X axis one zoom level
+    * shift + minus (underscore): zoom out Y axis one zoom level
+    * 9 : zoom out maintaining cursor position
+    * ctrl + 9 : zoom out X axis maintaining cursor position
+    * shift + 9 (left paren): zoom out Y axis maintaining cursor position
+    * 0 : zoom in maintaining cursor position
+    * ctrl + 0 : zoom in X axis maintaining cursor position
+    * shift + 0 (right paren): zoom in Y axis maintaining cursor position
+    * backquote : fit plot to window
+    * 1 : fit x axis only to window
+    * 2 : fit y axis only to window
+    * left arrow : pan left
+    * right arrow : pan right
+    * up arrow : pan up
+    * down arrow : pan down
+    * k : set lower X range to X value at cursor
+    * l : set upper X range to X value at cursor
+    * K : set lower Y range to Y value at cursor
+    * L : set upper Y range to Y value at cursor
+    """
+
+    # Needs to be set by reference viewer (via set_shell_ref) before any
+    # channel viewers are created
+    fv = None
+
+    @classmethod
+    def set_shell_ref(cls, fv):
+        cls.fv = fv
+
+    @classmethod
+    def is_compatible_viewer(cls, viewer):
+        return isinstance(viewer, PlotViewBase)
+
+    def __init__(self, viewer, settings=None):
+        super().__init__(viewer, settings=settings)
+
+        self.actions = dict(
+            dmod_spec1d=['__1', None, 'spec1d'],
+
+            ms_showxy=['spec1d+nobtn'],
+            ms_panset2d=['spec1d+middle', 'spec1d+shift+left'],
+
+            sc_zoom2d=['spec1d+*+scroll'],
+
+            kp_pan_left=['spec1d+*+left'],
+            kp_pan_right=['spec1d+*+right'],
+            kp_pan_up=['spec1d+*+up'],
+            kp_pan_down=['spec1d+*+down'],
+
+            kp_zoom_in=['spec1d++', 'spec1d+='],
+            kp_zoom_out=['spec1d+-', 'spec1d+_'],
+            kp_zoom_cursor_in=['spec1d+*+0', 'spec1d+*+)'],
+            kp_zoom_cursor_out=['spec1d+*+9', 'spec1d+*+('],
+
+            kp_zoom_fit=['spec1d+backquote'],
+            kp_zoom_fit_x=['spec1d+1'],
+            kp_zoom_fit_y=['spec1d+2'],
+
+            kp_cut_x_lo=['spec1d+k'],
+            kp_cut_x_hi=['spec1d+l'],
+            kp_cut_y_lo=['spec1d+K'],
+            kp_cut_y_hi=['spec1d+L'],
+
+            plot_zoom_rate=1.2,
+            plot_pan_pct=0.10,
+        )
+
+    def __str__(self):
+        return 'spec1d'
+
+    def start(self):
+        pass
+
+    def stop(self):
+        pass
+
+    #####  SCROLL ACTION CALLBACKS #####
+
+    #####  MOUSE ACTION CALLBACKS #####
+
+    def ms_showxy(self, viewer, event, data_x, data_y):
+        """Motion event in the channel viewer window.  Show the pointing
+        information under the cursor.
+        """
+        self.fv.showxy(viewer, data_x, data_y)
+        return False

--- a/pypeit/display/pypeit_modes.py
+++ b/pypeit/display/pypeit_modes.py
@@ -8,6 +8,8 @@ from ginga.modes.mode_base import Mode
 from ginga.modes.plot2d import Plot2DMode
 
 
+# Note inheritance from Plot2DMode, which already defines many callbacks
+#
 class Spec1DMode(Plot2DMode):
     """
     Spec1DMode enables special bindings for viewing PypeIt spec1d files.
@@ -20,8 +22,8 @@ class Spec1DMode(Plot2DMode):
     ----------------
     * Esc
 
-    Default bindings in mode
-    ------------------------
+    Mouse/trackpad bindings in mode
+    -------------------------------
     * Shift + left click : set pan position
     * middle click : set pan position
     * scroll : zoom in/out
@@ -29,6 +31,12 @@ class Spec1DMode(Plot2DMode):
     * shift + scroll : zoom in/out Y axis only
     * alt + scroll : zoom in/out Y axis only
     * meta + scroll : zoom in/out at cursor
+
+    Keystroke bindings in mode
+    --------------------------
+
+    Zooming
+    -------
     * equals : zoom in one zoom level
     * ctrl + equals : zoom in X axis one zoom level
     * shift + equals (plus) : zoom in Y axis one zoom level
@@ -44,14 +52,25 @@ class Spec1DMode(Plot2DMode):
     * backquote : fit plot to window
     * 1 : fit x axis only to window
     * 2 : fit y axis only to window
-    * left arrow : pan left
-    * right arrow : pan right
-    * up arrow : pan up
-    * down arrow : pan down
     * k : set lower X range to X value at cursor
     * l : set upper X range to X value at cursor
     * K : set lower Y range to Y value at cursor
     * L : set upper Y range to Y value at cursor
+
+    Panning
+    -------
+    * left arrow : pan left
+    * right arrow : pan right
+    * up arrow : pan up
+    * down arrow : pan down
+
+    Regions
+    -------
+    * [ : mark lower X boundary of region
+    * ] : mark upper X boundary of region
+    * backslash : clear region
+    * singlequote : (zoom) set X range to region
+    * f : fit region and show result
     """
 
     # Needs to be set by reference viewer (via set_shell_ref) before any
@@ -93,8 +112,18 @@ class Spec1DMode(Plot2DMode):
 
             kp_cut_x_lo=['spec1d+k'],
             kp_cut_x_hi=['spec1d+l'],
+            kp_cut_x_range=['spec1d+singlequote'],
             kp_cut_y_lo=['spec1d+K'],
             kp_cut_y_hi=['spec1d+L'],
+
+            kp_unsmooth=['spec1d+A'],
+            kp_smooth_less=['spec1d+a'],
+            kp_smooth_more=['spec1d+s'],
+
+            kp_mark_left=['spec1d+['],
+            kp_mark_right=['spec1d+]'],
+            kp_mark_clear=['spec1d+backslash'],
+            kp_fitting=['spec1d+f'],
 
             plot_zoom_rate=1.2,
             plot_pan_pct=0.10,
@@ -109,7 +138,11 @@ class Spec1DMode(Plot2DMode):
     def stop(self):
         pass
 
-    #####  SCROLL ACTION CALLBACKS #####
+    def get_plugin(self):
+        chname = self.fv.get_channel_name(self.viewer)
+        channel = self.fv.get_channel(chname)
+        pl_obj = channel.opmon.get_plugin('spec1dview')
+        return pl_obj
 
     #####  MOUSE ACTION CALLBACKS #####
 
@@ -122,7 +155,51 @@ class Spec1DMode(Plot2DMode):
 
     #####  KEYBOARD ACTION CALLBACKS #####
 
-    def kp_smooth(self, viewer, event, data_x, data_y):
+    def kp_unsmooth(self, viewer, event, data_x, data_y):
         event.accept()
-        plot = viewer.get_dataobj()
-        viewer.zoom_plot(delta_x, delta_y)
+
+        plugin = self.get_plugin()
+        plugin.unsmooth()
+
+    def kp_smooth_more(self, viewer, event, data_x, data_y):
+        event.accept()
+
+        plugin = self.get_plugin()
+        plugin.smooth_more()
+
+    def kp_smooth_less(self, viewer, event, data_x, data_y):
+        event.accept()
+
+        plugin = self.get_plugin()
+        plugin.smooth_less()
+
+    def kp_cut_x_range(self, viewer, event, data_x, data_y):
+        if not self.canpan:
+            return False
+        event.accept()
+        plugin = self.get_plugin()
+        plugin.cut_x_range('mark')
+
+    def kp_mark_left(self, viewer, event, data_x, data_y):
+        event.accept()
+
+        plugin = self.get_plugin()
+        plugin.set_region_side('mark', 'left', data_x)
+
+    def kp_mark_right(self, viewer, event, data_x, data_y):
+        event.accept()
+
+        plugin = self.get_plugin()
+        plugin.set_region_side('mark', 'right', data_x)
+
+    def kp_mark_clear(self, viewer, event, data_x, data_y):
+        event.accept()
+
+        plugin = self.get_plugin()
+        plugin.clear_region('mark')
+
+    def kp_fitting(self, viewer, event, data_x, data_y):
+        event.accept()
+
+        plugin = self.get_plugin()
+        plugin.fit_range('mark')

--- a/pypeit/display/pypeit_modes.py
+++ b/pypeit/display/pypeit_modes.py
@@ -28,9 +28,9 @@ class Spec1DMode(Plot2DMode):
     * middle click : set pan position
     * scroll : zoom in/out
     * ctrl + scroll : zoom in/out X axis only
-    * shift + scroll : zoom in/out Y axis only
-    * alt + scroll : zoom in/out Y axis only
-    * meta + scroll : zoom in/out at cursor
+    * shift + scroll : zoom in/out Y axis only (On MacOS, trackpad only)
+    * alt + scroll(mouse) : zoom in/out Y axis only (Option key on Macs)
+    * alt + scroll : zoom in/out at cursor
 
     Keystroke bindings in mode
     --------------------------
@@ -39,19 +39,19 @@ class Spec1DMode(Plot2DMode):
     -------
     * equals : zoom in one zoom level
     * ctrl + equals : zoom in X axis one zoom level
-    * shift + equals (plus) : zoom in Y axis one zoom level
+    * plus (shift + equals) : zoom in Y axis one zoom level
     * minus : zoom out one zoom level
     * ctrl + minus : zoom out X axis one zoom level
-    * shift + minus (underscore): zoom out Y axis one zoom level
+    * underscore (shift + minus): zoom out Y axis one zoom level
     * 9 : zoom out maintaining cursor position
     * ctrl + 9 : zoom out X axis maintaining cursor position
-    * shift + 9 (left paren): zoom out Y axis maintaining cursor position
+    * left paren (shift + 9): zoom out Y axis maintaining cursor position
     * 0 : zoom in maintaining cursor position
     * ctrl + 0 : zoom in X axis maintaining cursor position
-    * shift + 0 (right paren): zoom in Y axis maintaining cursor position
-    * backquote : fit plot to window
-    * 1 : fit x axis only to window
-    * 2 : fit y axis only to window
+    * right paren (shift + 0): zoom in Y axis maintaining cursor position
+    * backquote : zoom X and Y axes to fit window
+    * 1 : zoom X axis only to fit window
+    * 2 : zoom Y axis only to fit window
     * k : set lower X range to X value at cursor
     * l : set upper X range to X value at cursor
     * K : set lower Y range to Y value at cursor
@@ -95,17 +95,29 @@ class Spec1DMode(Plot2DMode):
             ms_showxy=['spec1d+nobtn'],
             ms_panset2d=['spec1d+middle', 'spec1d+shift+left'],
 
-            sc_zoom2d=['spec1d+*+scroll'],
+            sc_zoom2d=['spec1d+scroll'],
+            sc_zoom2d_x=['spec1d+ctrl+scroll'],
+            sc_zoom2d_y=['spec1d+shift+scroll'],
+            sc_zoom2d_cursor=['spec1d+win+scroll'],
 
-            kp_pan_left=['spec1d+*+left'],
-            kp_pan_right=['spec1d+*+right'],
-            kp_pan_up=['spec1d+*+up'],
-            kp_pan_down=['spec1d+*+down'],
+            kp_pan_left=['spec1d+left'],
+            kp_pan_right=['spec1d+right'],
+            kp_pan_up=['spec1d+up'],
+            kp_pan_down=['spec1d+down'],
 
-            kp_zoom_in=['spec1d++', 'spec1d+='],
-            kp_zoom_out=['spec1d+-', 'spec1d+_'],
-            kp_zoom_cursor_in=['spec1d+*+0', 'spec1d+*+)'],
-            kp_zoom_cursor_out=['spec1d+*+9', 'spec1d+*+('],
+            kp_zoom_in=['spec1d+='],
+            kp_zoom_in_x=['spec1d+ctrl+='],
+            kp_zoom_in_y=['spec1d+shift++'],
+            kp_zoom_out=['spec1d+-'],
+            kp_zoom_out_x=['spec1d+ctrl+-'],
+            kp_zoom_out_y=['spec1d+shift+_'],
+
+            kp_zoom_cursor_in=['spec1d+0'],
+            kp_zoom_cursor_in_x=['spec1d+ctrl+0'],
+            kp_zoom_cursor_in_y=['spec1d+shift+)'],
+            kp_zoom_cursor_out=['spec1d+9'],
+            kp_zoom_cursor_out_x=['spec1d+ctrl+9'],
+            kp_zoom_cursor_out_y=['spec1d+shift+('],
 
             kp_zoom_fit=['spec1d+backquote'],
             kp_zoom_fit_x=['spec1d+1'],
@@ -113,11 +125,10 @@ class Spec1DMode(Plot2DMode):
 
             kp_cut_x_lo=['spec1d+k'],
             kp_cut_x_hi=['spec1d+l'],
-            kp_cut_x_range=['spec1d+singlequote'],
             kp_cut_y_lo=['spec1d+K'],
             kp_cut_y_hi=['spec1d+L'],
 
-            kp_unsmooth=['spec1d+A'],
+            kp_no_smooth=['spec1d+A'],
             kp_smooth_less=['spec1d+a'],
             kp_smooth_more=['spec1d+s'],
 
@@ -157,11 +168,11 @@ class Spec1DMode(Plot2DMode):
 
     #####  KEYBOARD ACTION CALLBACKS #####
 
-    def kp_unsmooth(self, viewer, event, data_x, data_y):
+    def kp_no_smooth(self, viewer, event, data_x, data_y):
         event.accept()
 
         plugin = self.get_plugin()
-        plugin.unsmooth()
+        plugin.no_smooth()
 
     def kp_smooth_more(self, viewer, event, data_x, data_y):
         event.accept()

--- a/pypeit/display/pypeit_modes.py
+++ b/pypeit/display/pypeit_modes.py
@@ -71,6 +71,7 @@ class Spec1DMode(Plot2DMode):
     * backslash : clear region
     * singlequote : (zoom) set X range to region
     * f : fit region and show result
+    * c : clear fit result
     """
 
     # Needs to be set by reference viewer (via set_shell_ref) before any
@@ -124,6 +125,7 @@ class Spec1DMode(Plot2DMode):
             kp_mark_right=['spec1d+]'],
             kp_mark_clear=['spec1d+backslash'],
             kp_fitting=['spec1d+f'],
+            kp_clear_marks=['spec1d+c'],
 
             plot_zoom_rate=1.2,
             plot_pan_pct=0.10,
@@ -197,6 +199,12 @@ class Spec1DMode(Plot2DMode):
 
         plugin = self.get_plugin()
         plugin.clear_region('mark')
+
+    def kp_clear_marks(self, viewer, event, data_x, data_y):
+        event.accept()
+
+        plugin = self.get_plugin()
+        plugin.clear_markers()
 
     def kp_fitting(self, viewer, event, data_x, data_y):
         event.accept()

--- a/pypeit/display/pypeit_modes.py
+++ b/pypeit/display/pypeit_modes.py
@@ -119,3 +119,10 @@ class Spec1DMode(Plot2DMode):
         """
         self.fv.showxy(viewer, data_x, data_y)
         return False
+
+    #####  KEYBOARD ACTION CALLBACKS #####
+
+    def kp_smooth(self, viewer, event, data_x, data_y):
+        event.accept()
+        plot = viewer.get_dataobj()
+        viewer.zoom_plot(delta_x, delta_y)

--- a/pypeit/display/spec1dview.py
+++ b/pypeit/display/spec1dview.py
@@ -234,11 +234,11 @@ class Spec1dView(GingaPlugin.LocalPlugin):
         tbar = Widgets.Toolbar(orientation='horizontal')
         vbox.add_widget(tbar, stretch=0)
 
-        btn = tbar.add_action("Unsmooth")
-        btn.add_callback('activated', lambda w: self.unsmooth())
+        btn = tbar.add_action("No smooth")
+        btn.add_callback('activated', lambda w: self.no_smooth())
         btn.set_enabled(self.nsmooth > 0.0)
-        self.w.unsmooth = btn
-        btn.set_tooltip("Undo all smoothing")
+        self.w.no_smooth = btn
+        btn.set_tooltip("Turn off smoothing")
         btn = tbar.add_action("Smooth-")
         btn.add_callback('activated', lambda w: self.smooth_less())
         btn.set_enabled(self.nsmooth > 0.0)
@@ -326,17 +326,17 @@ class Spec1dView(GingaPlugin.LocalPlugin):
         self.logger.debug(f"Selected masked option: {self.masked}")
         self.recalc()
 
-    def unsmooth(self):
+    def no_smooth(self):
         """Completely remove all smoothing from the plot."""
         self.nsmooth = 0.0
-        self.w.unsmooth.set_enabled(False)
+        self.w.no_smooth.set_enabled(False)
         self.w.smooth_less.set_enabled(False)
         self.recalc()
 
     def smooth_more(self):
         """Increase the level of smoothing in the plot."""
         self.nsmooth += (0.5 if self.nsmooth > 0.0 else 1.0)
-        self.w.unsmooth.set_enabled(True)
+        self.w.no_smooth.set_enabled(True)
         self.w.smooth_less.set_enabled(True)
         self.recalc()
 
@@ -344,7 +344,7 @@ class Spec1dView(GingaPlugin.LocalPlugin):
         """Decrease the level of smoothing in the plot."""
         self.nsmooth -= (0.5 if self.nsmooth > 1.0 else 1.0)
         self.nsmooth = max(self.nsmooth, 0.0)
-        self.w.unsmooth.set_enabled(self.nsmooth > 0.0)
+        self.w.no_smooth.set_enabled(self.nsmooth > 0.0)
         self.w.smooth_less.set_enabled(self.nsmooth > 0.0)
         self.recalc()
 
@@ -377,6 +377,12 @@ class Spec1dView(GingaPlugin.LocalPlugin):
     def clear_region(self, name):
         """Clear the region named `name`."""
         self.region_dct[name] = [None, None]
+
+        self.plot_lines()
+
+    def clear_markers(self):
+        """Clear all the markers."""
+        self.marker_dct = dict()
 
         self.plot_lines()
 
@@ -414,8 +420,15 @@ class Spec1dView(GingaPlugin.LocalPlugin):
             line_sigma = line.stddev.value
             line_fwhm = 2.35482 * line_sigma
             line_flux = line.amplitude.value * np.sqrt(2 * np.pi) * line_sigma
+
+            # Plot the fitted gaussian
+            # Dense grid for smooth model curve
+            x_fitted = np.linspace(self.data.wave[idx_lo],
+                                  self.data.wave[idx_hi], 100)  # 1000?
+            y_fitted = model(x_fitted)
+
             result = dict(x=line_center, sigma=line_sigma, fwhm=line_fwhm,
-                          flux=line_flux)
+                          flux=line_flux, x_fitted=x_fitted, y_fitted=y_fitted)
 
             # TODO: probably want to plot multiple unique lines and label them
             # name = str(line_center)  # ?? what is a better unique name
@@ -477,7 +490,15 @@ class Spec1dView(GingaPlugin.LocalPlugin):
             line = self.dc.Line(x, y_lo, x, y_hi, linewidth=2,
                                 linestyle='dotted', arrow='start',
                                 color='green')
-            canvas.add(line, tag=f'mark_{name}', redraw=True)
+            canvas.add(line, tag=f'mark_{name}', redraw=False)
+
+            if 'x_fitted' in dct:
+                # <-- there is a fit to be plotted
+                points = np.array((dct['x_fitted'], dct['y_fitted'])).T
+                path = self.dc.Path(points, linewidth=2, linestyle='solid',
+                                    alpha=1.0, color='green')
+                canvas.add(path, tag='mark_{name}_fit', redraw=False)
+
 
     def plot_lines(self):
         """Plot the line list + regions + markers.

--- a/pypeit/display/spec1dview.py
+++ b/pypeit/display/spec1dview.py
@@ -72,6 +72,8 @@ import time
 import numpy as np
 # for smoothing
 from astropy.convolution import convolve, Gaussian1DKernel
+# for gaussian line fitting
+from astropy.modeling import models, fitting
 
 from ginga import GingaPlugin
 from ginga.misc import Bunch
@@ -137,6 +139,11 @@ class Spec1dView(GingaPlugin.LocalPlugin):
         self.plot = None
         self.plot_shelf = Shelf()
         self.plot_stocker = self.plot_shelf.get_stocker()
+
+        # holds regions of interest in the X axis
+        self.region_dct = dict(mark=[None, None])
+        # holds markers in the X axis
+        self.marker_dct = dict()
 
         viewer = self.channel.get_viewer('Ginga Plot')
         viewer.add_callback('range-set', self.range_changed_cb)
@@ -242,6 +249,11 @@ class Spec1dView(GingaPlugin.LocalPlugin):
         btn.set_tooltip("Smooth a bit more")
         self.w.smooth_more = btn
 
+        fr = Widgets.Frame("Result")
+        self.w.text = Widgets.TextArea(wrap=True)
+        fr.set_widget(self.w.text)
+        vbox.add_widget(fr, stretch=1)
+
         top.add_widget(vbox, stretch=0)
 
         spacer = Widgets.Label('')
@@ -315,26 +327,160 @@ class Spec1dView(GingaPlugin.LocalPlugin):
         self.recalc()
 
     def unsmooth(self):
+        """Completely remove all smoothing from the plot."""
         self.nsmooth = 0.0
         self.w.unsmooth.set_enabled(False)
         self.w.smooth_less.set_enabled(False)
         self.recalc()
 
     def smooth_more(self):
+        """Increase the level of smoothing in the plot."""
         self.nsmooth += (0.5 if self.nsmooth > 0.0 else 1.0)
         self.w.unsmooth.set_enabled(True)
         self.w.smooth_less.set_enabled(True)
         self.recalc()
 
     def smooth_less(self):
+        """Decrease the level of smoothing in the plot."""
         self.nsmooth -= (0.5 if self.nsmooth > 1.0 else 1.0)
         self.nsmooth = max(self.nsmooth, 0.0)
         self.w.unsmooth.set_enabled(self.nsmooth > 0.0)
         self.w.smooth_less.set_enabled(self.nsmooth > 0.0)
         self.recalc()
 
+    def set_region_side(self, name, side, value):
+        """Define one side (left, right, top, bottom) of a named region.
+
+        Parameters
+        ----------
+        name : str
+            The name of a region (e.g. 'mark')
+
+        side : str ('left', 'right', 'top', 'bottom')
+            The side of the region to set
+
+        value : float
+            The value to set for this side of the region
+        """
+        region = self.region_dct.setdefault(name, [None, None])
+        if side in ('left', 'bottom'):
+            region[0] = value
+            if region[1] is not None and region[1] <= value:
+                region[1] = None
+        elif side in ('right', 'top'):
+            region[1] = value
+            if region[0] is not None and region[0] >= value:
+                region[0] = None
+
+        self.plot_lines()
+
+    def clear_region(self, name):
+        """Clear the region named `name`."""
+        self.region_dct[name] = [None, None]
+
+        self.plot_lines()
+
+    def cut_x_range(self, name):
+        """Zoom the X range of the plot to the region named `name`."""
+        x_lo, x_hi = self.region_dct[name]
+        if None in (x_lo, x_hi):
+            self.fv.show_error("Please set left and right markers to delineate region to be cut!")
+            return
+
+        viewer = self.channel.get_viewer('Ginga Plot')
+        viewer.set_ranges(x_range=(x_lo, x_hi))
+        self.clear_region(name)
+
+    def fit_range(self, name):
+        """Perform a fitting on the flux data within the region named `name`."""
+        x_lo, x_hi = self.region_dct[name]
+        if None in (x_lo, x_hi):
+            self.fv.show_error("Please set left and right markers to delineate region to be fitted!")
+            return
+
+        try:
+            # find indices of low and high X values
+            idx_lo = np.searchsorted(self.data.wave, x_lo, side="left")
+            idx_hi = np.searchsorted(self.data.wave, x_hi, side="right")
+
+            # fit a gaussian
+            model, fitter = fit_gaussian_line(self.data.wave, self.data.flux,
+                                              idx_lo, idx_hi)
+            continuum = model[0]
+            line = model[1]
+
+            # collect some results and display
+            line_center = line.mean.value
+            line_sigma = line.stddev.value
+            line_fwhm = 2.35482 * line_sigma
+            line_flux = line.amplitude.value * np.sqrt(2 * np.pi) * line_sigma
+            result = dict(x=line_center, sigma=line_sigma, fwhm=line_fwhm,
+                          flux=line_flux)
+
+            # TODO: probably want to plot multiple unique lines and label them
+            # name = str(line_center)  # ?? what is a better unique name
+            # for now, just plot the last result
+            # self.add_marker(name, result)
+            self.marker_dct = dict(fitting=result)
+
+            text = """
+            Center: {x:.4f}
+            Sigma: {sigma:.6f}
+            FWHM: {fwhm:.6f}
+            Flux: {flux:.4f}
+            """.format(**result)
+            self.w.text.set_text(text)
+
+            self.plot_lines()
+
+        except Exception as e:
+            errtxt = f"error doing fitting: {e}; traceback in viewer log"
+            self.w.text.set_text(errtxt)
+            self.logger.error(f"error doing fitting: {e}", exc_info=True)
+
+    def add_marker(self, name, dct):
+        self.marker_dct[name] = dct
+
+        self.plot_lines()
+
+    def clear_marker(self, name):
+        if name in self.marker_dct:
+            del self.marker_dct[name]
+
+            self.plot_lines()
+
+    def clear_markers(self):
+        self.marker_dct = dict()
+        self.plot_lines()
+
+    def plot_markers(self):
+        """Plot the regions and markers.
+        """
+        if self.plot is None:
+            return
+
+        canvas = self.plot.get_canvas()
+        objs = canvas.get_objects_by_tag_pfx('mark_')
+        canvas.delete_objects(objs)
+
+        x_lo, x_hi = self.region_dct['mark']
+        if None not in (x_lo, x_hi):
+            canvas.add(self.dc.XRange(x_lo, x_hi, fillcolor='aquamarine',
+                                      fillalpha=0.25),
+                       tag='mark_%region', redraw=False)
+
+        viewer = self.channel.get_viewer('Ginga Plot')
+        (x_lo, x_hi), (y_lo, y_hi) = viewer.get_ranges()
+
+        for name, dct in self.marker_dct.items():
+            x = dct['x']
+            line = self.dc.Line(x, y_lo, x, y_hi, linewidth=2,
+                                linestyle='dotted', arrow='start',
+                                color='green')
+            canvas.add(line, tag=f'mark_{name}', redraw=True)
+
     def plot_lines(self):
-        """Plot the line list.
+        """Plot the line list + regions + markers.
 
         Lines are made into a single compound object so that it is easier
         to remove them as a group if the line list is changed.
@@ -356,9 +502,7 @@ class Spec1dView(GingaPlugin.LocalPlugin):
             gdwv = np.where((wvobs > x_min) & (wvobs < x_max))[0]
 
             viewer = self.channel.get_viewer('Ginga Plot')
-            ranges = viewer.get_ranges()
-            x_lo, x_hi = ranges[0]
-            y_lo, y_hi = ranges[1]
+            (x_lo, x_hi), (y_lo, y_hi) = viewer.get_ranges()
             # make label always sit about 3/4 up the Y range
             y_lbl = y_lo + (y_hi - y_lo) * 0.75
             # line should reach to the label at least
@@ -390,6 +534,8 @@ class Spec1dView(GingaPlugin.LocalPlugin):
 
         # will be empty if there were no lines
         canvas.add(lines, tag='lines', redraw=False)
+
+        self.plot_markers()
 
         # this causes the plot viewer to redraw itself
         with self.plot_stocker:
@@ -424,6 +570,9 @@ class Spec1dView(GingaPlugin.LocalPlugin):
         self.plot_lines()
 
     def range_changed_cb(self, viewer, ranges):
+        """Called when the plot viewers displayed range has changed.
+        We use this to replot lines of interest.
+        """
         if not self.plot_shelf.is_blocked():
             self.plot_lines()
 
@@ -675,3 +824,74 @@ def convolve_psf(array, fwhm, boundary='fill', fill_value=0.0,
     return convolve(array, Gaussian1DKernel(sigma, x_size=x_size),
                     boundary=boundary, fill_value=fill_value,
                     normalize_kernel=normalize_kernel)
+
+
+def fit_gaussian_line(x, flux, i_low, i_high):
+    """
+    Fit a Gaussian spectral line with a local linear continuum.
+
+    Parameters
+    ----------
+    x : array_like
+        Monotonically increasing spectral coordinate (wavelength, frequency, etc.).
+    flux : array_like
+        Flux values.
+    i_low : int
+        Lower index (inclusive) of fitting window.
+    i_high : int
+        Upper index (exclusive) of fitting window.
+
+    Returns
+    -------
+    model : astropy.modeling.CompoundModel
+        Best-fit (Gaussian1D + Linear1D) model.
+    fitter : astropy.modeling.fitting.LevMarLSQFitter
+        Fitter instance containing fit diagnostics.
+    """
+
+    x = np.asarray(x)
+    flux = np.asarray(flux)
+
+    if x.ndim != 1 or flux.ndim != 1:
+        raise ValueError("x and flux must be 1D arrays")
+    if len(x) != len(flux):
+        raise ValueError("x and flux must have the same length")
+    if not (0 <= i_low < i_high <= len(x)):
+        raise ValueError("Invalid index range")
+
+    # Extract window
+    x_fit = x[i_low:i_high]
+    f_fit = flux[i_low:i_high]
+
+    # --- Continuum initialization ---
+    # Estimate continuum from window edges
+    n_edge = max(1, int(0.1 * len(x_fit)))
+    cont_level = np.median(
+        np.concatenate([f_fit[:n_edge], f_fit[-n_edge:]])
+    )
+
+    cont_init = models.Linear1D(
+        slope=0.0,
+        intercept=cont_level
+    )
+
+    # --- Gaussian initialization ---
+    peak_index = np.argmax(np.abs(f_fit - cont_level))
+    mean_init = x_fit[peak_index]
+    amplitude_init = f_fit[peak_index] - cont_level
+
+    stddev_init = 0.25 * (x_fit[-1] - x_fit[0])
+
+    gauss_init = models.Gaussian1D(
+        amplitude=amplitude_init,
+        mean=mean_init,
+        stddev=stddev_init
+    )
+
+    # Compound model: continuum + line
+    model_init = cont_init + gauss_init
+
+    fitter = fitting.LevMarLSQFitter()
+    model_fit = fitter(model_init, x_fit, f_fit)
+
+    return model_fit, fitter

--- a/pypeit/display/spec1dview.py
+++ b/pypeit/display/spec1dview.py
@@ -68,7 +68,10 @@ Tips
 
 """
 import time
+
 import numpy as np
+# for smoothing
+from astropy.convolution import convolve, Gaussian1DKernel
 
 from ginga import GingaPlugin
 from ginga.misc import Bunch
@@ -125,6 +128,9 @@ class Spec1dView(GingaPlugin.LocalPlugin):
 
         self.masked_options = (True, False)
         self.masked = self.settings.get('masked', False)
+
+        # smoothing factor
+        self.nsmooth = 0.0
 
         # dictionary of plotable types
         self.dc = get_canvas_types()
@@ -218,6 +224,24 @@ class Spec1dView(GingaPlugin.LocalPlugin):
         fr.set_widget(w)
         vbox.add_widget(fr, stretch=0)
 
+        tbar = Widgets.Toolbar(orientation='horizontal')
+        vbox.add_widget(tbar, stretch=0)
+
+        btn = tbar.add_action("Unsmooth")
+        btn.add_callback('activated', lambda w: self.unsmooth())
+        btn.set_enabled(self.nsmooth > 0.0)
+        self.w.unsmooth = btn
+        btn.set_tooltip("Undo all smoothing")
+        btn = tbar.add_action("Smooth-")
+        btn.add_callback('activated', lambda w: self.smooth_less())
+        btn.set_enabled(self.nsmooth > 0.0)
+        btn.set_tooltip("Smooth a bit less")
+        self.w.smooth_less = btn
+        btn = tbar.add_action("Smooth+")
+        btn.add_callback('activated', lambda w: self.smooth_more())
+        btn.set_tooltip("Smooth a bit more")
+        self.w.smooth_more = btn
+
         top.add_widget(vbox, stretch=0)
 
         spacer = Widgets.Label('')
@@ -288,6 +312,25 @@ class Spec1dView(GingaPlugin.LocalPlugin):
         """
         self.masked = self.masked_options[idx]
         self.logger.debug(f"Selected masked option: {self.masked}")
+        self.recalc()
+
+    def unsmooth(self):
+        self.nsmooth = 0.0
+        self.w.unsmooth.set_enabled(False)
+        self.w.smooth_less.set_enabled(False)
+        self.recalc()
+
+    def smooth_more(self):
+        self.nsmooth += (0.5 if self.nsmooth > 0.0 else 1.0)
+        self.w.unsmooth.set_enabled(True)
+        self.w.smooth_less.set_enabled(True)
+        self.recalc()
+
+    def smooth_less(self):
+        self.nsmooth -= (0.5 if self.nsmooth > 1.0 else 1.0)
+        self.nsmooth = max(self.nsmooth, 0.0)
+        self.w.unsmooth.set_enabled(self.nsmooth > 0.0)
+        self.w.smooth_less.set_enabled(self.nsmooth > 0.0)
         self.recalc()
 
     def plot_lines(self):
@@ -458,6 +501,11 @@ class Spec1dView(GingaPlugin.LocalPlugin):
             flux = flux*gpm
             sig = sig*gpm
 
+        if self.nsmooth > 0.0:
+            # do smoothing if requested
+            flux = convolve_psf(flux, self.nsmooth)
+            sig = convolve_psf(sig, self.nsmooth)
+
         self.data.x_min, self.data.x_max = np.nanmin(wave), np.nanmax(wave)
         self.data.y_min, self.data.y_max = np.nanmin(flux), np.nanmax(flux)
         self.data.wave = wave
@@ -573,3 +621,57 @@ class Spec1dView(GingaPlugin.LocalPlugin):
     def __str__(self):
         # necessary to identify the plugin and provide correct operation in Ginga
         return 'spec1dview'
+
+# Used verbatim from linetools.spectra.convolve
+#
+def convolve_psf(array, fwhm, boundary='fill', fill_value=0.0,
+                 normalize_kernel=True):
+    """ Convolve an array with a gaussian kernel.
+
+    Given an array of values `a` and a gaussian full width at half
+    maximum `fwhm` in pixel units, returns the convolution of the
+    array with the gaussian kernel.
+
+    Parameters
+    ----------
+    array : array, shape(N,)
+        Array to convolve
+    fwhm : float
+        Gaussian full width at half maximum in pixels.
+    boundary : str, optional
+        A flag indicating how to handle boundaries:
+            * `None`
+                Set the ``result`` values to zero where the kernel
+                extends beyond the edge of the array (default).
+            * 'fill'
+                Set values outside the array boundary to ``fill_value``.
+            * 'wrap'
+                Periodic boundary that wrap to the other side of ``array``.
+            * 'extend'
+                Set values outside the array to the nearest ``array``
+                value.
+    fill_value : float, optional
+        The value to use outside the array when using boundary='fill'
+    normalize_kernel : bool, optional
+        Whether to normalize the kernel prior to convolving
+
+    Returns
+    -------
+    convolved_array : array, shape (N,)
+
+    Notes
+    -----
+    This function uses astropy.convolution
+    """
+
+    const2   = 2.354820046             # 2*sqrt(2*ln(2))
+    const100 = 3.034854259             # sqrt(2*ln(100))
+    sigma = fwhm / const2
+    # gaussian drops to 1/100 of maximum value at x =
+    # sqrt(2*ln(100))*sigma, so number of pixels to include from
+    # centre of gaussian is:
+    n = np.ceil(const100 * sigma)
+    x_size = int(2*n) + 1 # we want this to be odd integer
+    return convolve(array, Gaussian1DKernel(sigma, x_size=x_size),
+                    boundary=boundary, fill_value=fill_value,
+                    normalize_kernel=normalize_kernel)

--- a/pypeit/display/spec1dview.py
+++ b/pypeit/display/spec1dview.py
@@ -476,6 +476,10 @@ class Spec1dView(GingaPlugin.LocalPlugin):
 
         Simply attempt to process the latest FITS file loaded in the channel.
         """
+        viewer = self.channel.get_viewer('Ginga Plot')
+        bd = viewer.get_bindings()
+        bd.set_mode(viewer, 'spec1d', mode_type='locked')
+
         self.redo()
 
     def stop(self):

--- a/pypeit/display/spec1dview.py
+++ b/pypeit/display/spec1dview.py
@@ -415,41 +415,42 @@ class Spec1dView(GingaPlugin.LocalPlugin):
             continuum = model[0]
             line = model[1]
 
-            # collect some results and display
-            line_center = line.mean.value
-            line_sigma = line.stddev.value
-            line_fwhm = 2.35482 * line_sigma
-            line_flux = line.amplitude.value * np.sqrt(2 * np.pi) * line_sigma
-
-            # Plot the fitted gaussian
-            # Dense grid for smooth model curve
-            x_fitted = np.linspace(self.data.wave[idx_lo],
-                                  self.data.wave[idx_hi], 100)  # 1000?
-            y_fitted = model(x_fitted)
-
-            result = dict(x=line_center, sigma=line_sigma, fwhm=line_fwhm,
-                          flux=line_flux, x_fitted=x_fitted, y_fitted=y_fitted)
-
-            # TODO: probably want to plot multiple unique lines and label them
-            # name = str(line_center)  # ?? what is a better unique name
-            # for now, just plot the last result
-            # self.add_marker(name, result)
-            self.marker_dct = dict(fitting=result)
-
-            text = """
-            Center: {x:.4f}
-            Sigma: {sigma:.6f}
-            FWHM: {fwhm:.6f}
-            Flux: {flux:.4f}
-            """.format(**result)
-            self.w.text.set_text(text)
-
-            self.plot_lines()
-
         except Exception as e:
             errtxt = f"error doing fitting: {e}; traceback in viewer log"
             self.w.text.set_text(errtxt)
             self.logger.error(f"error doing fitting: {e}", exc_info=True)
+            return
+
+        # collect some results and display
+        line_center = line.mean.value
+        line_sigma = line.stddev.value
+        line_fwhm = 2.35482 * line_sigma
+        line_flux = line.amplitude.value * np.sqrt(2 * np.pi) * line_sigma
+
+        # Plot the fitted gaussian
+        # Dense grid for smooth model curve
+        x_fitted = np.linspace(self.data.wave[idx_lo],
+                              self.data.wave[idx_hi], 100)  # 1000?
+        y_fitted = model(x_fitted)
+
+        result = dict(x=line_center, sigma=line_sigma, fwhm=line_fwhm,
+                      flux=line_flux, x_fitted=x_fitted, y_fitted=y_fitted)
+
+        # TODO: probably want to plot multiple unique lines and label them
+        # name = str(line_center)  # ?? what is a better unique name
+        # for now, just plot the last result
+        # self.add_marker(name, result)
+        self.marker_dct = dict(fitting=result)
+
+        text = """
+        Center: {x:.4f}
+        Sigma: {sigma:.6f}
+        FWHM: {fwhm:.6f}
+        Flux: {flux:.4f}
+        """.format(**result)
+        self.w.text.set_text(text)
+
+        self.plot_lines()
 
     def add_marker(self, name, dct):
         self.marker_dct[name] = dct

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "configobj>=5.0.6",
     "scikit-learn>=1.2",
     "IPython>=8.0.0",
-    "ginga>=5.4.0",
+    "ginga>=5.5.0",
     "setuptools<81",    # Keep until we deprecate linetools
     "linetools>=0.3.2",
     "qtpy>=2.2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,6 +166,10 @@ pypeit_show_pixflat = "pypeit.scripts.show_pixflat:ShowPixFlat.entry_point"
 SlitWavelength = "pypeit.display:setup_SlitWavelength"
 Spec1dView = "pypeit.display:setup_Spec1dView"
 
+[project.entry-points."ginga_modes"]
+
+pypeit1d = "pypeit.display.pypeit_modes:Spec1DMode"
+
 [build-system]
 requires = [
     "setuptools",


### PR DESCRIPTION
Adds a custom `spec1d` keyboard mode for PypeIt special bindings in Ginga

- custom bindings when used with the Spec1DView plugin
- will require Ginga v5.5 +
- fix #1990

