### PR TITLE
Mark tests that require remote data

### DIFF
--- a/pypeit/tests/test_archive.py
+++ b/pypeit/tests/test_archive.py
@@ -101,6 +101,7 @@ def test_archive_meta(tmp_path):
 
     assert test_meta3._metadata == expected_rows
 
+@pytest.mark.remote_data
 def test_archive_dir(tmp_path):
 
     archive_root = str(tmp_path)

--- a/pypeit/tests/test_bspline.py
+++ b/pypeit/tests/test_bspline.py
@@ -1696,6 +1696,7 @@ def test_value_interpolate_training_x_fast_path():
 # iterative_bspline_fit — integration tests against reference data
 # ---------------------------------------------------------------------------
 
+@pytest.mark.remote_data
 def test_iterative_bspline_fit_spec():
     """
     iterative_bspline_fit reproduces the spectral flat-field reference fit
@@ -1719,6 +1720,7 @@ def test_iterative_bspline_fit_spec():
             'Bad spectral iterative_bspline_fit result'
 
 
+@pytest.mark.remote_data
 def test_iterative_bspline_fit_spat():
     """
     iterative_bspline_fit reproduces the spatial flat-field reference fit
@@ -1742,6 +1744,7 @@ def test_iterative_bspline_fit_spat():
             'Bad spatial iterative_bspline_fit result'
 
 
+@pytest.mark.remote_data
 def test_iterative_bspline_fit_twod():
     """
     iterative_bspline_fit reproduces the 2D flat-field reference fit

--- a/pypeit/tests/test_calibrations.py
+++ b/pypeit/tests/test_calibrations.py
@@ -60,6 +60,7 @@ def multi_caliBrate(fitstbl):
 ###################################################
 # TESTS BEGIN HERE
 
+@pytest.mark.remote_data
 def test_abstract_init(fitstbl):
     frame = fitstbl.find_frames('science', index=True)[0]
     par = pypeitpar.CalibrationsPar()
@@ -79,6 +80,7 @@ def test_abstract_init(fitstbl):
     assert isinstance(calib, calibrations.IFUCalibrations), 'Wrong calibration object type'
 
 
+@pytest.mark.remote_data
 def test_instantiate(fitstbl):
     frame = fitstbl.find_frames('science', index=True)[0]
     par = pypeitpar.CalibrationsPar()
@@ -89,6 +91,7 @@ def test_instantiate(fitstbl):
         fitstbl, par, spectrograph, caldir, calib_ID, frame, det)
 
 
+@pytest.mark.remote_data
 def test_bias(multi_caliBrate):
     """
     This should produce nothing as we have no bias frames
@@ -99,6 +102,7 @@ def test_bias(multi_caliBrate):
     multi_caliBrate.get_bias()
 
 
+@pytest.mark.remote_data
 def test_arc(multi_caliBrate):
     arc = multi_caliBrate.get_arc()
     assert isinstance(arc, buildimage.ArcImage), 'arc has wrong type'
@@ -109,6 +113,7 @@ def test_arc(multi_caliBrate):
     shutil.rmtree(multi_caliBrate.calib_dir)
 
 
+@pytest.mark.remote_data
 def test_tiltimg(multi_caliBrate):
     tilt = multi_caliBrate.get_tiltimg()
     assert isinstance(tilt, buildimage.TiltImage), 'tilt has wrong type'
@@ -119,6 +124,7 @@ def test_tiltimg(multi_caliBrate):
     shutil.rmtree(multi_caliBrate.calib_dir)
 
 
+@pytest.mark.remote_data
 def test_bpm(multi_caliBrate):
     # Build
     bpm = multi_caliBrate.get_bpm()
@@ -133,6 +139,7 @@ def test_bpm(multi_caliBrate):
 #   - get_tilts
 
 
+@pytest.mark.remote_data
 def test_asn(multi_caliBrate):
     caldir = Path().absolute()
     ofile = caldir / 'test.calib'
@@ -161,6 +168,7 @@ def test_asn(multi_caliBrate):
     ofile.unlink()
 
 
+@pytest.mark.remote_data
 def test_asn_calib_ID_dict(multi_caliBrate):
 
     caldir = Path().absolute()

--- a/pypeit/tests/test_coadd.py
+++ b/pypeit/tests/test_coadd.py
@@ -8,6 +8,7 @@ from pypeit.core import coadd
 from pypeit.core import standard
 from pypeit.core import meta
 
+@pytest.mark.remote_data
 def test_robust_median():
     # Build some test spectra
     ra, dec = meta.convert_radec('00:31:18.49', '-43:36:23')
@@ -49,6 +50,7 @@ def test_robust_median():
     assert ratio == 1., 'Should be too few good pixels, yielding ratio = 1'
 
 
