### PR TITLE
Error in rescaled coordinates for quasi-2D bspline construction

### DIFF
--- a/doc/help/run_pypeit.rst
+++ b/doc/help/run_pypeit.rst
@@ -6,7 +6,7 @@
                       pypeit_file
     
     PypeIt: The Python Spectroscopic Data Reduction Pipeline
-    Version 2.0.2.dev249+g6276c5ac3.d20260428
+    Version 2.0.2.dev229+g08f65ed6b
     
     Available spectrographs include:
         aat_uhrf, apf_levy, bok_bc, gemini_flamingos1, gemini_flamingos2,

--- a/doc/releases/2.1.0dev.rst
+++ b/doc/releases/2.1.0dev.rst
@@ -100,3 +100,5 @@ Bug Fixes
 - Fix a bug in 2D coaddition where manually identified objects were not being
   used to compute offsets between input frames.  Add description of this failure
   mode to the :ref:`known_issues_coadd2d` documentation for 2D coaddition.
+- Fixes a bug in :class:`~pypeit.bspline.bspline.bspline` which was not
+  correctly setting ``xmin`` and ``xmax`` when using the ``x2`` option.

--- a/pypeit/bspline/bspline.py
+++ b/pypeit/bspline/bspline.py
@@ -428,6 +428,10 @@ class bspline(datamodel.DataContainer):
             self.xmax = x2.max()
         if self.xmin == self.xmax:
             self.xmax = self.xmin + 1
+            warnings.warn(
+                'Minimum and maximum value used to rescale the range for x2 are identical.  '
+                'Adjusting xmax but be wary of the output!'
+            )
         if self.xmin > x2.min() or self.xmax < x2.max():
             warnings.warn('Rescaled range for x2 will not remap linearly to the range [-1,1]!')
 

--- a/pypeit/bspline/bspline.py
+++ b/pypeit/bspline/bspline.py
@@ -137,8 +137,8 @@ class bspline(datamodel.DataContainer):
         else:
             self.coeff = np.zeros((nc,), dtype=float)
             self.icoeff = np.zeros((nc,), dtype=float)
-        self.xmin = 0.0
-        self.xmax = 1.0
+        self.xmin = None
+        self.xmax = None
         self.funcname = funcname
 
     @staticmethod
@@ -422,6 +422,13 @@ class bspline(datamodel.DataContainer):
 
         if x2.size != nx:
             raise ValueError('Dimensions of x and x2 do not match.')
+
+        if self.xmin is None:
+            self.xmin = x2.min()
+        if self.xmax is None:
+            self.xmax = x2.max()
+        if self.xmin == self.xmax:
+            self.xmax = self.xmin + 1
 
         # TODO: Below is unchanged.
         x2norm = 2.0 * (x2 - self.xmin) / (self.xmax - self.xmin) - 1.0

--- a/pypeit/bspline/bspline.py
+++ b/pypeit/bspline/bspline.py
@@ -107,6 +107,9 @@ class bspline(datamodel.DataContainer):
         # Instantiate the base class
         datamodel.DataContainer.__init__(self)
 
+        self.xmin = None
+        self.xmax = None
+
         # Instantiate empty if neither fullbkpt or x is set
         if x is None and fullbkpt is None:
             self.nord = None
@@ -115,8 +118,6 @@ class bspline(datamodel.DataContainer):
             self.mask= None
             self.coeff= None
             self.icoeff= None
-            self.xmin= None
-            self.xmax= None
             self.funcname= None
             return
 
@@ -137,8 +138,6 @@ class bspline(datamodel.DataContainer):
         else:
             self.coeff = np.zeros((nc,), dtype=float)
             self.icoeff = np.zeros((nc,), dtype=float)
-        self.xmin = None
-        self.xmax = None
         self.funcname = funcname
 
     @staticmethod
@@ -429,6 +428,8 @@ class bspline(datamodel.DataContainer):
             self.xmax = x2.max()
         if self.xmin == self.xmax:
             self.xmax = self.xmin + 1
+        if self.xmin > x2.min() or self.xmax < x2.max():
+            warnings.warn('Rescaled range for x2 will not remap linearly to the range [-1,1]!')
 
         # TODO: Below is unchanged.
         x2norm = 2.0 * (x2 - self.xmin) / (self.xmax - self.xmin) - 1.0


### PR DESCRIPTION
When using the `x2` functionality in `bspline`, the default xmin and xmax are set to 0 and 1.  You can set them to something different by directly accessing the `bspline` attributes after an instance is created, as is done in `bspline_profile`.  However, if you don't, the rescaling of the `x2` data will not correctly map to be within the range [-1,1] as needed for the orthogonal basis functions, except when `x2` is in the range [0,1].

This PR sets the default `xmin` and `xmax` to None so that they are dynamically defined by the `action` method.  That method also checks that the range of `x2` is actually within the limits of `xmin` and `xmax`; it raises a warning if not.

This should be mostly invisible to the code, but I need to run the dev-suite to check.