### PR TITLE
Alternate Cosmic Ray Rejection Option

### DIFF
--- a/pypeit/core/procimg.py
+++ b/pypeit/core/procimg.py
@@ -44,7 +44,7 @@ def boxcar_average(arr, boxcar):
     Returns:
         `numpy.ndarray`_: The averaged array.  If boxcar is a single
         integer, the returned array shape is::
-            
+
             tuple([s//boxcar for s in arr.shape])
 
         A similar operation gives the shape when boxcar has elements
@@ -98,6 +98,34 @@ def boxcar_replicate(arr, boxcar):
     for axis, box in zip(range(arr.ndim), _boxcar):
         _arr = np.repeat(_arr, box, axis=axis)
     return _arr
+
+
+def crthresh(sciframe, thresh: float, grow_times: int = 1):
+    """
+    Identify cosmic rays by a crude threshold, and grow the mask by a certain
+    number of pixels
+
+    Args:
+        sciframe (`numpy.ndarray`_):
+            Science frame to process.
+        thresh (:obj:`float`):
+            The threshold to use. All pixels with flux above `thresh` will be
+            marked as cosmic rays.
+        grow_times (:obj:`int`, optional):
+            How much to grow the mask after thresholding. Zero means mask
+            will not be grown, the raw threshold mask will be used as-is;
+            the default (grow_times=1) expands the mask by 1 pixel in all
+            directions.
+
+    Returns:
+        `numpy.ndarray`_: Boolean array flagging pixels with detected cosmic
+        rays; True means the pixel has a cosmic ray.
+    """
+    crmask = sciframe > float(thresh)
+    growkernel = np.ones((3, 3), dtype=bool)
+    for _ in range(grow_times):
+        crmask = scipy.ndimage.binary_dilation(crmask, structure=growkernel)
+    return crmask
 
 
 def lacosmic(sciframe, saturation=None, nonlinear=1., bpm=None, varframe=None, maxiter=1, grow=1.5,
@@ -307,7 +335,7 @@ def boxcar_fill(img, width, bpm=None, maxiter=None, fill_value=np.nan):
     an image.
 
     .. warning::
-        
+
         Depending the size of the kernel, the masked regions, and the maximum
         number of iterations, the procedure may not be able to fill all masked
         pixels.  Any left-over masked pixels are returned with the provided
@@ -337,7 +365,7 @@ def boxcar_fill(img, width, bpm=None, maxiter=None, fill_value=np.nan):
     """
     # TODO: A 2D median filter that accounts for masked pixels may be better,
     # but I couldn't find a canned algorithm.  Could also imagine using
-    # different kernels (e.g., a Gaussian).  See: 
+    # different kernels (e.g., a Gaussian).  See:
     #   https://docs.astropy.org/en/stable/convolution/index.html
 
     # Check input
@@ -489,7 +517,7 @@ def rn2_frame(datasec_img, ronoise, units='e-', gain=None, digitization=False):
     {\rm RN}^2` otherwise; where RN is the readnoise and :math:`\gamma` is the
     gain in e-/ADU.  In the rare case one would need the units in ADU, the
     returned variance is :math:`V/\gamma^2`.
-    
+
     .. [1] `Newberry (1991, PASP, 103, 122) <https://ui.adsabs.harvard.edu/abs/1991PASP..103..122N/abstract>`_
     .. [2] `Merline & Howell (1995, ExA, 6, 163) <https://ui.adsabs.harvard.edu/abs/1995ExA.....6..163M/abstract>`_
 
@@ -678,7 +706,7 @@ def subtract_overscan(rawframe, datasec_img, oscansec_img, method='savgol', para
         if var is not None:
             # pi/2 coefficient yields asymptotic variance in the median relative
             # to the error in the mean
-            osvar = np.pi/2*(np.sum(osvar)/osvar.size**2 if method.lower() == 'median' 
+            osvar = np.pi/2*(np.sum(osvar)/osvar.size**2 if method.lower() == 'median'
                              else np.sum(osvar, axis=compress_axis)/osvar.shape[compress_axis]**2)
         # Method time
         if method.lower() == 'polynomial':
@@ -1149,7 +1177,7 @@ def base_variance(rn_var, darkcurr=None, exptime=None, proc_var=None, count_scal
     .. math::
 
         V = s^2\ \left[ {\rm max}(0, C) + D t_{\rm exp} / 3600 +
-                V_{\rm rn} + V_{\rm proc} \right] 
+                V_{\rm rn} + V_{\rm proc} \right]
                 + \epsilon^2 {\rm max}(0, c)^2
 
     where:
@@ -1199,7 +1227,7 @@ def base_variance(rn_var, darkcurr=None, exptime=None, proc_var=None, count_scal
           that it is the dark-current expected in the *binned* pixel.  For
           example, see the calling function
           :func:`pypeit.images.rawimage.RawImage.build_ivar`.
-        
+
         - The input arrays can have any dimensionality (i.e., they can be single
           2D images or a 3D array containing multiple 2D images); however, the
           exposure time must be a scalar applied to all array values.
@@ -1281,7 +1309,7 @@ def variance_model(base, counts=None, count_scale=None, noise_floor=None):
     .. math::
 
         V = s^2\ \left[ {\rm max}(0, C) + D t_{\rm exp} / 3600 +
-                V_{\rm rn} + V_{\rm proc} \right] 
+                V_{\rm rn} + V_{\rm proc} \right]
                 + \epsilon^2 {\rm max}(0, c)^2
 
     where:

--- a/pypeit/images/pypeitimage.py
+++ b/pypeit/images/pypeitimage.py
@@ -381,26 +381,28 @@ class PypeItImage(datamodel.DataContainer):
         saturation = self.map_detector_value('saturation')
         nonlinear = self.map_detector_value('nonlinear')
 
-        crthresh = os.environ.get('PYPEIT_CRTHRESH')
+        # crthresh = os.environ.get('PYPEIT_CRTHRESH')
+        crthresh = par['crthresh']
 
         if crthresh is not None:
-            # FIXME this will fail for multi detector
-            log.info(f'Using cosmic ray threshold {crthresh=}, not L.A.Cosmic...')
-            crmask = use_img > float(crthresh)
-            log.info(f'Masked {crmask.sum} pixels...')
-            import scipy
-            growkernel = np.ones((3, 3), dtype=bool)
-            crmask = scipy.ndimage.binary_dilation(crmask, structure=growkernel)
-        elif self.is_multidetector:
+            log.info(f'Using cosmic ray threshold {crthresh=}, not L.A.Cosmic')
+
+        if self.is_multidetector:
             # If the object has multiple images, need to flag each image individually
             crmask = np.empty(self.shape, dtype=bool)
-            for i in range(self.shape[0]):
-                crmask[i] = procimg.lacosmic(use_img[i], saturation=saturation[i],
-                                             nonlinear=nonlinear[i], bpm=bpm[i], varframe=var[i],
-                                             maxiter=par['lamaxiter'], grow=par['grow'],
-                                             remove_compact_obj=par['rmcompact'],
-                                             sigclip=par['sigclip'], sigfrac=par['sigfrac'],
-                                             objlim=par['objlim'])
+            if crthresh is not None:
+                for i in range(self.shape[0]):
+                    crmask[i] = procimg.crthresh(use_img[i], crthresh, grow_times=int(par['grow']))
+            else:
+                for i in range(self.shape[0]):
+                    crmask[i] = procimg.lacosmic(use_img[i], saturation=saturation[i],
+                                                 nonlinear=nonlinear[i], bpm=bpm[i], varframe=var[i],
+                                                 maxiter=par['lamaxiter'], grow=par['grow'],
+                                                 remove_compact_obj=par['rmcompact'],
+                                                 sigclip=par['sigclip'], sigfrac=par['sigfrac'],
+                                                 objlim=par['objlim'])
+        elif crthresh is not None:
+            crmask = procimg.crthresh(use_img, crthresh, grow_times=int(par['grow']))
         else:
             # Otherwise, just run LA Cosmic once
             crmask = procimg.lacosmic(use_img, saturation=saturation, nonlinear=nonlinear,

--- a/pypeit/images/pypeitimage.py
+++ b/pypeit/images/pypeitimage.py
@@ -11,6 +11,8 @@ import numpy as np
 
 from astropy.io import fits
 
+import os
+
 from pypeit import log
 from pypeit import PypeItError
 from pypeit.images.imagebitmask import ImageBitMaskArray
@@ -51,7 +53,7 @@ class PypeItImage(datamodel.DataContainer):
     functions are provided to interface with the underlying object;  see
     :func:`update_mask` and :func:`select_flag`, as well as
     :class:`~pypeit.images.imagebitmask.ImageBitMask` for the valid flag names.
-    
+
     Additionally, pixels can be flagged on instantiation as being part of a
     bad-pixel mask (``bpm``), a cosmic ray hit (``crmask``), or a user-level
     bad-pixel mask (``usermask``).  Importantly, if both ``fullmask`` and one of
@@ -63,7 +65,7 @@ class PypeItImage(datamodel.DataContainer):
 
     The following lists only those parameters that are *not* part of the class
     datamodel (see above).
-    
+
     Args:
         bpm (`numpy.ndarray`_, optional):
             The image bad-pixel mask, which typically selects image values that
@@ -94,7 +96,7 @@ class PypeItImage(datamodel.DataContainer):
 
     # TODO These docs are confusing. The __init__ method needs to be documented just as it is for
     # every other class that we have written in PypeIt, i.e. the arguments all need to be documented. They are not
-    # documented here and instead we have the odd Args documentation above. 
+    # documented here and instead we have the odd Args documentation above.
     version = '1.3.1'
     """Datamodel version number"""
 
@@ -131,7 +133,7 @@ class PypeItImage(datamodel.DataContainer):
                  'shot_noise': dict(otype=bool, descr='Shot-noise included in variance'),
                  'spat_flexure': dict(otype=float,
                                       descr='Shift, in spatial pixels, between this image '
-                                            'and SlitTrace'), 
+                                            'and SlitTrace'),
                  'filename': dict(otype=str, descr='Filename for the image'),
                  'rel_scaleImg': dict(otype=np.ndarray, atype=np.floating,
                                   descr='Image used to apply a relative scaling to the science '
@@ -177,10 +179,10 @@ class PypeItImage(datamodel.DataContainer):
         # Done
         return self
 
-    # TODO This init method needs proper docs, which includes every optional argument. See my comment above. 
+    # TODO This init method needs proper docs, which includes every optional argument. See my comment above.
     def __init__(self, image, ivar=None, nimg=None, amp_img=None, det_img=None, rn2img=None,
                  base_var=None, img_scale=None, fullmask=None, detector=None, spat_flexure=None,
-                 filename=None, PYP_SPEC=None, units=None, exptime=None, noise_floor=None, 
+                 filename=None, PYP_SPEC=None, units=None, exptime=None, noise_floor=None,
                  shot_noise=None, bpm=None, crmask=None, usermask=None, clean_mask=False):
 
         if image is None:
@@ -340,7 +342,7 @@ class PypeItImage(datamodel.DataContainer):
         Identify and flag cosmic rays in the image.
 
         This is mainly a wrapper to :func:`pypeit.core.procimg.lacosmic`, with
-        the boolean cosmic-ray mask is saved to :attr:`crmask`. 
+        the boolean cosmic-ray mask is saved to :attr:`crmask`.
 
         Args:
             par (:class:`~pypeit.par.pypeitpar.ProcessImagesPar`):
@@ -379,7 +381,17 @@ class PypeItImage(datamodel.DataContainer):
         saturation = self.map_detector_value('saturation')
         nonlinear = self.map_detector_value('nonlinear')
 
-        if self.is_multidetector:
+        crthresh = os.environ.get('PYPEIT_CRTHRESH')
+
+        if crthresh is not None:
+            # FIXME this will fail for multi detector
+            log.info(f'Using cosmic ray threshold {crthresh=}, not L.A.Cosmic...')
+            crmask = use_img > float(crthresh)
+            log.info(f'Masked {crmask.sum} pixels...')
+            import scipy
+            growkernel = np.ones((3, 3), dtype=bool)
+            crmask = scipy.ndimage.binary_dilation(crmask, structure=growkernel)
+        elif self.is_multidetector:
             # If the object has multiple images, need to flag each image individually
             crmask = np.empty(self.shape, dtype=bool)
             for i in range(self.shape[0]):
@@ -539,7 +551,7 @@ class PypeItImage(datamodel.DataContainer):
                 and mincounts.shape != self.shape:
             raise PypeItError('Minimum counts array must have the same shape as the image.')
 
-        # Setup the saturation level 
+        # Setup the saturation level
         if isinstance(saturation, str):
             if saturation != 'default':
                 raise PypeItError(f'Unknown saturation string: {saturation}')
@@ -550,7 +562,7 @@ class PypeItImage(datamodel.DataContainer):
         else:
             _saturation = saturation
 
-        # Setup the minimum counts level 
+        # Setup the minimum counts level
         if isinstance(mincounts, str):
             if mincounts != 'default':
                 raise PypeItError(f'Unknown mincounts string: {mincounts}')
@@ -678,7 +690,7 @@ class PypeItImage(datamodel.DataContainer):
                 good pixels (i.e., a bad-pixel mask).  If True, invert the sense
                 of the mask (i.e., create a good-pixel mask, True for good
                 pixels, False for bad pixels).
-    
+
         Returns:
             `numpy.ndarray`_: Boolean array where pixels with the selected bits
             flagged are returned as True (if ``invert`` is False); i.e., this is
@@ -694,7 +706,7 @@ class PypeItImage(datamodel.DataContainer):
     def sub(self, other):
         """
         Subtract this PypeItImage from another.
-        
+
         The following operations are performed:
 
             - the image data is subtracted (images must have the same shape)
@@ -872,7 +884,7 @@ class PypeItImage(datamodel.DataContainer):
 class PypeItCalibrationImage(PypeItImage, CalibFrame):
     """
     Abstract base class used with PypeIt calibration images.
-    
+
     This class inherits the core datamodel attributes and functionality from
     :class:`PypeItImage`, including the version number, but uses the naming
     conventions driven by :class:`~pypeit.calibframe.CalibFrame`.  Some
@@ -903,7 +915,7 @@ class PypeItCalibrationImage(PypeItImage, CalibFrame):
     """
     Combines internals from both base classes.
     """
-    
+
     @classmethod
     def from_hdu(cls, hdu, chk_version=True, hdu_prefix=None, **kwargs):
         """

--- a/pypeit/par/pypeitpar.py
+++ b/pypeit/par/pypeitpar.py
@@ -215,6 +215,7 @@ class ProcessImagesPar(ParSet):
                  scale_to_mean=None,
                  #cr_sigrej=None,
                  n_lohi=None, #replace=None,
+                 crthresh=None,
                  lamaxiter=None, grow=None,
                  comb_sigrej=None,
 #                 calib_setup_and_bit=None,
@@ -370,11 +371,11 @@ class ProcessImagesPar(ParSet):
         defaults['spat_flexure_correct'] = False
         dtypes['spat_flexure_correct'] = bool
         descr['spat_flexure_correct'] = 'Correct slits, illumination flat, etc. for flexure'
-        
+
         defaults['spat_flexure_maxlag'] = 20
         dtypes['spat_flexure_maxlag'] = int
         descr['spat_flexure_maxlag'] = 'Maximum of possible spatial flexure correction, in pixels'
-        
+
         defaults['spat_flexure_sigdetect'] = 5.
         dtypes['spat_flexure_sigdetect'] = [int, float]
         descr['spat_flexure_sigdetect'] = 'Sigma threshold above fluctuations in the '  \
@@ -435,6 +436,11 @@ class ProcessImagesPar(ParSet):
 #        descr['replace'] = 'If all pixels are rejected, replace them using this method.  ' \
 #                           'Options are: {0}'.format(', '.join(options['replace']))
 
+        defaults['crthresh'] = None
+        dtypes['crthresh'] = [int, float]
+        descr['crthresh'] = 'Crude threshold to detect cosmic rays. Overrides ' \
+                            'other options and skips LA Cosmic'
+
         defaults['lamaxiter'] = 1
         dtypes['lamaxiter'] = int
         descr['lamaxiter'] = 'Maximum number of iterations for LA cosmics routine.'
@@ -489,8 +495,8 @@ class ProcessImagesPar(ParSet):
                    'spat_flexure_vrange', 'use_illumflat', 'use_specillum', 'skip_write_2d',
                    'empirical_rn', 'shot_noise', 'noise_floor', 'use_pixelflat', 'combine',
                    'scale_to_mean', 'correct_nonlinear', 'satpix', #'calib_setup_and_bit',
-                   'n_lohi', 'mask_cr', 'lamaxiter', 'grow', 'clip', 'comb_sigrej', 'rmcompact',
-                   'sigclip', 'sigfrac', 'objlim']
+                   'n_lohi', 'mask_cr', 'crthresh', 'lamaxiter', 'grow', 'clip', 'comb_sigrej',
+                   'rmcompact', 'sigclip', 'sigfrac', 'objlim']
 
         badkeys = np.array([pk not in parkeys for pk in k])
         if np.any(badkeys):
@@ -3562,7 +3568,7 @@ class EdgeTracePar(ParSet):
         descr['niter_gaussian'] = 'The number of iterations of ' \
                                   ':func:`~pypeit.core.trace.fit_trace` to use when using ' \
                                   'Gaussian weighting.'
-        
+
         defaults['min_edge_side_sep'] = 5.0
         dtypes['min_edge_side_sep'] = [int, float]
         descr['min_edge_side_sep'] = 'Minimum separation between same-side edges (e.g., the ' \


### PR DESCRIPTION
This PR adds a ProcessImagesPar parameter called `crthresh`, which when present bypasses the LA Cosmic CR detection algorithm and identifies CR contamination as all pixels above a certain threshold.

This is a crude approach, and is probably a "bad idea" 99% of the time. My use case for this is for KCRM, where LA Cosmic really struggles. I'm not sure what is unique about KCRM or its detector, but I invested more time than I would like trying to tune LA Cosmic to work well without finding a satisfying solution. The best LA Cosmic configurations I found erroneously rejected lots of good data, while still allowing some CR-contaminated pixels through. This `crthresh` is the best approach I have found with my data. I can share comparisons of how this performs on my data set later.

As this is a crude approach, I understand if the PypeIt devs would prefer not to allow this option. The implementation was very small and straightforward, so I figured I should make it available for discussion.