### PR TITLE
Support for python 3.14

### DIFF
--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python: ['3.11', '3.12', '3.13']
+        python: ['3.11', '3.12', '3.13', '3.14']
         toxenv: [test, test-alldeps-cov, test-numpydev, test-gingadev, test-astropydev]
     steps:
     - name: Check out repository

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python: ['3.11', '3.12', '3.13']
+        python: ['3.11', '3.12', '3.13', '3.14']
         toxenv: [test, test-alldeps-cov, test-numpydev, test-gingadev, test-astropydev]
     steps:
     - name: Check out repository
@@ -48,7 +48,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, macos-latest]
-        python: ['3.11', '3.12', '3.13']
+        python: ['3.11', '3.12', '3.13', '3.14']
         toxenv: [test-alldeps]
     steps:
     - name: Check out repository

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: pypeit
 channels:
   - conda-forge
 dependencies:
-  - python>=3.11,<3.14
+  - python>=3.11,<3.15
   - numpy
   - astropy
   - scipy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,9 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
-requires-python = ">=3.11,<3.14"
+requires-python = ">=3.11,<3.15"
 dependencies = [ 
     "numpy>=2.4.1",
     "astropy>=7.0",

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,8 @@
 
 [tox]
 envlist =
-    {3.11,3.12,3.13}-test{,-alldeps}{,-cov}
-    {3.11,3.12,3.13}-test-{numpy,astropy,ginga}dev
+    {3.11,3.12,3.13,3.14}-test{,-alldeps}{,-cov}
+    {3.11,3.12,3.13,3.14}-test-{numpy,astropy,ginga}dev
     codestyle
 requires =
     setuptools >= 65.0


### PR DESCRIPTION
Bumps the python support limit to include 3.14, and adds python3.14 tests to the CI matrix.

Note this includes edits from #2058.