### PR TITLE
WCS and alignment operations fixed for datacubes

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -1,10 +1,13 @@
 name: CI Tests
 
 on:
+  workflow_dispatch:
+
   push:
     branches:
     - release
     - develop
+
   pull_request:
     types: [labeled]
 

--- a/doc/releases/2.1.0dev.rst
+++ b/doc/releases/2.1.0dev.rst
@@ -56,6 +56,7 @@ Testing
 
 - Add new tests for :mod:`~pypeit.core.pydl`
 - Added new tests for :class:`~pypeit.inputfiles.InputFile` objects.
+- Added new tests for :mod:`~pypeit.core.datacube`.
 
 Under-the-hood Improvements
 ---------------------------
@@ -72,6 +73,8 @@ Under-the-hood Improvements
 - Refactor how script and spectrograph classes are imported.  Instead of
   importing each module in the relevant ``__init__.py`` file, we now define
   ``__all__`` and import all the relevant classes where needed.
+- Multiple improvements for datacube generation, including no transpose operations
+  and faster cube generation.
 
 Bug Fixes
 ---------
@@ -93,3 +96,4 @@ Bug Fixes
 - Fix a bug in 2D coaddition where manually identified objects were not being
   used to compute offsets between input frames.  Add description of this failure
   mode to the :ref:`known_issues_coadd2d` documentation for 2D coaddition.
+- Fixed bugs with the datacube WCS and datacube alignments.

--- a/pypeit/coadd3d.py
+++ b/pypeit/coadd3d.py
@@ -1556,7 +1556,7 @@ class SlicerIFUCoAdd3D(CoAdd3D):
                                     wave_min=self.cubepar['wave_min'], wave_max=self.cubepar['wave_max'],
                                     reference=self.cubepar['reference_image'], collapse=True, equinox=2000.0,
                                     specname=self.specname)
