### PR TITLE
Allow for different sizes on det 1 and 2

### DIFF
--- a/pypeit/spectrographs/keck_lris.py
+++ b/pypeit/spectrographs/keck_lris.py
@@ -580,19 +580,19 @@ class KeckLRISSpectrograph(spectrograph.Spectrograph):
             if 'VidInp' in ihdu.name:
                 extensions.append(kk)
         n_ext = len(extensions)
-        xcol = []
+        xcol = np.zeros(n_ext, dtype=int)
         xmax = 0
         ymax = 0
         xmin = 10000
         ymin = 10000
-        xmins = []
-        xmaxs = []
-        ymins = []
-        ymaxs = []
+        xmins = np.zeros(n_ext, dtype=int)
+        xmaxs = np.zeros(n_ext, dtype=int)
+        ymins = np.zeros(n_ext, dtype=int)
+        ymaxs = np.zeros(n_ext, dtype=int)
 
-        for i in extensions:
+        for i, ext in enumerate(extensions):
 
-            theader = hdu[i].header
+            theader = hdu[ext].header
             detsec = theader['DETSEC']
             if detsec != '0':
                 # parse the DETSEC keyword to determine the size of the array.
@@ -601,22 +601,18 @@ class KeckLRISSpectrograph(spectrograph.Spectrograph):
                 # find the range of detector space occupied by the data
                 # [xmin:xmax,ymin:ymax]
                 xt = max(x2, x1)
-                xmaxs.append(max(xt, xmax))
+                xmaxs[i] += max(xt, xmax)
                 yt = max(y2, y1)
-                ymaxs.append(max(yt, ymax))
+                ymaxs[i] += max(yt, ymax)
 
                 # find the min size of the array
                 xt = min(x1, x2)
-                xmins.append(min(xmin, xt))
+                xmins[i] += min(xmin, xt)
                 yt = min(y1, y2)
-                ymins.append(min(ymin, yt))
+                ymins[i] += min(ymin, yt)
                 # Save
-                xcol.append(xt)
+                xcol[i] += xt
 
-        xmins = np.asarray(xmins)
-        xmaxs = np.asarray(xmaxs)
-        ymins = np.asarray(ymins)
-        ymaxs = np.asarray(ymaxs)
         # Deal with detectors
         if det in [1, 2]:
             n_ext = n_ext // 2
@@ -652,7 +648,7 @@ class KeckLRISSpectrograph(spectrograph.Spectrograph):
 
         # allocate output arrays...
         array = np.zeros((nx, ny))
-        order = np.argsort(np.array(xcol))
+        order = np.argsort(xcol)
         rawdatasec_img = np.zeros_like(array, dtype=int)
         oscansec_img = np.zeros_like(array, dtype=int)
 

--- a/pypeit/spectrographs/keck_lris.py
+++ b/pypeit/spectrographs/keck_lris.py
@@ -585,8 +585,13 @@ class KeckLRISSpectrograph(spectrograph.Spectrograph):
         ymax = 0
         xmin = 10000
         ymin = 10000
+        xmins = []
+        xmaxs = []
+        ymins = []
+        ymaxs = []
 
         for i in extensions:
+
             theader = hdu[i].header
             detsec = theader['DETSEC']
             if detsec != '0':
@@ -596,17 +601,38 @@ class KeckLRISSpectrograph(spectrograph.Spectrograph):
                 # find the range of detector space occupied by the data
                 # [xmin:xmax,ymin:ymax]
                 xt = max(x2, x1)
-                xmax = max(xt, xmax)
+                xmaxs.append(max(xt, xmax))
                 yt = max(y2, y1)
-                ymax = max(yt, ymax)
+                ymaxs.append(max(yt, ymax))
 
                 # find the min size of the array
                 xt = min(x1, x2)
-                xmin = min(xmin, xt)
+                xmins.append(min(xmin, xt))
                 yt = min(y1, y2)
-                ymin = min(ymin, yt)
+                ymins.append(min(ymin, yt))
                 # Save
                 xcol.append(xt)
+
+        xmins = np.asarray(xmins)
+        xmaxs = np.asarray(xmaxs)
+        ymins = np.asarray(ymins)
+        ymaxs = np.asarray(ymaxs)
+        # Deal with detectors
+        if det in [1, 2]:
+            n_ext = n_ext // 2
+            det_idx = np.arange(n_ext, dtype=int) + (det - 1) * n_ext
+            xmin = min(xmins[det_idx])
+            xmax = max(xmaxs[det_idx])
+            ymin = min(ymins[det_idx])
+            ymax = max(ymaxs[det_idx])
+        elif det is None:
+            det_idx = np.arange(n_ext).astype(int)
+            xmin = min(xmins)
+            xmax = max(xmaxs)
+            ymin = min(ymins)
+            ymax = max(ymaxs)
+        else:
+            raise ValueError('Bad value for det')
 
         # determine the output array size...
         nx = xmax - xmin + 1
@@ -619,16 +645,6 @@ class KeckLRISSpectrograph(spectrograph.Spectrograph):
         # Update PRECOL and POSTPIX
         precol = precol // xbin
         postpix = postpix // xbin
-
-        # Deal with detectors
-        if det in [1, 2]:
-            nx = nx // 2
-            n_ext = n_ext // 2
-            det_idx = np.arange(n_ext, dtype=int) + (det - 1) * n_ext
-        elif det is None:
-            det_idx = np.arange(n_ext).astype(int)
-        else:
-            raise ValueError('Bad value for det')
 
         # change size for pre/postscan...
         nx += n_ext * (precol + postpix)

--- a/pypeit/spectrographs/keck_lris.py
+++ b/pypeit/spectrographs/keck_lris.py
@@ -601,17 +601,17 @@ class KeckLRISSpectrograph(spectrograph.Spectrograph):
                 # find the range of detector space occupied by the data
                 # [xmin:xmax,ymin:ymax]
                 xt = max(x2, x1)
-                xmaxs[i] += max(xt, xmax)
+                xmaxs[i] = max(xt, xmax)
                 yt = max(y2, y1)
-                ymaxs[i] += max(yt, ymax)
+                ymaxs[i] = max(yt, ymax)
 
                 # find the min size of the array
                 xt = min(x1, x2)
-                xmins[i] += min(xmin, xt)
+                xmins[i] = min(xmin, xt)
                 yt = min(y1, y2)
-                ymins[i] += min(ymin, yt)
+                ymins[i] = min(ymin, yt)
                 # Save
-                xcol[i] += xt
+                xcol[i] = xt
 
         # Deal with detectors
         if det in [1, 2]:


### PR DESCRIPTION
The `get_rawimage()` method used for the `keck_lris_red` spectrometer (not the original red nor the current Mark IV) 
handles windowed images incorrectly. 
For example, when reading in the following windowed 1x1 image from the dev suite 
(data taken with LRIS-R Science mosaic Mark 2: CCD  1: 19-3  CCD 2: 19-2)
`long_400_8500_longread/LR.20181003.56288.fits.gz`
there are two image extensions 
1 (4116, 635)
2 (4116, 739)
Running `get_rawimage()` on that frame and retrieving the dat for detector 1 and 2 yields out data with following shapes:
1 (4116, 687)
2 (4116, 687)

This PR fixes that while maintaining the rest of the functionality (such as correctly mapping the individual amplifiers and
making a full image with the `det=None` option.)