+@pytest.mark.remote_data
 def test_median_filt_spec():
 
     # Read in an example spectrum
@@ -81,6 +83,7 @@ def test_poly_model_eval():
         poly_r = coadd.poly_model_eval(theta, 'legendre', 'junk', wave, wave[0], wave[-1])
 
 
+@pytest.mark.remote_data
 def test_solve_poly_ratio():
     # Build some test spectra
     ra, dec = meta.convert_radec('00:31:18.49', '-43:36:23')

--- a/pypeit/tests/test_collate_1d.py
+++ b/pypeit/tests/test_collate_1d.py
@@ -503,6 +503,7 @@ def test_get_report_metadata(monkeypatch):
                                                 ['MASKDEF_OBJNAME', 'NAME'],
                                                 "afilename")
 
+@pytest.mark.remote_data
 def test_flux(monkeypatch):
     
     def mock_get_header(file):

--- a/pypeit/tests/test_fitting.py
+++ b/pypeit/tests/test_fitting.py
@@ -55,6 +55,7 @@ def test_legendre():
                                                    -6.84581686e-01, -7.59352737e-17]), atol=1e-9)
 
 
+@pytest.mark.remote_data
 def test_pypeitfitcollection():
 
     # These are results generated from the old TraceSet fitter.  This just

--- a/pypeit/tests/test_flexure.py
+++ b/pypeit/tests/test_flexure.py
@@ -4,6 +4,8 @@ Module to run tests on simple fitting routines for arrays
 
 import numpy as np
 
+import pytest
+
 from pypeit.core import flexure
 from pypeit import dataPaths
 from pypeit.core.wavecal import autoid
@@ -12,6 +14,7 @@ from pypeit import onespec
 from IPython import embed
 
 
+@pytest.mark.remote_data
 def test_flex_shift():
     # Dummy slf
     # Read spectra

--- a/pypeit/tests/test_fluxspec.py
+++ b/pypeit/tests/test_fluxspec.py
@@ -21,6 +21,7 @@ from pypeit import PypeItError
 from pypeit import scripts
 
 
+@pytest.mark.remote_data
 def test_flux_calib(tmp_path, monkeypatch):
     """ Some of these items are also tested in test_fluxspec.py"""
 
@@ -91,9 +92,11 @@ def test_flux_calib(tmp_path, monkeypatch):
 # TODO: Include tests for coadd2d, sensfunc
 
 
+@pytest.mark.remote_data
 def test_extinction_correction_uvis():
     extinction_correction_tester('UVIS')
 
+@pytest.mark.remote_data
 def test_extinction_correction_ir():
     extinction_correction_tester('IR')
 

--- a/pypeit/tests/test_inputfiles.py
+++ b/pypeit/tests/test_inputfiles.py
@@ -37,6 +37,7 @@ def _pypeitfile_components():
     return confdict, data, file_paths, setup_dict
 
 
+@pytest.mark.remote_data
 def test_grab_rawfiles():
 
     tst_file = Path(tstutils.data_output_path('test.rawfiles')).absolute()
@@ -71,6 +72,7 @@ def test_grab_rawfiles():
     tst_file.unlink()
 
 
+@pytest.mark.remote_data
 def test_instantiate_pypeitfile():
     # Test of instantiation
     confdict, data, file_paths, setup_dict = _pypeitfile_components()
@@ -530,6 +532,7 @@ def test_fluxfile_basic():
         'FluxFile.vet should add an empty sensfile column when not provided'
 
 
+@pytest.mark.remote_data
 def test_input_flux_file():
     """Tests for generating and reading fluxing input files
     """

--- a/pypeit/tests/test_install.py
+++ b/pypeit/tests/test_install.py
@@ -5,6 +5,8 @@ from IPython import embed
 
 from astropy.config import set_temp_cache
 
+import pytest
+
 from pypeit import dataPaths
 from pypeit.scripts import install_telluric
 from pypeit.scripts import install_extinctfile
@@ -87,6 +89,7 @@ def run_install_linelist():
 
 
 # TODO: There's got to be a more concise way to do this...
+@pytest.mark.remote_data
 def test_install_telluric():
 
     root = 'cache_test'    

--- a/pypeit/tests/test_metadata.py
+++ b/pypeit/tests/test_metadata.py
@@ -17,6 +17,7 @@ from astropy.table import Table
 from pypeit import PypeItError
 
 
+@pytest.mark.remote_data
 def test_read_combid():
 
     # ------------------------------------------------------------------
@@ -180,6 +181,7 @@ def test_multiple_setups():
         os.remove(fil)
 
 
+@pytest.mark.remote_data
 def test_get_row_for_filename():
     ## Clone of above test, just trying to get a metadata object
     config_dir = Path(tstutils.data_output_path('shane_kast_blue_A')).absolute()