-            if voxedge[2].size != 2:
+            if voxedge[0].size != 2:
                 raise PypeItError("Spectral range for WCS is incorrect for white light image")
 
             wl_imgs, sig_imgs, bpm_imgs = datacube.generate_image_subpixel(
@@ -1575,6 +1575,7 @@ class SlicerIFUCoAdd3D(CoAdd3D):
 
             # Calculate the image offsets relative to the reference image
             if self.alignment_method == 'phase':
+                embed()
                 for ff in range(self.numfiles):
                     # Calculate the shift
                         ra_shift, dec_shift = calculate_image_phase(
@@ -1770,7 +1771,7 @@ class SlicerIFUCoAdd3D(CoAdd3D):
 
         # If we are combining frames, check that alignment has been requested. 
         # If not, then print out a warning. 
-        if self.combine and not self.align:
+        if self.combine and not self.align and self.numfiles!=1:
             log.warning(
                 "Combining frames without aligning them.  Make sure that you know what you are "
                 "doing!  Even if your frames are taken at the same position, alignment is still "

--- a/pypeit/coadd3d.py
+++ b/pypeit/coadd3d.py
@@ -1575,7 +1575,6 @@ class SlicerIFUCoAdd3D(CoAdd3D):
 
             # Calculate the image offsets relative to the reference image
             if self.alignment_method == 'phase':
-                embed()
                 for ff in range(self.numfiles):
                     # Calculate the shift
                         ra_shift, dec_shift = calculate_image_phase(

--- a/pypeit/coadd3d.py
+++ b/pypeit/coadd3d.py
@@ -1845,9 +1845,6 @@ class SlicerIFUCoAdd3D(CoAdd3D):
                     self.scidir, self.spec2d[ff], self.cubepar['output_filename'], False, idx=ff+1
                 )
                 # Generate the datacube       
-                
-                # TODO Put in a self.native flag to allow for the datacube to be generated in the native resolution
-                # of the data as it is currently being done in the load method?    
                 flxcube, sigcube, bpmcube, normcube, wave = \
                     datacube.generate_cube_subpixel(cube_wcs, vox_edges,
                                                     self.all_sci[ff], self.all_ivar[ff], self.all_wave[ff],

--- a/pypeit/coadd3d.py
+++ b/pypeit/coadd3d.py
@@ -1577,7 +1577,7 @@ class SlicerIFUCoAdd3D(CoAdd3D):
             if self.alignment_method == 'phase':
                 for ff in range(self.numfiles):
                     # Calculate the shift
-                        ra_shift, dec_shift = calculate_image_phase(
+                        dec_shift, ra_shift = calculate_image_phase(
                             reference_image.copy(), wl_imgs[:, :, ff], maskval=0.0)
                         # Convert pixel shift to degrees shift
                         ra_shift *= self._dspat/cosdec
@@ -1588,8 +1588,8 @@ class SlicerIFUCoAdd3D(CoAdd3D):
                             f"{dec_shift*3600.0:+0.3f} N"
                         )
                         # Store the shift in the RA and DEC offsets in degrees
-                        ra_offsets[ff] += ra_shift
-                        dec_offsets[ff] += dec_shift
+                        ra_offsets[ff] -= ra_shift
+                        dec_offsets[ff] -= dec_shift
             elif self.alignment_method == 'fit':
                 ra_pix_star = np.zeros(self.numfiles)
                 dec_pix_star = np.zeros(self.numfiles)
@@ -1610,8 +1610,8 @@ class SlicerIFUCoAdd3D(CoAdd3D):
 
                 ra_shifts = (ra_pix_star - ra_pix_star[ref_idx]) * self._dspat / cosdec
                 dec_shifts = (dec_pix_star - dec_pix_star[ref_idx]) * self._dspat
-                ra_offsets =[ra_offsets[ff] + ra_shifts[ff] for ff in range(self.numfiles)]
-                dec_offsets =[dec_offsets[ff] + dec_shifts[ff] for ff in range(self.numfiles)]
+                ra_offsets = [ra_offsets[ff] - ra_shifts[ff] for ff in range(self.numfiles)]
+                dec_offsets = [dec_offsets[ff] - dec_shifts[ff] for ff in range(self.numfiles)]
             else:
                 raise PypeItError(f"self.alignment_method method '{self.alignment_method}' is not supported.")
 

--- a/pypeit/coadd3d.py
+++ b/pypeit/coadd3d.py
@@ -1608,10 +1608,10 @@ class SlicerIFUCoAdd3D(CoAdd3D):
                             np.logical_not(bpm_imgs[:, :, ff]), model, gaussian_position,
                             init_obj_position, channel_prefix = f'Img_{ff}'
                         )
-                    ra_pix_star[ff], dec_pix_star[ff] = gaussian_position
+                    dec_pix_star[ff], ra_pix_star[ff] = gaussian_position
 
-                ra_shifts = (ra_pix_star - ra_pix_star[ref_idx]) * self._dspat / cosdec
-                dec_shifts = (dec_pix_star - dec_pix_star[ref_idx]) * self._dspat
+                ra_shifts = (ra_pix_star[ref_idx] - ra_pix_star) * self._dspat / cosdec
+                dec_shifts = (dec_pix_star[ref_idx] - dec_pix_star) * self._dspat
                 ra_offsets = [ra_offsets[ff] - ra_shifts[ff] for ff in range(self.numfiles)]
                 dec_offsets = [dec_offsets[ff] - dec_shifts[ff] for ff in range(self.numfiles)]
             else:

--- a/pypeit/coadd3d.py
+++ b/pypeit/coadd3d.py
@@ -1582,13 +1582,8 @@ class SlicerIFUCoAdd3D(CoAdd3D):
                         reference_image.copy(), wl_imgs[:, :, ff], maskval=0.0, force_cc=force_cc
                     )
                     # Convert pixel shift to degrees shift
-                    ra_shift *= self._dspat/cosdec
+                    ra_shift *= -self._dspat/cosdec
                     dec_shift *= self._dspat
-                    log.info(
-                        f"Spatial shift of cube #{ff+1}:\n"
-                        f"RA, DEC (arcsec) = {ra_shift*3600.0:+0.3f} E, "
-                        f"{dec_shift*3600.0:+0.3f} N"
-                    )
                     # Store the shift in the RA and DEC offsets in degrees
                     ra_offsets[ff] -= ra_shift
                     dec_offsets[ff] -= dec_shift
@@ -1610,7 +1605,7 @@ class SlicerIFUCoAdd3D(CoAdd3D):
                         )
                     dec_pix_star[ff], ra_pix_star[ff] = gaussian_position
 
-                ra_shifts = (ra_pix_star[ref_idx] - ra_pix_star) * self._dspat / cosdec
+                ra_shifts = -(ra_pix_star[ref_idx] - ra_pix_star) * self._dspat / cosdec
                 dec_shifts = (dec_pix_star[ref_idx] - dec_pix_star) * self._dspat
                 ra_offsets = [ra_offsets[ff] - ra_shifts[ff] for ff in range(self.numfiles)]
                 dec_offsets = [dec_offsets[ff] - dec_shifts[ff] for ff in range(self.numfiles)]
@@ -1619,7 +1614,7 @@ class SlicerIFUCoAdd3D(CoAdd3D):
 
             for ff in range(self.numfiles):
                 log.info(
-                    f"Spatial shift of cube #{ff + 1}:\n"
+                    f"Total spatial offset of cube #{ff + 1}:\n"
                     f"RA, DEC (arcsec) = {ra_offsets[ff]*3600.0:+0.3f} E, "
                     f"{dec_offsets[ff]*3600.0:+0.3f} N"
                 )

--- a/pypeit/coadd3d.py
+++ b/pypeit/coadd3d.py
@@ -1574,22 +1574,24 @@ class SlicerIFUCoAdd3D(CoAdd3D):
                 log.info("Calculating the spatial translation of each cube relative to user-defined 'reference_image'")
 
             # Calculate the image offsets relative to the reference image
-            if self.alignment_method == 'phase':
+            if self.alignment_method in ['phase', 'cc']:
+                force_cc = True if self.alignment_method == 'cc' else False
                 for ff in range(self.numfiles):
                     # Calculate the shift
-                        dec_shift, ra_shift = calculate_image_phase(
-                            reference_image.copy(), wl_imgs[:, :, ff], maskval=0.0)
-                        # Convert pixel shift to degrees shift
-                        ra_shift *= self._dspat/cosdec
-                        dec_shift *= self._dspat
-                        log.info(
-                            f"Spatial shift of cube #{ff+1}:\n"
-                            f"RA, DEC (arcsec) = {ra_shift*3600.0:+0.3f} E, "
-                            f"{dec_shift*3600.0:+0.3f} N"
-                        )
-                        # Store the shift in the RA and DEC offsets in degrees
-                        ra_offsets[ff] -= ra_shift
-                        dec_offsets[ff] -= dec_shift
+                    dec_shift, ra_shift = calculate_image_phase(
+                        reference_image.copy(), wl_imgs[:, :, ff], maskval=0.0, force_cc=force_cc
+                    )
+                    # Convert pixel shift to degrees shift
+                    ra_shift *= self._dspat/cosdec
+                    dec_shift *= self._dspat
+                    log.info(
+                        f"Spatial shift of cube #{ff+1}:\n"
+                        f"RA, DEC (arcsec) = {ra_shift*3600.0:+0.3f} E, "
+                        f"{dec_shift*3600.0:+0.3f} N"
+                    )
+                    # Store the shift in the RA and DEC offsets in degrees
+                    ra_offsets[ff] -= ra_shift
+                    dec_offsets[ff] -= dec_shift
             elif self.alignment_method == 'fit':
                 ra_pix_star = np.zeros(self.numfiles)
                 dec_pix_star = np.zeros(self.numfiles)

--- a/pypeit/core/datacube.py
+++ b/pypeit/core/datacube.py
@@ -2365,11 +2365,9 @@ def subpixellate(
                 # Interpolate the RA/Dec over the subpixel spatial positions
                 tmp_ra = this_ra[this_sl]
                 tmp_dec = this_dec[this_sl]
-                ra_spl = interp1d(spatpos[ssrt], tmp_ra[ssrt], kind='linear', bounds_error=False, fill_value='extrapolate')
-                dec_spl = interp1d(spatpos[ssrt], tmp_dec[ssrt], kind='linear', bounds_error=False, fill_value='extrapolate')
                 # Evaluate the RA/Dec at the subpixel spatial positions
-                this_ra_int = ra_spl(spatpos_subpix)
-                this_dec_int = dec_spl(spatpos_subpix)
+                this_ra_int = utils.linear_interpolate_extrapolate(spatpos_subpix, spatpos[ssrt], tmp_ra[ssrt])
+                this_dec_int = utils.linear_interpolate_extrapolate(spatpos_subpix, spatpos[ssrt], tmp_dec[ssrt])
                 # Now apply the DAR correction and any user-supplied offsets
                 this_ra_int += ra_corr + _ra_offset[fr]
                 this_dec_int += dec_corr + _dec_offset[fr]

--- a/pypeit/core/datacube.py
+++ b/pypeit/core/datacube.py
@@ -692,7 +692,7 @@ def extract_point_source(
     if fluxed:
         sobj.OPT_FLAM = sobj.OPT_COUNTS
         sobj.OPT_FLAM_SIG = sobj.OPT_COUNTS_SIG
-        sobj.OPT_FLAM_IVAR = sobj.OPT_COUNTS_IVARf
+        sobj.OPT_FLAM_IVAR = sobj.OPT_COUNTS_IVAR
 
     # Make a specobjs object
     sobjs = specobjs.SpecObjs()

--- a/pypeit/core/datacube.py
+++ b/pypeit/core/datacube.py
@@ -97,7 +97,7 @@ def fitGaussian2D(image, ivar=None, gpm=None, init_obj_position=None,
         The inverse variance of the image. Optional. If not passed, the standard deviation computed
         from the image will be used to compute the inverse variance. Default is None.
     gpm : `numpy.ndarray`_, optional
-        A good pixel mask. Pixels that are True are good. Default is None,
+        A good pixel mask. Pixels that are True are good. Default is None.
     init_obj_position : tuple, optional
         The initial guess for the object position in the image with format
         (x, y). If set, the 2D Gaussian fit will be performed with the position constrainted
@@ -150,7 +150,7 @@ def fitGaussian2D(image, ivar=None, gpm=None, init_obj_position=None,
     # Normalise if requested
     wlscl = np.max(image) if norm else 1.0
     if ivar is None: 
-        mean, median, std = sigma_clipped_stats(image[np.logical_not(totmask)], sigma=3.0)
+        mean, median, std = sigma_clipped_stats(image[_gpm], sigma=3.0)
         if std > 0:
             _ivar = np.full_like(image, 1.0/std**2)
         else:

--- a/pypeit/core/datacube.py
+++ b/pypeit/core/datacube.py
@@ -149,15 +149,6 @@ def fitGaussian2D(image, ivar=None, gpm=None, init_obj_position=None,
     sigma = fwhm*fwhm2sigma
     # Normalise if requested
     wlscl = np.max(image) if norm else 1.0
-    if ivar is None: 
-        mean, median, std = sigma_clipped_stats(image[_gpm], sigma=3.0)
-        if std > 0:
-            _ivar = np.full_like(image, 1.0/std**2)
-        else:
-            log.warning('Could not measure standard deviation from image.  Assuming 1.')
-            _ivar = np.ones_like(image)
-    else: 
-        _ivar = ivar
 
     ## Find the objects
     ximg = np.tile(np.arange(image.shape[1]), (image.shape[0], 1))
@@ -165,6 +156,16 @@ def fitGaussian2D(image, ivar=None, gpm=None, init_obj_position=None,
     edgemask = (ximg < mask_edge) | (ximg >= image.shape[1] - mask_edge) | \
                 (yimg < mask_edge) | (yimg >= image.shape[0] - mask_edge)
     totmask = edgemask | np.logical_not(_gpm)
+
+    if ivar is None:
+        mean, median, std = sigma_clipped_stats(image[np.logical_not(totmask)], sigma=3.0)
+        if std > 0:
+            _ivar = np.full_like(image, 1.0/std**2)
+        else:
+            log.warning('Could not measure standard deviation from image.  Assuming 1.')
+            _ivar = np.ones_like(image)
+    else:
+        _ivar = ivar
 
     if init_obj_position is None: 
         if DAOStarFinder is None:
@@ -188,7 +189,7 @@ def fitGaussian2D(image, ivar=None, gpm=None, init_obj_position=None,
 
         # Create a border mask to exclude junk at the edges
         daofind = DAOStarFinder(
-            fwhm=fwhm, threshold=nsigma, sharpness_range=(None, 2.0),
+            fwhm=fwhm, threshold=nsigma, sharpness_range=(0.2, 2.0),
             exclude_border=False, n_brightest=1)
         # switched exclude_border to False since we use the edgemask now
         sources = daofind((objfind_image - median_objfind)*np.sqrt(ivar_objfind), mask=totmask)
@@ -199,6 +200,7 @@ def fitGaussian2D(image, ivar=None, gpm=None, init_obj_position=None,
                     sources[col].info.format = '%.2f'  # for consistent table output
             sources.pprint(max_width=76)
         if sources is None:
+            embed()
             display.show_image((objfind_image*np.logical_not(totmask)*np.sqrt(ivar_objfind)),
                             chname='S/N objfind_image', cuts=(-2.0, 5.0))
             raise PypeItError(
@@ -206,7 +208,7 @@ def fitGaussian2D(image, ivar=None, gpm=None, init_obj_position=None,
                 f"nsigma = {nsigma:.1f} or adjust the DAOStarFinder parameters."
             )
 
-        _init_obj_position = sources['ycentroid'][0], sources['xcentroid'][0]
+        _init_obj_position = sources['y_centroid'][0], sources['x_centroid'][0]
     else:
         _init_obj_position = init_obj_position
         
@@ -2022,7 +2024,7 @@ def generate_image_subpixel(image_wcs, bins, sciImg, ivarImg, waveImg, slitid_im
                                  _all_wcs, _tilts, _slits, _astrom_trans, _all_dar, _ra_offset, _dec_offset,
                                  spec_subpixel=spec_subpixel, spat_subpixel=spat_subpixel, slice_subpixel=slice_subpixel,
                                  skip_subpix_weights=True, correct_dar=correct_dar)
-        return img[:, :, 0], sigimg[:, :, 0], bpmimg[:, :, 0]
+        return img[0, :, :], sigimg[0, :, :], bpmimg[0, :, :]
     else:
         # Prepare the array of white light images to be stored
         numframes = len(_sciImg)

--- a/pypeit/core/datacube.py
+++ b/pypeit/core/datacube.py
@@ -5,7 +5,7 @@ Module containing routines used by 3D datacubes.
 """
 
 import os
-# import line_profiler
+import line_profiler
 
 from astropy import wcs, units
 from astropy.coordinates import AltAz, SkyCoord
@@ -2165,7 +2165,7 @@ def generate_cube_subpixel(
     return flxcube, sigcube, bpmcube, normcube, wave
 
 
-# @line_profiler.profile
+@line_profiler.profile
 def subpixellate(
     output_wcs, bins, sciImg, ivarImg, waveImg, slitid_img_gpm, wghtImg, all_wcs, tilts, slits,
     astrom_trans, all_dar, ra_offset, dec_offset, spec_subpixel=5, spat_subpixel=5,
@@ -2287,6 +2287,8 @@ def subpixellate(
     # Prepare the output arrays
     outshape = (bins[0].size-1, bins[1].size-1, bins[2].size-1)
     binrng = np.array([[bins[0][0], bins[0][-1]], [bins[1][0], bins[1][-1]], [bins[2][0], bins[2][-1]]])
+    voxscale = outshape / (binrng[:, 1] - binrng[:, 0])  # shape (3,)
+    voxoffset = binrng[:, 0] * voxscale  # shape (3,)
     flxcube, varcube, normcube = np.zeros(outshape), np.zeros(outshape), np.zeros(outshape)
     # Divide each pixel into subpixels
     spec_offs = np.arange(0.5/spec_subpixel, 1, 1/spec_subpixel) - 0.5  # -0.5 is to offset from the centre of each pixel.
@@ -2311,6 +2313,13 @@ def subpixellate(
         this_sci = _sciImg[fr][this_onslit_gpm]
         this_var = utils.inverse(_ivarImg[fr][this_onslit_gpm])
         this_wav = _waveImg[fr][this_onslit_gpm]
+        slshape = (this_slits.nspec, this_slits.nspat, slice_subpixel)
+        raimg_slc, decimg_slc = np.zeros(slshape, dtype=float), np.zeros(slshape, dtype=float)
+        for ss in range(slice_subpixel):
+            # Generate an RA/Dec image for this subslice
+            raimg_slc[:, :, ss], decimg_slc[:, :, ss], _ = this_slits.get_radec_image(
+                this_wcs, this_astrom_trans, this_tilts, slice_offset=slice_offs[ss]
+            )
         # Loop through all slits
         for sl, spatid in enumerate(this_slits.spat_id):
             if verbose:
@@ -2350,11 +2359,9 @@ def subpixellate(
                 if verbose and slice_subpixel > 1: 
                     # Only print this if there are multiple subslices
                     log.info(f"Resampling subslice {ss+1}/{slice_subpixel}")
-                # Generate an RA/Dec image for this subslice
-                raimg, decimg, delta_pix = this_slits.get_radec_image(this_wcs, this_astrom_trans, this_tilts,
-                                                                      slit_compute=sl, slice_offset=slice_offs[ss])
-                this_ra = raimg[this_onslit_gpm]
-                this_dec = decimg[this_onslit_gpm]
+                # Select the RA/Dec image for this subslice
+                this_ra = raimg_slc[:,:,ss][this_onslit_gpm]
+                this_dec = decimg_slc[:,:,ss][this_onslit_gpm]
                 # Interpolate the RA/Dec over the subpixel spatial positions
                 tmp_ra = this_ra[this_sl]
                 tmp_dec = this_dec[this_sl]
@@ -2381,8 +2388,9 @@ def subpixellate(
             else:
                 if verbose: 
                     log.info("Preparing subpixel weights")
-                vox_index = np.floor(outshape * (vox_coord - binrng[:,0].reshape((1, 1, 3))) /
-                                                (binrng[:,1] - binrng[:,0]).reshape((1, 1, 3))).astype(int)
+                vox_index = np.floor(vox_coord * voxscale - voxoffset).astype(int)
+                # vox_index = np.floor(outshape * (vox_coord - binrng[:,0].reshape((1, 1, 3))) /
+                #                                 (binrng[:,1] - binrng[:,0]).reshape((1, 1, 3))).astype(int)
                 # Convert to a unique index
                 vox_index = np.dot(vox_index, np.array([1, outshape[0], outshape[0]*outshape[1]]))
                 # Calculate the number of repeated indices for each subpixel - this is the subpixel weights

--- a/pypeit/core/datacube.py
+++ b/pypeit/core/datacube.py
@@ -188,8 +188,8 @@ def fitGaussian2D(image, ivar=None, gpm=None, init_obj_position=None,
 
         # Create a border mask to exclude junk at the edges
         daofind = DAOStarFinder(
-            fwhm=fwhm, threshold=nsigma, sharphi=2.0, 
-            exclude_border=False, brightest=1)
+            fwhm=fwhm, threshold=nsigma, sharpness_range=(None, 2.0),
+            exclude_border=False, n_brightest=1)
         # switched exclude_border to False since we use the edgemask now
         sources = daofind((objfind_image - median_objfind)*np.sqrt(ivar_objfind), mask=totmask)
         if verbose: 

--- a/pypeit/core/datacube.py
+++ b/pypeit/core/datacube.py
@@ -2038,9 +2038,9 @@ def generate_image_subpixel(image_wcs, bins, sciImg, ivarImg, waveImg, slitid_im
                                      _all_wcs[fr], _tilts[fr], _slits[fr], _astrom_trans[fr], _all_dar[fr], _ra_offset[fr], _dec_offset[fr],
                                      spec_subpixel=spec_subpixel, spat_subpixel=spat_subpixel, slice_subpixel=slice_subpixel,
                                      skip_subpix_weights=True, correct_dar=correct_dar)
-            all_wl_imgs[:, :, fr] = img[:, :, 0]
-            all_sig_imgs[:, :, fr] = sigimg[:, :, 0]
-            all_bpm_imgs[:, :, fr] = bpmimg[:, :, 0]
+            all_wl_imgs[:, :, fr] = img[0, :, :]
+            all_sig_imgs[:, :, fr] = sigimg[0, :, :]
+            all_bpm_imgs[:, :, fr] = bpmimg[0, :, :]
             
         # Return the constructed white light images
         return all_wl_imgs, all_sig_imgs, all_bpm_imgs

--- a/pypeit/core/datacube.py
+++ b/pypeit/core/datacube.py
@@ -5,6 +5,7 @@ Module containing routines used by 3D datacubes.
 """
 
 import os
+# import line_profiler
 
 from astropy import wcs, units
 from astropy.coordinates import AltAz, SkyCoord
@@ -2164,7 +2165,7 @@ def generate_cube_subpixel(
     return flxcube, sigcube, bpmcube, normcube, wave
 
 
-
+# @line_profiler.profile
 def subpixellate(
     output_wcs, bins, sciImg, ivarImg, waveImg, slitid_img_gpm, wghtImg, all_wcs, tilts, slits,
     astrom_trans, all_dar, ra_offset, dec_offset, spec_subpixel=5, spat_subpixel=5,
@@ -2385,7 +2386,7 @@ def subpixellate(
                 # Convert to a unique index
                 vox_index = np.dot(vox_index, np.array([1, outshape[0], outshape[0]*outshape[1]]))
                 # Calculate the number of repeated indices for each subpixel - this is the subpixel weights
-                subpix_wght = np.apply_along_axis(utils.occurrences, 1, vox_index).flatten()
+                subpix_wght = utils.occurrences_sorted(vox_index)
             # Reshape the voxel coordinates
             vox_coord = vox_coord.reshape(numpix * num_all_subpixels, 3)
             # Use the "fast histogram" algorithm, that assumes regular bin spacing

--- a/pypeit/core/datacube.py
+++ b/pypeit/core/datacube.py
@@ -170,7 +170,7 @@ def fitGaussian2D(image, ivar=None, gpm=None, init_obj_position=None,
     if init_obj_position is None: 
         if DAOStarFinder is None:
             raise PypeItError(
-                'Requires optional photutils dependency to proceed.  Try to reinstall pypeit '
+                'Requires optional photutils (>=3.0.0) dependency to proceed.  Try to reinstall pypeit '
                 'including the datacube dependencies; e.g., pip install "pypeit[datacube]".'
             )
         if median_filter:
@@ -200,7 +200,6 @@ def fitGaussian2D(image, ivar=None, gpm=None, init_obj_position=None,
                     sources[col].info.format = '%.2f'  # for consistent table output
             sources.pprint(max_width=76)
         if sources is None:
-            embed()
             display.show_image((objfind_image*np.logical_not(totmask)*np.sqrt(ivar_objfind)),
                             chname='S/N objfind_image', cuts=(-2.0, 5.0))
             raise PypeItError(
@@ -1396,21 +1395,24 @@ def wcs_bounds(raImg, decImg, waveImg, slitid_img_gpm, ra_offsets=None, dec_offs
         # Get the RA, Dec, and wavelength of the pixels on the slit
         if ra_min is None or ra_max is None:
             this_ra = _raImg[fr][_slitid_img_gpm[fr] > 0]
-            tmp_min, tmp_max = np.min(this_ra)-_ra_offsets[fr], np.max(this_ra)-_ra_offsets[fr]
+            tmp_min = np.min(this_ra) - _ra_offsets[fr]
+            tmp_max = np.max(this_ra) - _ra_offsets[fr]
             if fr == 0 or tmp_min < _ra_min:
                 _ra_min = tmp_min
             if fr == 0 or tmp_max > _ra_max:
                 _ra_max = tmp_max
         if dec_min is None or dec_max is None:
             this_dec = _decImg[fr][_slitid_img_gpm[fr] > 0]
-            tmp_min, tmp_max = np.min(this_dec)-_dec_offsets[fr], np.max(this_dec)-_dec_offsets[fr]
+            tmp_min = np.min(this_dec) - _dec_offsets[fr]
+            tmp_max = np.max(this_dec) - _dec_offsets[fr]
             if fr == 0 or tmp_min < _dec_min:
                 _dec_min = tmp_min
             if fr == 0 or tmp_max > _dec_max:
                 _dec_max = tmp_max
         if wave_min is None or wave_max is None:
             this_wave = _waveImg[fr][_slitid_img_gpm[fr] > 0]
-            tmp_min, tmp_max = np.min(this_wave), np.max(this_wave)
+            tmp_min = np.min(this_wave)
+            tmp_max = np.max(this_wave)
             if fr == 0 or tmp_min < _wave_min:
                 _wave_min = tmp_min
             if fr == 0 or tmp_max > _wave_max:
@@ -2166,7 +2168,8 @@ def generate_cube_subpixel(
 
     return flxcube, sigcube, bpmcube, normcube, wave
 
-
+# DEVELOPER NOTES: RJC is working towards making subpixellate a faster routine, and sometimes uses this decorator
+# find out the bottlenecks and how to speed things up. Please leave this decorator in for the time-being, uncommented.
 # @line_profiler.profile
 def subpixellate(
     output_wcs, bins, sciImg, ivarImg, waveImg, slitid_img_gpm, wghtImg, all_wcs, tilts, slits,
@@ -2316,7 +2319,8 @@ def subpixellate(
         this_var = utils.inverse(_ivarImg[fr][this_onslit_gpm])
         this_wav = _waveImg[fr][this_onslit_gpm]
         slshape = (this_slits.nspec, this_slits.nspat, slice_subpixel)
-        raimg_slc, decimg_slc = np.zeros(slshape, dtype=float), np.zeros(slshape, dtype=float)
+        raimg_slc = np.zeros(slshape, dtype=float)
+        decimg_slc = np.zeros(slshape, dtype=float)
         for ss in range(slice_subpixel):
             # Generate an RA/Dec image for this subslice
             raimg_slc[:, :, ss], decimg_slc[:, :, ss], _ = this_slits.get_radec_image(
@@ -2384,8 +2388,6 @@ def subpixellate(
                 if verbose: 
                     log.info("Preparing subpixel weights")
                 vox_index = np.floor(vox_coord * voxscale - voxoffset).astype(int)
-                # vox_index = np.floor(outshape * (vox_coord - binrng[:,0].reshape((1, 1, 3))) /
-                #                                 (binrng[:,1] - binrng[:,0]).reshape((1, 1, 3))).astype(int)
                 # Convert to a unique index
                 vox_index = np.dot(vox_index, np.array([1, outshape[0], outshape[0]*outshape[1]]))
                 # Calculate the number of repeated indices for each subpixel - this is the subpixel weights

--- a/pypeit/core/datacube.py
+++ b/pypeit/core/datacube.py
@@ -1225,8 +1225,8 @@ def align_user_offsets(ifu_ra, ifu_dec, ra_offset, dec_offset):
     out_dec_offsets = [0.0 for _ in range(numfiles)]
     for ff in range(numfiles):
         # Apply the shift
-        out_ra_offsets[ff] = ref_shift_ra[ff] + ra_offset[ff]
-        out_dec_offsets[ff] = ref_shift_dec[ff] + dec_offset[ff]
+        out_ra_offsets[ff] = ref_shift_ra[ff] - ra_offset[ff]
+        out_dec_offsets[ff] = ref_shift_dec[ff] - dec_offset[ff]
         log.info(
             f"Spatial shift of cube #{ff + 1}:\nRA, DEC (arcsec) = {ra_offset[ff]*3600.0:+0.3f} "
             f"E, {dec_offset[ff]*3600.0:+0.3f} N"
@@ -1394,14 +1394,14 @@ def wcs_bounds(raImg, decImg, waveImg, slitid_img_gpm, ra_offsets=None, dec_offs
         # Get the RA, Dec, and wavelength of the pixels on the slit
         if ra_min is None or ra_max is None:
             this_ra = _raImg[fr][_slitid_img_gpm[fr] > 0]
-            tmp_min, tmp_max = np.min(this_ra)+_ra_offsets[fr], np.max(this_ra)+_ra_offsets[fr]
+            tmp_min, tmp_max = np.min(this_ra)-_ra_offsets[fr], np.max(this_ra)-_ra_offsets[fr]
             if fr == 0 or tmp_min < _ra_min:
                 _ra_min = tmp_min
             if fr == 0 or tmp_max > _ra_max:
                 _ra_max = tmp_max
         if dec_min is None or dec_max is None:
             this_dec = _decImg[fr][_slitid_img_gpm[fr] > 0]
-            tmp_min, tmp_max = np.min(this_dec)+_dec_offsets[fr], np.max(this_dec)+_dec_offsets[fr]
+            tmp_min, tmp_max = np.min(this_dec)-_dec_offsets[fr], np.max(this_dec)-_dec_offsets[fr]
             if fr == 0 or tmp_min < _dec_min:
                 _dec_min = tmp_min
             if fr == 0 or tmp_max > _dec_max:
@@ -2369,13 +2369,8 @@ def subpixellate(
                 this_ra_int = utils.linear_interpolate_extrapolate(spatpos_subpix, spatpos[ssrt], tmp_ra[ssrt])
                 this_dec_int = utils.linear_interpolate_extrapolate(spatpos_subpix, spatpos[ssrt], tmp_dec[ssrt])
                 # Now apply the DAR correction and any user-supplied offsets
-                this_ra_int += ra_corr + _ra_offset[fr]
-                this_dec_int += dec_corr + _dec_offset[fr]
-                # TODO: Below was a hack to fix bug for KCRM. I suspected the
-                # WCS was being set incorrectly, which was true, and this hack
-                # fixed it. Old code is the line above.  See
-                # https://github.com/pypeit/PypeIt/issues/2116
-                #this_dec_int += dec_corr - _dec_offset[fr]
+                this_ra_int += ra_corr - _ra_offset[fr]
+                this_dec_int += dec_corr - _dec_offset[fr]
                 # Convert world coordinates to voxel coordinates, then histogram
                 sslo = ss * num_subpixels
                 sshi = (ss + 1) * num_subpixels

--- a/pypeit/core/datacube.py
+++ b/pypeit/core/datacube.py
@@ -5,7 +5,7 @@ Module containing routines used by 3D datacubes.
 """
 
 import os
-import line_profiler
+# import line_profiler
 
 from astropy import wcs, units
 from astropy.coordinates import AltAz, SkyCoord
@@ -2167,7 +2167,7 @@ def generate_cube_subpixel(
     return flxcube, sigcube, bpmcube, normcube, wave
 
 
-@line_profiler.profile
+# @line_profiler.profile
 def subpixellate(
     output_wcs, bins, sciImg, ivarImg, waveImg, slitid_img_gpm, wghtImg, all_wcs, tilts, slits,
     astrom_trans, all_dar, ra_offset, dec_offset, spec_subpixel=5, spat_subpixel=5,

--- a/pypeit/core/datacube.py
+++ b/pypeit/core/datacube.py
@@ -2025,11 +2025,11 @@ def generate_image_subpixel(image_wcs, bins, sciImg, ivarImg, waveImg, slitid_im
     else:
         # Prepare the array of white light images to be stored
         numframes = len(_sciImg)
-        numra = bins[0].size - 1
+        numra = bins[2].size - 1
         numdec = bins[1].size - 1
-        all_wl_imgs = np.zeros((numra, numdec, numframes))
-        all_sig_imgs = np.zeros((numra, numdec, numframes))
-        all_bpm_imgs = np.zeros((numra, numdec, numframes), dtype=bool)
+        all_wl_imgs = np.zeros((numdec, numra, numframes))
+        all_sig_imgs = np.zeros((numdec, numra, numframes))
+        all_bpm_imgs = np.zeros((numdec, numra, numframes), dtype=bool)
         # Loop through all frames and generate white light images
         for fr in range(numframes):
             log.info(f"Creating image {fr + 1}/{numframes}")

--- a/pypeit/core/flexure.py
+++ b/pypeit/core/flexure.py
@@ -1371,7 +1371,8 @@ def spec_flexure_qa(slitords:np.ndarray, bpm:np.ndarray, basename:str,
     plt.rcdefaults()
 
 
-def calculate_image_phase(imref, imshift, gpm_ref=None, gpm_shift=None, maskval=None):
+def calculate_image_phase(imref, imshift, gpm_ref=None, gpm_shift=None, maskval=None,
+                          force_cc=False):
     """
     Perform a masked cross-correlation and optical flow calculation to robustly
     estimate the subpixel shifts of two images.
@@ -1395,6 +1396,10 @@ def calculate_image_phase(imref, imshift, gpm_ref=None, gpm_shift=None, maskval=
     maskval : float, optional
         If gpm_ref and gpm_shift are both None, a single value can be specified
         and this value will be masked in both images.
+    force_cc : bool, optional
+        If True, forces the use of the standard (unmasked) cross-correlation
+        method, even if skimage is installed and the input images are the same
+        shape.  This is useful for testing and debugging.
 
     Returns
     -------
@@ -1407,6 +1412,8 @@ def calculate_image_phase(imref, imshift, gpm_ref=None, gpm_shift=None, maskval=
         In order to align image with im_ref, dec_diff should be added to the
         y-coordinates of image
     """
+    if force_cc:
+        return calculate_image_offset(imref, imshift)
     # Do some checks first
     try:
         from skimage.registration import optical_flow_tvl1, phase_cross_correlation

--- a/pypeit/par/pypeitpar.py
+++ b/pypeit/par/pypeitpar.py
@@ -1714,9 +1714,11 @@ class CubePar(ParSet):
             'reference image (see ``reference_image``) or the whitelight '
             'image of the first spec2d listed in the coadd3d file. This parameter allows you to set the '
             'method used to spatially align the datacubes. The current allowed options include "none", "phase", '
-            '"fit", and "user". Setting ``alignment_method = phase`` (the default) will use a cross-correlation '
-            'method to determine the offsets, where the cross-correlation is always with respect to a reference '
-            'image. This method uses the scikit-image package, if it is installed; otherwise it will use scipy. '
+            '"cc", "fit", and "user". Setting ``alignment_method = phase`` (the default) will use a phase '
+            'cross-correlation method to determine the offsets, where the cross-correlation is always with '
+            'respect to a reference image. To use an ordinary cross-correlation, set ``alignment_method = cc``. '
+            'To use the phase cross-correlation, you need to install the scikit-image package; otherwise the '
+            'the standard scipy cross-correlation method (i.e. ``alignment_method = cc``) will be used. '
             'Setting ``alignment_method = fit`` requires that photutils is installed. For each '
             'datacube being combined, a 2D Gaussian is fit the brightest point-like object found '
             'in each whitelight image and used to set the alignment coordinate. Setting ``alignment_method = user`` '
@@ -1937,7 +1939,7 @@ class CubePar(ParSet):
         """
         Return the valid method identifiers for registration
         """
-        return ['none', 'user', 'phase', 'fit']
+        return ['none', 'user', 'phase', 'cc', 'fit']
 
 
 

--- a/pypeit/spectrographs/keck_kcwi.py
+++ b/pypeit/spectrographs/keck_kcwi.py
@@ -1279,7 +1279,6 @@ class KeckKCRMSpectrograph(KeckKCWIKCRMSpectrograph):
                         dataext         = 0,
                         specaxis        = 0,
                         specflip        = specflip,
-                        #spatflip        = False,  # JFH changed to False after consulting with R. Cooke on 2024-12-21
                         spatflip        = True,  # Due to the extra mirror, the slices are flipped relative to KCWI
                         platescale      = 0.145728,  # arcsec/pixel TODO :: Need to double check this
                         darkcurr        = None,  # e-/pixel/hour  TODO :: Need to check this.

--- a/pypeit/spectrographs/keck_kcwi.py
+++ b/pypeit/spectrographs/keck_kcwi.py
@@ -672,19 +672,17 @@ class KeckKCWIKCRMSpectrograph(spectrograph.Spectrograph):
         porg = hdr['PONAME']
         ifunum = hdr['IFUNUM']
         if 'IFU' in porg:
-            # if ifunum == 1:  # Large slicer
-            #     off1 = 1.0
-            #     off2 = 4.0
-            # elif ifunum == 2:  # Medium slicer
-            #     off1 = 1.0
-            #     off2 = 5.0
-            # elif ifunum == 3:  # Small slicer
-            #     off1 = 0.05
-            #     off2 = 5.6
-            # else:
-            #     log.warning("Unknown IFU number: {0:d}".format(ifunum))
-            off1 = 0.
-            off2 = 0.
+            if ifunum == 1:  # Large slicer
+                off1 = 1.0
+                off2 = 4.0
+            elif ifunum == 2:  # Medium slicer
+                off1 = 1.0
+                off2 = 5.0
+            elif ifunum == 3:  # Small slicer
+                off1 = 0.05
+                off2 = 5.6
+            else:
+                log.warning("Unknown IFU number: {0:d}".format(ifunum))
             off1 /= binspec
             off2 /= binspat
             crpix1 += off1

--- a/pypeit/spectrographs/keck_kcwi.py
+++ b/pypeit/spectrographs/keck_kcwi.py
@@ -662,7 +662,7 @@ class KeckKCWIKCRMSpectrograph(spectrograph.Spectrograph):
         # Calculate the CD Matrix
         cd11 = cdelt1 * np.cos(crota)                          # RA degrees per column
         cd12 = abs(cdelt2) * np.sign(cdelt1) * np.sin(crota)   # RA degrees per row
-        cd21 = -abs(cdelt1) * np.sign(cdelt2) * np.sin(crota)  # DEC degress per column
+        cd21 = -abs(cdelt1) * np.sign(cdelt2) * np.sin(crota)  # DEC degrees per column
         cd22 = cdelt2 * np.cos(crota)                          # DEC degrees per row
         # Get reference pixels (set these to the middle of the FOV)
         crpix1 = 24/2   # i.e. 24 slices/2

--- a/pypeit/tests/test_datacube.py
+++ b/pypeit/tests/test_datacube.py
@@ -67,7 +67,7 @@ def make_point_source_image(ra, dec, dspat, wcs,
 
     return image
 
-def test_align():
+def test_align_phase():
     numiter = 5  # This is the same number of iterations used in the coadd3d run_align() method
     ref_idx = 0
     _dspat = 0.2*u.arcsec  # Spatial pixel scale
@@ -125,6 +125,34 @@ def test_align():
     assert np.isclose(ra_offsets[1].to(u.arcsec).value, offs_ra.to(u.arcsec).value, atol=atol)
     assert np.isclose(dec_offsets[1].to(u.arcsec).value, offs_dec.to(u.arcsec).value, atol=atol)
 
+
+def test_align_cc():
+    numiter = 5  # This is the same number of iterations used in the coadd3d run_align() method
+    ref_idx = 0
+    _dspat = 0.2 * u.arcsec  # Spatial pixel scale
+    fwhm = 4 * _dspat
+    ra1, dec1 = 130.0 * u.deg, 35.0 * u.deg  # Pick two random numbers
+    cosdec = np.cos(dec1.to(u.radian).value)
+    offs_ra, offs_dec = 1.0 * u.arcsec, -1.5 * u.arcsec
+    # Compute second coordinates using pre-defined offset
+    ra2, dec2 = ra1 + offs_ra, dec1 + offs_dec
+    # Build a simple TAN-projected WCS
+    n_pix = 100
+    wcs = WCS(naxis=2)
+    wcs.wcs.crpix = [n_pix // 2, n_pix // 2]
+    wcs.wcs.cdelt = [-_dspat.to(u.deg).value, _dspat.to(u.deg).value]
+    wcs.wcs.crval = [ra1.to(u.deg).value, dec1.to(u.deg).value]  # RA, Dec in degrees
+    wcs.wcs.ctype = ['RA---TAN', 'DEC--TAN']
+
+    # Define two coordinates
+    coord1 = SkyCoord(ra=ra1, dec=dec1, frame='icrs')
+    coord2 = SkyCoord(ra=ra2, dec=dec2, frame='icrs')
+
+    # Calculate and check the separation
+    dra, ddec = coord1.spherical_offsets_to(coord2)
+    assert np.isclose(dra.to(u.arcsec).value, offs_ra.to(u.arcsec).value * cosdec, atol=0.001)
+    assert np.isclose(ddec.to(u.arcsec).value, offs_dec.to(u.arcsec).value, atol=0.001)
+
     # Loop through iterations to find the offsets using the CC method
     # Set up the offsets arrays that will be computed by the spatial alignment methods
     ra_offsets, dec_offsets = np.zeros(2) * u.deg, np.zeros(2) * u.deg
@@ -155,6 +183,33 @@ def test_align():
     assert np.isclose(dec_offsets[0].to(u.arcsec).value, 0.0, atol=atol)
     assert np.isclose(ra_offsets[1].to(u.arcsec).value, offs_ra.to(u.arcsec).value, atol=atol)
     assert np.isclose(dec_offsets[1].to(u.arcsec).value, offs_dec.to(u.arcsec).value, atol=atol)
+
+def test_align_fit():
+    numiter = 5  # This is the same number of iterations used in the coadd3d run_align() method
+    ref_idx = 0
+    _dspat = 0.2 * u.arcsec  # Spatial pixel scale
+    fwhm = 4 * _dspat
+    ra1, dec1 = 130.0 * u.deg, 35.0 * u.deg  # Pick two random numbers
+    cosdec = np.cos(dec1.to(u.radian).value)
+    offs_ra, offs_dec = 1.0 * u.arcsec, -1.5 * u.arcsec
+    # Compute second coordinates using pre-defined offset
+    ra2, dec2 = ra1 + offs_ra, dec1 + offs_dec
+    # Build a simple TAN-projected WCS
+    n_pix = 100
+    wcs = WCS(naxis=2)
+    wcs.wcs.crpix = [n_pix // 2, n_pix // 2]
+    wcs.wcs.cdelt = [-_dspat.to(u.deg).value, _dspat.to(u.deg).value]
+    wcs.wcs.crval = [ra1.to(u.deg).value, dec1.to(u.deg).value]  # RA, Dec in degrees
+    wcs.wcs.ctype = ['RA---TAN', 'DEC--TAN']
+
+    # Define two coordinates
+    coord1 = SkyCoord(ra=ra1, dec=dec1, frame='icrs')
+    coord2 = SkyCoord(ra=ra2, dec=dec2, frame='icrs')
+
+    # Calculate and check the separation
+    dra, ddec = coord1.spherical_offsets_to(coord2)
+    assert np.isclose(dra.to(u.arcsec).value, offs_ra.to(u.arcsec).value * cosdec, atol=0.001)
+    assert np.isclose(ddec.to(u.arcsec).value, offs_dec.to(u.arcsec).value, atol=0.001)
 
     # Loop through iterations to find the offsets using the FIT method
     # Set up the offsets arrays that will be computed by the spatial alignment methods

--- a/pypeit/tests/test_datacube.py
+++ b/pypeit/tests/test_datacube.py
@@ -81,7 +81,7 @@ def test_align():
     n_pix = 100
     wcs = WCS(naxis=2)
     wcs.wcs.crpix = [n_pix//2, n_pix//2]
-    wcs.wcs.cdelt = [_dspat.to(u.deg).value, _dspat.to(u.deg).value]
+    wcs.wcs.cdelt = [-_dspat.to(u.deg).value, _dspat.to(u.deg).value]
     wcs.wcs.crval = [ra1.to(u.deg).value, dec1.to(u.deg).value]  # RA, Dec in degrees
     wcs.wcs.ctype = ['RA---TAN', 'DEC--TAN']
 
@@ -108,12 +108,11 @@ def test_align():
         ref_img = wl_imgs[ref_idx].copy()
         # Compute the offsets between all images
         for ff in range(len(wl_imgs)):
-            print(ii, ra_offsets[ff].to(u.arcsec)*cosdec, dec_offsets[ff].to(u.arcsec))
             dec_shift, ra_shift = calculate_image_phase(
                 ref_img.copy(), wl_imgs[ff], maskval=0.0
             )
             # Convert pixel shift to degrees shift
-            ra_shift *= _dspat.to(u.deg)/cosdec
+            ra_shift *= -_dspat.to(u.deg)/cosdec
             dec_shift *= _dspat.to(u.deg)
             # Update the offsets for the next iteration
             ra_offsets[ff] -= ra_shift.to(u.deg)
@@ -140,12 +139,11 @@ def test_align():
         ref_img = wl_imgs[ref_idx].copy()
         # Compute the offsets between all images
         for ff in range(len(wl_imgs)):
-            print(ii, ra_offsets[ff].to(u.arcsec)*cosdec, dec_offsets[ff].to(u.arcsec))
             dec_shift, ra_shift = calculate_image_phase(
                 ref_img.copy(), wl_imgs[ff], maskval=0.0, force_cc=True
             )
             # Convert pixel shift to degrees shift
-            ra_shift *= _dspat.to(u.deg)/cosdec
+            ra_shift *= -_dspat.to(u.deg)/cosdec
             dec_shift *= _dspat.to(u.deg)
             # Update the offsets for the next iteration
             ra_offsets[ff] -= ra_shift.to(u.deg)
@@ -182,7 +180,7 @@ def test_align():
                 )
             gaussian_position = popt[1], popt[2]
             dec_pix_star[ff], ra_pix_star[ff] = gaussian_position
-        ra_shifts = (ra_pix_star[ref_idx] - ra_pix_star) * _dspat / cosdec
+        ra_shifts = -(ra_pix_star[ref_idx] - ra_pix_star) * _dspat / cosdec
         dec_shifts = (dec_pix_star[ref_idx] - dec_pix_star) * _dspat
         ra_offsets = [ra_offsets[ff] - ra_shifts[ff] for ff in range(numfiles)]
         dec_offsets = [dec_offsets[ff] - dec_shifts[ff] for ff in range(numfiles)]

--- a/pypeit/tests/test_datacube.py
+++ b/pypeit/tests/test_datacube.py
@@ -15,7 +15,8 @@ from pypeit.core import datacube
 from pypeit.core.flexure import calculate_image_phase
 
 
-def make_point_source_image(ra, dec, dspat, wcs, n_pix=100):
+def make_point_source_image(ra, dec, dspat, wcs,
+                            n_pix=100, fwhm_arcsec=None):
     """
     Create a 100x100 pixel image of a point source modelled as a 2D Gaussian.
 
@@ -32,6 +33,8 @@ def make_point_source_image(ra, dec, dspat, wcs, n_pix=100):
         Only the spatial axes are used.
     n_pix : int, optional
         Number of pixels along each axis of the output image. Default is 100.
+    fwhm_arcsec : float, optional
+        The FWHM of the PSF in arcseconds. Default is None.
 
     Returns
     -------
@@ -43,10 +46,10 @@ def make_point_source_image(ra, dec, dspat, wcs, n_pix=100):
         Sub-pixel y (row) position of the source in the image.
     """
     # Default PSF FWHM: 6 pixels
-    fwhm_arcsec = 6 * dspat
+    _fwhm_arcsec = 6 * dspat if fwhm_arcsec is None else fwhm_arcsec
 
     # Convert FWHM to sigma in pixels
-    fwhm_pix = fwhm_arcsec / dspat
+    fwhm_pix = _fwhm_arcsec / dspat
     sigma_pix = fwhm_pix / (2.0 * np.sqrt(2.0 * np.log(2.0)))
 
     # Get the source position in output image pixel coords
@@ -68,6 +71,7 @@ def test_align():
     numiter = 5  # This is the same number of iterations used in the coadd3d run_align() method
     ref_idx = 0
     _dspat = 0.2*u.arcsec  # Spatial pixel scale
+    fwhm = 4*_dspat
     ra1, dec1 = 130.0*u.deg, 35.0*u.deg  # Pick two random numbers
     cosdec = np.cos(dec1.to(u.radian).value)
     offs_ra, offs_dec = 1.0*u.arcsec, -1.5*u.arcsec
@@ -95,8 +99,10 @@ def test_align():
     ra_offsets, dec_offsets = np.zeros(2) * u.deg, np.zeros(2) * u.deg
     for ii in range(numiter):
         # Generate two images wih the current RA, Dec and offsets
-        img1 = make_point_source_image(ra1-ra_offsets[0], dec1-dec_offsets[0], _dspat.value, wcs, n_pix=n_pix)
-        img2 = make_point_source_image(ra2-ra_offsets[1], dec2-dec_offsets[1], _dspat.value, wcs, n_pix=n_pix)
+        img1 = make_point_source_image(ra1-ra_offsets[0], dec1-dec_offsets[0], _dspat.value, wcs,
+                                       fwhm_arcsec=fwhm.value, n_pix=n_pix)
+        img2 = make_point_source_image(ra2-ra_offsets[1], dec2-dec_offsets[1], _dspat.value, wcs,
+                                       fwhm_arcsec=fwhm.value, n_pix=n_pix)
         wl_imgs = [img1, img2]
         # Select the reference image (i.e. the one that doesn't shift)
         ref_img = wl_imgs[ref_idx].copy()
@@ -125,8 +131,10 @@ def test_align():
     ra_offsets, dec_offsets = np.zeros(2) * u.deg, np.zeros(2) * u.deg
     for ii in range(numiter):
         # Generate two images wih the current RA, Dec and offsets
-        img1 = make_point_source_image(ra1-ra_offsets[0], dec1-dec_offsets[0], _dspat.value, wcs, n_pix=n_pix)
-        img2 = make_point_source_image(ra2-ra_offsets[1], dec2-dec_offsets[1], _dspat.value, wcs, n_pix=n_pix)
+        img1 = make_point_source_image(ra1-ra_offsets[0], dec1-dec_offsets[0], _dspat.value, wcs,
+                                       fwhm_arcsec=fwhm.value, n_pix=n_pix)
+        img2 = make_point_source_image(ra2-ra_offsets[1], dec2-dec_offsets[1], _dspat.value, wcs,
+                                       fwhm_arcsec=fwhm.value, n_pix=n_pix)
         wl_imgs = [img1, img2]
         # Select the reference image (i.e. the one that doesn't shift)
         ref_img = wl_imgs[ref_idx].copy()
@@ -155,26 +163,27 @@ def test_align():
     ra_offsets, dec_offsets = np.zeros(2) * u.deg, np.zeros(2) * u.deg
     for ii in range(numiter):
         # Generate two images wih the current RA, Dec and offsets
-        img1 = make_point_source_image(ra1-ra_offsets[0], dec1-dec_offsets[0], _dspat.value, wcs, n_pix=n_pix)
-        img2 = make_point_source_image(ra2-ra_offsets[1], dec2-dec_offsets[1], _dspat.value, wcs, n_pix=n_pix)
+        img1 = make_point_source_image(ra1-ra_offsets[0], dec1-dec_offsets[0], _dspat.value, wcs,
+                                       fwhm_arcsec=fwhm.value, n_pix=n_pix)
+        img2 = make_point_source_image(ra2-ra_offsets[1], dec2-dec_offsets[1], _dspat.value, wcs,
+                                       fwhm_arcsec=fwhm.value, n_pix=n_pix)
         wl_imgs = [img1, img2]
         numfiles = len(wl_imgs)
         # Compute the offsets between all images
         ra_pix_star = np.zeros(len(wl_imgs))
         dec_pix_star = np.zeros(len(wl_imgs))
         for ff in range(numfiles):
-            print(ii, ra_offsets[ff].to(u.arcsec)*cosdec, dec_offsets[ff].to(u.arcsec))
             popt, pcov, model, init_obj_position, flux_opt, sigma_opt = \
                 datacube.fitGaussian2D(
-                    wl_imgs[:, :, ff],
-                    #ivar=utils.inverse(np.square(sig_imgs[:, :, ff])),
-                    #gpm=np.logical_not(bpm_imgs[:, :, ff]),
-                    fwhm=fwhm / dspat, norm=False
+                    wl_imgs[ff],
+                    # ivar=utils.inverse(np.square(sig_imgs[ff])),
+                    # gpm=np.logical_not(bpm_imgs[ff]),
+                    fwhm=fwhm.value/_dspat.value, norm=False
                 )
             gaussian_position = popt[1], popt[2]
-            ra_pix_star[ff], dec_pix_star[ff] = gaussian_position
-        ra_shifts = (ra_pix_star - ra_pix_star[ref_idx]) * _dspat / cosdec
-        dec_shifts = (dec_pix_star - dec_pix_star[ref_idx]) * _dspat
+            dec_pix_star[ff], ra_pix_star[ff] = gaussian_position
+        ra_shifts = (ra_pix_star[ref_idx] - ra_pix_star) * _dspat / cosdec
+        dec_shifts = (dec_pix_star[ref_idx] - dec_pix_star) * _dspat
         ra_offsets = [ra_offsets[ff] - ra_shifts[ff] for ff in range(numfiles)]
         dec_offsets = [dec_offsets[ff] - dec_shifts[ff] for ff in range(numfiles)]
 

--- a/pypeit/tests/test_datacube.py
+++ b/pypeit/tests/test_datacube.py
@@ -1,0 +1,155 @@
+"""
+Module to run tests on datacube generation
+"""
+from pathlib import Path
+
+from IPython import embed
+
+import numpy as np
+
+from astropy.wcs import WCS
+import astropy.units as u
+from astropy.coordinates import SkyCoord
+
+from pypeit.core import datacube
+from pypeit.core.flexure import calculate_image_phase
+
+
+def make_point_source_image(ra, dec, dspat, wcs, n_pix=100):
+    """
+    Create a 100x100 pixel image of a point source modelled as a 2D Gaussian.
+
+    Parameters
+    ----------
+    ra : float
+        Right ascension of the point source in degrees.
+    dec : float
+        Declination of the point source in degrees.
+    dspat : float
+        Spatial pixel size in arcseconds.
+    wcs : astropy.wcs.WCS
+        Astropy WCS object describing the coordinate system.
+        Only the spatial axes are used.
+    n_pix : int, optional
+        Number of pixels along each axis of the output image. Default is 100.
+
+    Returns
+    -------
+    image : ndarray, shape (100, 100)
+        Normalised 2D Gaussian image. Peak value is 1.0.
+    x_cen : float
+        Sub-pixel x (column) position of the source in the image.
+    y_cen : float
+        Sub-pixel y (row) position of the source in the image.
+    """
+    # Default PSF FWHM: 6 pixels
+    fwhm_arcsec = 6 * dspat
+
+    # Convert FWHM to sigma in pixels
+    fwhm_pix = fwhm_arcsec / dspat
+    sigma_pix = fwhm_pix / (2.0 * np.sqrt(2.0 * np.log(2.0)))
+
+    # Get the source position in output image pixel coords
+    src_pix = wcs.wcs_world2pix(ra, dec, 0)
+    x_cen_out, y_cen_out = src_pix[0], src_pix[1]
+
+    # Evaluate 2D Gaussian on the pixel grid
+    x = np.arange(n_pix, dtype=np.float64)  # column indices
+    y = np.arange(n_pix, dtype=np.float64)  # row indices
+    xx, yy = np.meshgrid(x, y)  # shape (100, 100)
+
+    image = np.exp(
+        -((xx - x_cen_out) ** 2 + (yy - y_cen_out) ** 2) / (2.0 * sigma_pix ** 2)
+    )
+
+    return image
+
+def test_align():
+    numiter = 5  # This is the same number of iterations used in the coadd3d run_align() method
+    ref_idx = 0
+    _dspat = 0.2*u.arcsec  # Spatial pixel scale
+    ra1, dec1 = 130.0*u.deg, 35.0*u.deg  # Pick two random numbers
+    cosdec = np.cos(dec1.to(u.radian).value)
+    offs_ra, offs_dec = 1.0*u.arcsec, -1.5*u.arcsec
+    # Compute second coordinates using pre-defined offset
+    ra2, dec2 = ra1 + offs_ra, dec1 + offs_dec
+    # Build a simple TAN-projected WCS
+    n_pix = 100
+    wcs = WCS(naxis=2)
+    wcs.wcs.crpix = [n_pix//2, n_pix//2]
+    wcs.wcs.cdelt = [_dspat.to(u.deg).value, _dspat.to(u.deg).value]
+    wcs.wcs.crval = [ra1.to(u.deg).value, dec1.to(u.deg).value]  # RA, Dec in degrees
+    wcs.wcs.ctype = ['RA---TAN', 'DEC--TAN']
+
+    # Define two coordinates
+    coord1 = SkyCoord(ra=ra1, dec=dec1, frame='icrs')
+    coord2 = SkyCoord(ra=ra2, dec=dec2, frame='icrs')
+
+    # Calculate and check the separation
+    dra, ddec = coord1.spherical_offsets_to(coord2)
+    assert np.isclose(dra.to(u.arcsec).value, offs_ra.to(u.arcsec).value*cosdec, atol=0.001)
+    assert np.isclose(ddec.to(u.arcsec).value, offs_dec.to(u.arcsec).value, atol=0.001)
+
+    # Loop through iterations to find the offsets using the PHASE method
+    # Set up the offsets arrays that will be computed by the spatial alignment methods
+    ra_offsets, dec_offsets = np.zeros(2) * u.deg, np.zeros(2) * u.deg
+    for ii in range(numiter):
+        # Generate two images wih the current RA, Dec and offsets
+        img1 = make_point_source_image(ra1-ra_offsets[0], dec1-dec_offsets[0], _dspat.value, wcs, n_pix=n_pix)
+        img2 = make_point_source_image(ra2-ra_offsets[1], dec2-dec_offsets[1], _dspat.value, wcs, n_pix=n_pix)
+        wl_imgs = [img1, img2]
+        # Select the reference image (i.e. the one that doesn't shift)
+        ref_img = wl_imgs[ref_idx].copy()
+        # Compute the offsets between all images
+        for ff in range(len(wl_imgs)):
+            print(ii, ra_offsets[ff].to(u.arcsec)*cosdec, dec_offsets[ff].to(u.arcsec))
+            dec_shift, ra_shift = calculate_image_phase(
+                ref_img.copy(), wl_imgs[ff], maskval=0.0)
+            # Convert pixel shift to degrees shift
+            ra_shift *= _dspat.to(u.deg)/cosdec
+            dec_shift *= _dspat.to(u.deg)
+            # Update the offsets for the next iteration
+            ra_offsets[ff] -= ra_shift.to(u.deg)
+            dec_offsets[ff] -= dec_shift.to(u.deg)
+
+    # Check that the offsets agree to within 1/3 of a pixel
+    atol = _dspat.to(u.arcsec).value/3
+    assert np.isclose(ra_offsets[0].to(u.arcsec).value, 0.0, atol=atol)
+    assert np.isclose(dec_offsets[0].to(u.arcsec).value, 0.0, atol=atol)
+    assert np.isclose(ra_offsets[1].to(u.arcsec).value, offs_ra.to(u.arcsec).value, atol=atol)
+    assert np.isclose(dec_offsets[1].to(u.arcsec).value, offs_dec.to(u.arcsec).value, atol=atol)
+
+    # Loop through iterations to find the offsets using the FIT method
+    # Set up the offsets arrays that will be computed by the spatial alignment methods
+    ra_offsets, dec_offsets = np.zeros(2) * u.deg, np.zeros(2) * u.deg
+    for ii in range(numiter):
+        # Generate two images wih the current RA, Dec and offsets
+        img1 = make_point_source_image(ra1-ra_offsets[0], dec1-dec_offsets[0], _dspat.value, wcs, n_pix=n_pix)
+        img2 = make_point_source_image(ra2-ra_offsets[1], dec2-dec_offsets[1], _dspat.value, wcs, n_pix=n_pix)
+        wl_imgs = [img1, img2]
+        numfiles = len(wl_imgs)
+        # Compute the offsets between all images
+        ra_pix_star = np.zeros(len(wl_imgs))
+        dec_pix_star = np.zeros(len(wl_imgs))
+        for ff in range(numfiles):
+            print(ii, ra_offsets[ff].to(u.arcsec)*cosdec, dec_offsets[ff].to(u.arcsec))
+            popt, pcov, model, init_obj_position, flux_opt, sigma_opt = \
+                datacube.fitGaussian2D(
+                    wl_imgs[:, :, ff],
+                    #ivar=utils.inverse(np.square(sig_imgs[:, :, ff])),
+                    #gpm=np.logical_not(bpm_imgs[:, :, ff]),
+                    fwhm=fwhm / dspat, norm=False
+                )
+            gaussian_position = popt[1], popt[2]
+            ra_pix_star[ff], dec_pix_star[ff] = gaussian_position
+        ra_shifts = (ra_pix_star - ra_pix_star[ref_idx]) * _dspat / cosdec
+        dec_shifts = (dec_pix_star - dec_pix_star[ref_idx]) * _dspat
+        ra_offsets = [ra_offsets[ff] - ra_shifts[ff] for ff in range(numfiles)]
+        dec_offsets = [dec_offsets[ff] - dec_shifts[ff] for ff in range(numfiles)]
+
+    # Check that the offsets agree to within 1/3 of a pixel
+    atol = _dspat.to(u.arcsec).value/3
+    assert np.isclose(ra_offsets[0].to(u.arcsec).value, 0.0, atol=atol)
+    assert np.isclose(dec_offsets[0].to(u.arcsec).value, 0.0, atol=atol)
+    assert np.isclose(ra_offsets[1].to(u.arcsec).value, offs_ra.to(u.arcsec).value, atol=atol)
+    assert np.isclose(dec_offsets[1].to(u.arcsec).value, offs_dec.to(u.arcsec).value, atol=atol)

--- a/pypeit/tests/test_datacube.py
+++ b/pypeit/tests/test_datacube.py
@@ -104,7 +104,38 @@ def test_align():
         for ff in range(len(wl_imgs)):
             print(ii, ra_offsets[ff].to(u.arcsec)*cosdec, dec_offsets[ff].to(u.arcsec))
             dec_shift, ra_shift = calculate_image_phase(
-                ref_img.copy(), wl_imgs[ff], maskval=0.0)
+                ref_img.copy(), wl_imgs[ff], maskval=0.0
+            )
+            # Convert pixel shift to degrees shift
+            ra_shift *= _dspat.to(u.deg)/cosdec
+            dec_shift *= _dspat.to(u.deg)
+            # Update the offsets for the next iteration
+            ra_offsets[ff] -= ra_shift.to(u.deg)
+            dec_offsets[ff] -= dec_shift.to(u.deg)
+
+    # Check that the offsets agree to within 1/3 of a pixel
+    atol = _dspat.to(u.arcsec).value/3
+    assert np.isclose(ra_offsets[0].to(u.arcsec).value, 0.0, atol=atol)
+    assert np.isclose(dec_offsets[0].to(u.arcsec).value, 0.0, atol=atol)
+    assert np.isclose(ra_offsets[1].to(u.arcsec).value, offs_ra.to(u.arcsec).value, atol=atol)
+    assert np.isclose(dec_offsets[1].to(u.arcsec).value, offs_dec.to(u.arcsec).value, atol=atol)
+
+    # Loop through iterations to find the offsets using the CC method
+    # Set up the offsets arrays that will be computed by the spatial alignment methods
+    ra_offsets, dec_offsets = np.zeros(2) * u.deg, np.zeros(2) * u.deg
+    for ii in range(numiter):
+        # Generate two images wih the current RA, Dec and offsets
+        img1 = make_point_source_image(ra1-ra_offsets[0], dec1-dec_offsets[0], _dspat.value, wcs, n_pix=n_pix)
+        img2 = make_point_source_image(ra2-ra_offsets[1], dec2-dec_offsets[1], _dspat.value, wcs, n_pix=n_pix)
+        wl_imgs = [img1, img2]
+        # Select the reference image (i.e. the one that doesn't shift)
+        ref_img = wl_imgs[ref_idx].copy()
+        # Compute the offsets between all images
+        for ff in range(len(wl_imgs)):
+            print(ii, ra_offsets[ff].to(u.arcsec)*cosdec, dec_offsets[ff].to(u.arcsec))
+            dec_shift, ra_shift = calculate_image_phase(
+                ref_img.copy(), wl_imgs[ff], maskval=0.0, force_cc=True
+            )
             # Convert pixel shift to degrees shift
             ra_shift *= _dspat.to(u.deg)/cosdec
             dec_shift *= _dspat.to(u.deg)

--- a/pypeit/utils.py
+++ b/pypeit/utils.py
@@ -1036,6 +1036,47 @@ def occurrences(inarr):
     return cnt[idx]
 
 
+def occurrences_sorted(inarr):
+    """ Calculate the sub-pixellation weights for a 2D array.
+
+    This function calculates the number of occurrences of each unique value in the 2D input array along one axis.
+
+    Parameters
+    ----------
+    inarr : ndarray
+        Input array. Must be 2D. The first axis is expected to be a large number of indices, N,
+        and the second axis is expected to be of length M, where M is the number of unique values in each row.
+        The function calculates the number of occurrences of each unique value along the first axis for each row.
+
+    Returns
+    -------
+    ndarray
+        Array of sub-pixellation weights.
+    """
+    n_rows, n_cols = inarr.shape
+
+    # Sort each row and find where values change
+    sorted_idx = np.argsort(inarr, axis=1, kind='stable')
+    sorted_vals = np.take_along_axis(inarr, sorted_idx, axis=1)
+
+    # Detect boundaries between different values within each row
+    boundaries = np.ones((n_rows, n_cols), dtype=bool)
+    boundaries[:, 1:] = sorted_vals[:, 1:] != sorted_vals[:, :-1]
+
+    # Use cumsum trick to count occurrences
+    counts = np.diff(np.where(boundaries.ravel())[0],
+                     append=n_rows * n_cols)
+
+    # Build output in sorted order, then unsort
+    result_sorted = np.repeat(counts, counts)  # each element gets its group's count
+
+    # Unsort back to original order
+    unsort_idx = np.argsort(sorted_idx, axis=1)
+    return np.take_along_axis(
+        result_sorted.reshape(n_rows, n_cols), unsort_idx, axis=1
+    ).ravel()
+
+
 def pyplot_rcparams():
     """
     params for pretty matplotlib plots

--- a/pypeit/utils.py
+++ b/pypeit/utils.py
@@ -1522,6 +1522,30 @@ def linear_interpolate(x1, y1, x2, y2, x):
     return y1 if np.isclose(x1,x2) else y1 + (x-x1)*(y2-y1)/(x2-x1)
 
 
+def linear_interpolate_extrapolate(x, xp, fp):
+    """ Perform a linear interpolation on a set of points, but allow for extrapolation at the boundaries.
+
+    Parameters
+    ----------
+    x : `numpy.ndarray`_
+        Points to evaluate the linear interpolation at
+    xp : `numpy.ndarray`_
+        The x-coordinates of the data points, must be increasing
+    fp : `numpy.ndarray`_
+        The y-coordinates of the data points, must be increasing
+
+    Returns
+    -------
+    `numpy.ndarray`_
+        The interpolated/extrapolated values at the points in x
+    """
+    idx = np.searchsorted(xp, x, side='right').clip(1, len(xp) - 1)
+    x0, x1 = xp[idx - 1], xp[idx]
+    f0, f1 = fp[idx - 1], fp[idx]
+    slope = (f1 - f0) / (x1 - x0)
+    return f0 + slope * (x - x0)  # naturally extrapolates at boundaries
+
+
 def replace_bad(frame, bpm):
     """ Find all bad pixels, and replace the bad pixels with the nearest good pixel
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,8 +55,8 @@ dependencies = [
 scikit-image = [
     "scikit-image>=0.23",
 ]
-photutils = [
-    "photutils>=2.0",
+datacube = [
+    "photutils>=3.0",
 ]
 specutils = [
     "specutils>=2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ dependencies = [
 scikit-image = [
     "scikit-image>=0.23",
 ]
-photutils = [
+datacube = [
     "photutils>=3.0",
 ]
 specutils = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ dependencies = [
 scikit-image = [
     "scikit-image>=0.23",
 ]
-datacube = [
+photutils = [
     "photutils>=3.0",
 ]
 specutils = [
@@ -83,7 +83,7 @@ devsuite = [
 ]
 dev = [
     "scikit-image>=0.23",
-    "photutils>=2.0",
+    "photutils>=3.0",
     "specutils>=2.0",
     "pygit2",
     "pytest>=7.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,10 +52,8 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-scikit-image = [
-    "scikit-image>=0.23",
-]
 datacube = [
+    "scikit-image>=0.23",
     "photutils>=3.0",
 ]
 specutils = [


### PR DESCRIPTION
This is an extension to PR #1929 that fixes the alignment and WCS values discussed there. I will run the dev-suite to make sure I haven't broken everything, but all of the modes that I have tested work. This PR also includes a test (it's not ideal, because it doesn't touch the `coadd3d` file, but at least it's a fast way to confirm the core alignments codes). This addresses (I think!) Issue #2116.

I have also made some coding improvements that increased the speed (by almost 2x) of creating datacubes.