### PR TITLE
Add config to limit PR CI to PRs that have been checked and labeled.

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -6,6 +6,7 @@ on:
     - release
     - develop
   pull_request:
+    types: [labeled]
 
 env:
   SETUP_XVFB: True  # avoid issues if something tries to open a GUI window


### PR DESCRIPTION
Letting PRs run CI automatically upon submission is a pretty bad security practice. Malicious code could easily be added to tests and then blindly run. This PR adds the basic protection of only running CI on PRs that have been labeled. 