### PR TITLE
Remove instances of `log.error`

### DIFF
--- a/pypeit/flatfield.py
+++ b/pypeit/flatfield.py
@@ -2230,9 +2230,12 @@ def illum_profile_spectral(rawimg, waveimg, slits, slit_illum_ref_idx=0, smooth_
         onslit_init = (slitid_img == slit_spat)
         # Check if a wavelength calibration exists for this slice
         if np.all(np.logical_not(onslit_init)):
-            log.error(f"Slit {slit_idx+1}/{slits.nslits} ({slit_spat}) has no wavelength solution. Cannot perform "
-                      f"relative spectral sensitivity calculation. You can turn off the relative spectral sensitivity "
-                      f"correction or check that your wavelength calibration is correct for this slit.")
+            raise PypeItError(
+                f"Slit {slit_idx+1}/{slits.nslits} ({slit_spat}) has no wavelength solution. "
+                "Cannot perform relative spectral sensitivity calculation. You can turn off the "
+                "relative spectral sensitivity correction or check that your wavelength "
+                "calibration is correct for this slit."
+            )
         mnmx_wv[slit_idx, 0] = np.min(waveimg[onslit_init])
         mnmx_wv[slit_idx, 1] = np.max(waveimg[onslit_init])
     wavecen = np.mean(mnmx_wv, axis=1)

--- a/pypeit/spectrographs/vlt_uves.py
+++ b/pypeit/spectrographs/vlt_uves.py
@@ -13,6 +13,7 @@ from astropy.io import fits
 from astropy.table import Table
 
 from pypeit import log
+from pypeit import PypeItError
 from pypeit import telescopes
 from pypeit.core import parse
 from pypeit.core import framematch
@@ -212,7 +213,7 @@ class VLTUVESSpectrograph(spectrograph.Spectrograph):
                 cwlen = 'None'
             return cwlen
         else:
-            log.error("Not ready for this compound meta")
+            raise PypeItError("Not ready for this compound meta")
 
     def configuration_keys(self):
         """
@@ -625,7 +626,7 @@ class VLTUVESRedSpectrograph(VLTUVESSpectrograph):
         detectors = np.array([self.get_detector_par(det, hdu=hdu) for det in mosaic])
         # Binning *must* be consistent for all detectors
         if any(d.binning != detectors[0].binning for d in detectors[1:]):
-            log.error('Binning is somehow inconsistent between detectors in the mosaic!')
+            raise PypeItError('Binning is somehow inconsistent between detectors in the mosaic!')
 
         # Collect the offsets and rotations for *all unbinned* detectors in the
         # full instrument, ordered by the number of the detector.  Detector


### PR DESCRIPTION
Unlike the old `msgs.error`, `log.error` does not raise an exception.  That means we basically should never be using it.  Instead we should be raising exceptions, typically `raise PypeItError`, which will be caught and handled by the new logging code.

This PR replaces the few instances I found in the code.