--- a/pypeit/tests/test_pca.py
+++ b/pypeit/tests/test_pca.py
@@ -50,6 +50,7 @@ def test_prediction(vec_coo, bogus_vectors):
     # TODO: More checks?
 
 
+@pytest.mark.remote_data
 def test_rms():
     """Test on some real data."""
     center = np.load(dataPaths.tests.get_file_path('example_trace_deimos_1200G_M_7750.npz'))['center']

--- a/pypeit/tests/test_pkgdata.py
+++ b/pypeit/tests/test_pkgdata.py
@@ -21,6 +21,7 @@ from pypeit.core.wavecal import waveio
 from pypeit import onespec
 
 
+@pytest.mark.remote_data
 def test_cloud_url():
 
     # The telgrid files live on a cloud server.  Test for file existance (or URL change)
@@ -34,6 +35,7 @@ def test_cloud_url():
            f"Got status {get.status_code} (!= 200) for URL {telgrid_src[0]}"
 
 
+@pytest.mark.remote_data
 def test_fetch_github_files():
 
     # These are commonly used files, do all three in one test; the test just ensures
@@ -49,6 +51,7 @@ def test_fetch_github_files():
                             force_update=True)
     
 
+@pytest.mark.remote_data
 def test_github_contents():
 
     # In case we're working in a fork
@@ -73,6 +76,7 @@ def test_github_contents():
             'tests/ directory expected to have subdirectories'
     
 
+@pytest.mark.remote_data
 def test_filepath_routines():
 
     filepath, format = dataPaths.reid_arxiv.get_file_path("keck_deimos_600ZD.fits",
@@ -139,6 +143,7 @@ def test_pygit2():
 #    assert date is not None, 'Failed to get most recent tag version'
 
 
+@pytest.mark.remote_data
 def test_waveio_load_reid_arxiv():
 
     # Test the extension logic, given the download/cache system
@@ -161,6 +166,7 @@ def test_datapath():
         p = PypeItDataPath('junk')
 
 
+@pytest.mark.remote_data
 def test_truediv():
     p = PypeItDataPath('tests')
 
@@ -182,6 +188,7 @@ def test_truediv():
     assert str(_p.path.relative_to(p.path)) == subdir, 'Wrong subdirectory'
 
 
+@pytest.mark.remote_data
 def test_get_file_path():
     f = 'b1.fits.gz'
     # NOTE: Setting to_pkg symlink only needs to be done once for each unique file
@@ -195,6 +202,7 @@ def test_get_file_path():
                                          to_pkg='symlink')[1] == 'npz', 'Wrong file format'
 
 
+@pytest.mark.remote_data
 def test_cache_to_pkg():
     test_file_name = 'cache_test.txt'
     test_file = dataPaths.tests.path / test_file_name

--- a/pypeit/tests/test_runpypeit.py
+++ b/pypeit/tests/test_runpypeit.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import shutil
 from IPython.terminal.embed import embed
 import numpy as np
+import pytest
 
 import matplotlib
 matplotlib.use('agg')  
@@ -18,6 +19,7 @@ from pypeit import specobjs, sensfunc
 from pypeit.par import pypeitpar 
 from pypeit.tests import tstutils
 
+@pytest.mark.remote_data
 def test_run_pypeit():
 
     # Just get a few files

--- a/pypeit/tests/test_sensfilearchive.py
+++ b/pypeit/tests/test_sensfilearchive.py
@@ -23,6 +23,7 @@ def test_getinstance():
 def test_supported_spectrgraphs():
     assert SensFileArchive.supported_spectrographs() == ['keck_deimos']
 
+@pytest.mark.remote_data
 def test_get_archived_sensfile(monkeypatch):
     sfa = SensFileArchive.get_instance("keck_deimos")
     

--- a/pypeit/tests/test_setups.py
+++ b/pypeit/tests/test_setups.py
@@ -21,6 +21,7 @@ def expected_file_extensions():
     return ['sorted']
 
 
