### PR TITLE
Numpy 2.4.x fixes

### DIFF
--- a/pypeit/core/skysub.py
+++ b/pypeit/core/skysub.py
@@ -1324,8 +1324,8 @@ def ech_local_skysub_extract(sciimg, sciivar, fullmask, tilts, waveimg,
             if np.sum(ind) == 0:
                 msgs.error('There is a missing order for object {0:d} on slit {1:d}!'.format(iobj, slitid))
             if iobj == 0:
-                order_vec[islit] = sobjs[ind].ECH_ORDER
-            order_snr[islit,iobj] = sobjs[ind].ech_snr
+                order_vec[islit] = sobjs[ind][0].ECH_ORDER
+            order_snr[islit,iobj] = sobjs[ind][0].ech_snr
 
     # Enforce that the number of objects in the sobjs object is an integer multiple of the number of good orders
     if (np.sum(sobjs.sign > 0) % norders) == 0:

--- a/pypeit/scripts/run_to_calibstep.py
+++ b/pypeit/scripts/run_to_calibstep.py
@@ -89,7 +89,7 @@ class RunToCalibStep(scriptbase.ScriptBase):
             if len(rows) == 0:
                 msgs.error(f"Calibration group {args.calib_group} not found")
             row = rows[0]
-        row = int(row)
+        row = int(row[0])
         calib_id = pypeIt.fitstbl.find_frame_calib_groups(row)[0]
 
         # Calibrations?

--- a/pypeit/spectrographs/keck_deimos.py
+++ b/pypeit/spectrographs/keck_deimos.py
@@ -1571,7 +1571,7 @@ class KeckDEIMOSSpectrograph(spectrograph.Spectrograph):
             sobj = sobjs[ibobj]
             mtc = sobj.RA == robjs.RA
             if np.sum(mtc) == 1:
-                irobj = int(ridx[mtc])
+                irobj = int(ridx[mtc][0])
                 if not np.isclose(sobj.DEC, sobjs[irobj].DEC):
                     msgs.error('DEC does not match RA!')
                 bmt.append(ibobj)


### PR DESCRIPTION
This PR fixes crashes caused by changes in numpy version 2.4.x.

Devsuite results:
```
Test Summary
--------------------------------------------------------
--- PYTEST PYPEIT UNIT TESTS PASSED  281 passed, 439 warnings in 316.56s (0:05:16) ---
--- PYTEST UNIT TESTS PASSED  158 passed, 1573 warnings in 870.91s (0:14:30) ---
--- PYTEST VET TESTS PASSED  73 passed, 1686 warnings in 5260.50s (1:27:40) ---
--- PYPEIT DEVELOPMENT SUITE PASSED 291/291 TESTS  ---
Total disk usage: 325.999 GiB
Testing Started at 2026-01-17T01:19:03.073941
Testing Completed at 2026-01-17T15:43:29.837886
Total Time: 14:24:26.763945

```