### PR TITLE
Improve workflow triggers

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -1,21 +1,77 @@
+
 name: CI Tests
 
 on:
   workflow_dispatch:
 
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - labeled
+      - synchronize
+
   push:
     branches:
-    - release
-    - develop
-
-  pull_request:
-    types: [labeled]
+      - release
+      - develop
 
 env:
   SETUP_XVFB: True  # avoid issues if something tries to open a GUI window
 
 jobs:
+  validate:
+    runs-on: ubuntu-latest
+    outputs:
+      success: ${{ steps.check.outputs.success }}
+    steps:
+      - name: Check for protected branches or PR label
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Always pass the gate for pushes directly to our two protected
+          # branches
+          if [ "${{ github.event_name }}" = "push" ]; then
+            BRANCH="${{ github.ref_name }}"
+            if [ "$BRANCH" = "release" ] || [ "$BRANCH" = "develop" ]; then
+              echo "Push to protected branch '$BRANCH' — bypassing label check."
+              echo "success=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            PR_NUMBER="${{ github.event.pull_request.number }}"
+          else
+            PR_NUMBER=$(gh pr list \
+              --repo "${{ github.repository }}" \
+              --head "${{ github.ref_name }}" \
+              --state open \
+              --json number \
+              --jq '.[0].number')
+          fi
+
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No open PR found for this branch — skipping."
+            echo "success=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          LABEL_COUNT=$(gh pr view "$PR_NUMBER" \
+            --repo "${{ github.repository }}" \
+            --json labels \
+            --jq '.labels | length')
+
+          if [ "$LABEL_COUNT" -gt 0 ]; then
+            echo "success=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "success=false" >> "$GITHUB_OUTPUT"
+          fi
+
   ci-tests:
+    needs: validate
+    if: needs.validate.outputs.success == 'true'
     name: Tox env ${{ matrix.python }}-${{ matrix.toxenv }}
     runs-on: ${{ matrix.os }}
     permissions:
@@ -40,6 +96,8 @@ jobs:
         tox -e ${{ matrix.python }}-${{ matrix.toxenv }}
 
   dev-tests:
+    needs: validate
+    if: needs.validate.outputs.success == 'true'
     name: Tox env ${{ matrix.python }}-${{ matrix.toxenv }}
     runs-on: ${{ matrix.os }}
     permissions:
@@ -64,6 +122,8 @@ jobs:
         tox -e ${{ matrix.python }}-${{ matrix.toxenv }}
 
   os-tests:
+    needs: validate
+    if: needs.validate.outputs.success == 'true'
     name: Python ${{ matrix.python }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     permissions:
@@ -90,6 +150,8 @@ jobs:
         tox -e ${{ matrix.python }}-${{ matrix.toxenv }}
 
   conda:
+    needs: validate
+    if: needs.validate.outputs.success == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -107,6 +169,8 @@ jobs:
         tox -e conda
 
   codestyle:
+    needs: validate
+    if: needs.validate.outputs.success == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -22,6 +22,8 @@ env:
 jobs:
   validate:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       success: ${{ steps.check.outputs.success }}
     steps:


### PR DESCRIPTION
#2138 didn't solve the workflow triggering issues.

This is what Claude and I came up with.

CI should now trigger on any push to `release` or `develop`, and it should trigger on labeled PRs once they're labeled and anytime the relevant branch is updated afterward.