### PR TITLE
updated np.is1d to np.isin

### DIFF
--- a/pypeit/flatfield.py
+++ b/pypeit/flatfield.py
@@ -2527,7 +2527,7 @@ def load_pixflat(pixel_flat_file, spectrograph, det, flatimages, calib_dir=None,
         traceimg = edgetrace.EdgeTraceSet.from_file(edges_file, chk_version=chk_version).traceimg
         det_info = traceimg.detector
         # check that the mosaic parameters are defined
-        if not np.all(np.in1d(['tform', 'msc_ord'], list(det_info.keys()))) or  \
+        if not np.all(np.isin(['tform', 'msc_ord'], list(det_info.keys()))) or  \
                 det_info.tform is None or det_info.msc_ord is None:
             msgs.error('Mosaic parameters are not defined in the Edges frame. Cannot load the pixel flat!')
 
@@ -2536,7 +2536,7 @@ def load_pixflat(pixel_flat_file, spectrograph, det, flatimages, calib_dir=None,
             # list of available detectors in the pixel flat file
             file_dets = [int(h.name.split('-')[0].split('DET')[1]) for h in hdu[1:]]
             # check if all detectors required for the mosaic are in the list
-            if not np.all(np.in1d(list(det), file_dets)):
+            if not np.all(np.isin(list(det), file_dets)):
                 msgs.error(f'Not all detectors in the mosaic are in the pixel flat file: '
                            f'{pixel_flat_file}. Cannot load the pixel flat!')
 

--- a/pypeit/slittrace.py
+++ b/pypeit/slittrace.py
@@ -1642,7 +1642,7 @@ def average_maskdef_offset(calib_slits, platescale, list_detectors):
         return calib_slits
 
     # are there dets from calib_slits that are blue?
-    indx_b = np.where(np.in1d(calib_dets, spectrograph_dets[0]))[0]
+    indx_b = np.where(np.isin(calib_dets, spectrograph_dets[0]))[0]
     # if this spectrograph is not split into blue and red detectors
     # or if it is but there are no available offsets in the blue
     if not blue_and_red or indx_b.size == 0:
@@ -1666,7 +1666,7 @@ def average_maskdef_offset(calib_slits, platescale, list_detectors):
                   '{:.2f} pixels ({:.2f} arcsec).'.format(median_off, median_off * platescale))
 
         # which dets from calib_slits are red?
-        indx_r = np.where(np.in1d(calib_dets, spectrograph_dets[1]))[0]
+        indx_r = np.where(np.isin(calib_dets, spectrograph_dets[1]))[0]
         if indx_r.size > 0:
             # compute median if these red dets have values of slitmask_offsets
             _, median_off, _ = sigma_clipped_stats(slitmask_offsets[indx_r], sigma=2.)

--- a/pypeit/wavecalib.py
+++ b/pypeit/wavecalib.py
@@ -543,12 +543,12 @@ class BuildWaveCalib:
             # Redo?
             if self.par['redo_slits'] is not None:
                 if self.par['echelle'] and self.slits.ech_order is not None:
-                    idx = np.in1d(self.slits.ech_order, self.par['redo_slits'])
+                    idx = np.isin(self.slits.ech_order, self.par['redo_slits'])
                     # Turn off mask
                     self.slits.mask[idx] = self.slits.bitmask.turn_off(
                             self.slits.mask[idx], 'BADWVCALIB')
                 else:
-                    idx = np.in1d(self.slits.spat_id, self.par['redo_slits'])
+                    idx = np.isin(self.slits.spat_id, self.par['redo_slits'])
                     self.slits.mask[idx] = self.slits.bitmask.turn_off(
                             self.slits.mask[idx], 'BADWVCALIB')
 
@@ -835,7 +835,7 @@ class BuildWaveCalib:
         fixed = False
 
         for idet in range(len(dets)):
-            in_det = np.in1d(bad_orders, order_dets[idet])
+            in_det = np.isin(bad_orders, order_dets[idet])
             if not np.any(in_det):
                 continue
             msgs.info(f"Attempting to refit bad orders in detector={dets[idet]}")


### PR DESCRIPTION
Was trying to reduce Magellan FIRE spectra an ran into an error with the np.is1d command when running run_pypeit. The error specifically mentioned that np.isin was the correct function to use. Turns out np.is1d was deprecated and np.isin is the way to go now. This was in a fresh installation of pypeit using an anaconda environment with python 3.11.14