### PR TITLE
State update fixes

### DIFF
--- a/pypeit/calibrations.py
+++ b/pypeit/calibrations.py
@@ -2170,9 +2170,6 @@ class IFUCalibrations(Calibrations):
         self.slits.set_paths(self.calib_dir, setup, calib_id, detname)
         self.slits.to_file()
 
-        # State
-        self.slits_state(self.slits.get_path())
-
         if self.user_slits is not None:
             self.slits.user_mask(detname, self.user_slits)
 
@@ -2335,22 +2332,12 @@ class IFUCalibrations(Calibrations):
         self.flatimages, self.fiber_flatimages = fiberFlatField.run(
             doqa=self.write_qa, show=self.show)
 
-        # State
-        if self.state is not None:
-            self.state.update_calib('flats', self.calib_ID, self.det,
-                                    'types', 'pixelflat')
-
         if self.flatimages is not None:
             self.flatimages.set_paths(self.calib_dir, setup, calib_id,
                                       detname)
             self.flatimages.to_file()
             # Save slits too, in case they were tweaked
             self.slits.to_file()
-            # State
-            if self.state is not None:
-                self.state.update_calib('flats', self.calib_ID, self.det,
-                                        'output_file',
-                                        self.flatimages.get_path())
 
         if self.fiber_flatimages is not None:
             self.fiber_flatimages.set_paths(self.calib_dir, setup, calib_id,


### PR DESCRIPTION
Likely because of an unintentionally bad merge, the `IFUCalibrations` class was still making calls to various state updates.  This doesn't match the pattern in the main `Calibrations` class, and they were causing the `mmt_binospec_ifu` tests to fail in the dev-suite.