+@pytest.mark.remote_data
 def test_read_list_rawfiles():
     """ Read in a file which is a 
     list of raw data files for setting up
@@ -53,6 +54,7 @@ def test_read_list_rawfiles():
         os.remove(tst_file)
 
 
+@pytest.mark.remote_data
 def test_run_setup():
     """ Test the setup script
     """

--- a/pypeit/tests/test_spec2dobj.py
+++ b/pypeit/tests/test_spec2dobj.py
@@ -127,6 +127,7 @@ def test_spec2dobj_update_slit(init_dict):
 ####################################################3
 # Testing of AllSpec2DObj
 
+@pytest.mark.remote_data
 def test_all2dobj_hdr(init_dict):
     # Build one
     init_dict['detector'] = tstutils.get_kastb_detector()

--- a/pypeit/tests/test_spectrographs.py
+++ b/pypeit/tests/test_spectrographs.py
@@ -19,6 +19,7 @@ from pypeit.tests.tstutils import data_output_path
 from IPython import embed
 
 
+@pytest.mark.remote_data
 def test_shanekastblue():
     s = spectrographs.shane_kast.ShaneKastBlueSpectrograph()
     example_file = dataPaths.tests.get_file_path('b1.fits.gz')
@@ -30,6 +31,7 @@ def test_shanekastblue():
     assert bpm.shape == (2048,350)
 
 
+@pytest.mark.remote_data
 def test_select_detectors_pypeit_file():
     # Generate a PypeIt file
     tstutils.install_shane_kast_blue_raw_data()
@@ -154,6 +156,7 @@ def test_atmext():
     atmext = spec.get_atmospheric_extinction('mkoextinct.dat')
     assert atmext.file == 'mkoextinct.dat', 'Used wrong extinction file'
 
+@pytest.mark.remote_data
 def test_load_spectrograph():
 
     # Basic test
@@ -210,6 +213,7 @@ def fitstbl():
     setupc.fitstbl.finalize_usr_build(None, 'A')
     return setupc.fitstbl
 
+@pytest.mark.remote_data
 def test_config_specific_par(fitstbl):
     # Grab a science file for configuration specific parameters
     indx = fitstbl.find_frames('science', index=True)[0]

--- a/pypeit/tests/test_standard.py
+++ b/pypeit/tests/test_standard.py
@@ -103,6 +103,7 @@ def test_archive_classes():
     assert len(classes) == 6, 'Number of classes changed'
 
 
+@pytest.mark.remote_data
 def test_archived_standards():
 
     archive_classes = standard.archived_flux_classes()
@@ -246,6 +247,7 @@ def test_blackbody():
     assert np.array_equal(_bb.flux, bb.flux[:10]), 'Bad fluxes'
 
 
+@pytest.mark.remote_data
 def test_kurucz_models():
     spec = standard.KuruczModelStandard(14., 'B0')
 
@@ -259,6 +261,7 @@ def test_kurucz_models():
         spec = standard.KuruczModelStandard(14., 'K0')
 
 
+@pytest.mark.remote_data
 def test_vega_model():
     spec = standard.VegaStandard(14.0)
     assert spec.size == 21617, 'Spectrum has the wrong length'
@@ -267,6 +270,7 @@ def test_vega_model():
     assert spec.meta['source'] == 'Vega', 'Bad model source'
 
 
+@pytest.mark.remote_data
 def test_phoenix_model():
     spec = standard.PhoenixStandard(14.0)
     assert spec.size == 1554127, 'Spectrum has the wrong length'
@@ -312,6 +316,7 @@ def test_archive_sets():
         archive = standard.get_archive_sets(archives=['junk1', 'junk2'])
 
 
+@pytest.mark.remote_data
 def test_get_archive_standard():
 
     # No star within the tolerance
@@ -369,6 +374,7 @@ def test_get_archive_standard():
     assert spec.meta['Name'] == 'HZ15', 'Found the wrong object'
 
 
+@pytest.mark.remote_data
 def test_get_model_standard():
 
     # Get the TSpecTool model
@@ -396,6 +402,7 @@ def test_get_model_standard():
         spec = standard.get_model_standard('K0', 14.)
 
 
+@pytest.mark.remote_data
 def test_get_standard_spectrum():
 
     # Get the TSpecTool model

--- a/pypeit/tests/test_wavemodel.py
+++ b/pypeit/tests/test_wavemodel.py
@@ -13,6 +13,7 @@ except NameError:
 
 # TODO -- Note that the transparency function is not used anywhere
 
+@pytest.mark.remote_data
 def test_transparency():
     """ Test for creting the ski transmission model. It is basically
     testing if the skisim directory is reachable.

--- a/pypeit/tests/test_wvcalib.py
+++ b/pypeit/tests/test_wvcalib.py
@@ -16,6 +16,7 @@ from pypeit.tests.tstutils import data_output_path
 from pypeit.core.wavecal import waveio
 
 
+@pytest.mark.remote_data
 def test_load_template():
     # Test full read
     ret = waveio.load_template('gemini_gmos_r831_ham.fits', 1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -201,6 +201,9 @@ minversion = 7.0
 testpaths = [
     "pypeit",
 ]
+addopts = [
+    "--remote-data",
+]
 
 [tool.coverage]
 


### PR DESCRIPTION
This makes it possible to run a subset of the tests when no internet connection is available, like when building a Debian package.

Fixes #2176 