### PR TITLE
Use ginga v5.5.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "configobj>=5.0.6",
     "scikit-learn>=1.2",
     "IPython>=8.0.0",
-    "ginga>=5.5.0",
+    "ginga>=5.5.1",
     "setuptools<81",    # Keep until we deprecate linetools
     "linetools>=0.3.2",
     "qtpy>=2.2.0",


### PR DESCRIPTION
There was a bug on the cursor readout (mouse around readout of values underneath the cursor) in v5.5.0.  This is fixed in v5.5.1

Also included is a possible fix for issue #2026