### PR TITLE
Write temporary test output to pytest tmp_path

### DIFF
--- a/pypeit/tests/test_alignments.py
+++ b/pypeit/tests/test_alignments.py
@@ -5,15 +5,16 @@ from pathlib import Path
 
 from IPython import embed
 
+import pytest
+
 import numpy as np
 
 from astropy.io import fits
 
 from pypeit import alignframe
-from pypeit.tests.tstutils import data_output_path
 
 
-def test_alignments():
+def test_alignments(tmp_path):
     nspat, nspec, nslits, nalign = 100, 1000, 10, 5
     tmp = np.ones((nspec, nspat)) * 10.
     traces = np.zeros((nspec, nalign, nslits))
@@ -26,7 +27,7 @@ def test_alignments():
                         spat_id=np.arange(nslits))
 
     alignments = alignframe.Alignments(**instant_dict)
-    alignments.set_paths(data_output_path(''), 'A', '1', 'DET01')
+    alignments.set_paths(str(tmp_path), 'A', '1', 'DET01')
     ofile = Path(alignments.get_path()).absolute()
 
     # I/O

--- a/pypeit/tests/test_arcimage.py
+++ b/pypeit/tests/test_arcimage.py
@@ -5,6 +5,8 @@ from pathlib import Path
 
 from IPython import embed
 
+import pytest
+
 import numpy as np
 
 from pypeit.images import pypeitimage
@@ -22,7 +24,7 @@ def test_init():
     arcImage = buildimage.ArcImage.from_pypeitimage(pypeitImage)
 
 
-def test_io():
+def test_io(tmp_path):
     # Instantiate a simple pypeitImage
     pypeitImage = pypeitimage.PypeItImage(np.ones((1000, 1000)))
     pypeitImage.reinit_mask()
@@ -30,12 +32,12 @@ def test_io():
     pypeitImage.PYP_SPEC = 'shane_kast_blue'
     # Now the arcimage
     arcImage = buildimage.ArcImage.from_pypeitimage(
-        pypeitImage, calib_dir=tstutils.data_output_path(''), setup='A', calib_id=['1'],
+        pypeitImage, calib_dir=str(tmp_path), setup='A', calib_id=['1'],
         detname='DET01'
     )
     # Set paths and check name
     ofile = Path(arcImage.get_path()).absolute()
-    assert str(ofile) == str(Path(tstutils.data_output_path('Arc_A_1_DET01.fits')).absolute()), \
+    assert str(ofile) == str(tmp_path / 'Arc_A_1_DET01.fits'), \
             'Calibration file name changed'
     
     # Write

--- a/pypeit/tests/test_calibframe.py
+++ b/pypeit/tests/test_calibframe.py
@@ -12,7 +12,6 @@ import pytest
 from pypeit import PypeItError
 from pypeit.calibframe import CalibFrame
 from pypeit import io
-from pypeit.tests.tstutils import data_output_path
 
 
 class NoTypeCalibFrame(CalibFrame):
@@ -46,9 +45,9 @@ def test_implementation_faults():
         calib = MissingPYPSPECCalibFrame()
 
 
-def test_init():
+def test_init(tmp_path):
     calib = MinimalCalibFrame()
-    odir = Path(data_output_path('')).absolute()
+    odir = tmp_path
     calib.set_paths(odir, 'A', '1', 'DET01')
     ofile = Path(calib.get_path()).name
     assert ofile == 'Minimal_A_1_DET01.fits', 'Wrong file name'
@@ -61,9 +60,9 @@ def test_init():
     assert ofile == 'Minimal_A_1+2_DET01.fits', 'Wrong file name'
 
 
-def test_io():
+def test_io(tmp_path):
     calib = MinimalCalibFrame()
-    odir = Path(data_output_path('')).absolute()
+    odir = tmp_path
     calib.set_paths(odir, 'A', '1', 'DET01')
     calib.PYP_SPEC = 'this is a test'
     opath = Path(calib.get_path()).absolute()
@@ -142,9 +141,9 @@ def test_parse_calib_id():
             'Bad complex construction'
 
 
-def test_parse_key_dir():
+def test_parse_key_dir(tmp_path):
     calib = MinimalCalibFrame()
-    odir = Path(data_output_path('')).absolute()
+    odir = tmp_path
     calib.set_paths(odir, 'A', '1', 'DET01')
     calib.PYP_SPEC = 'this is a test'
     opath = Path(calib.get_path()).absolute()
@@ -164,9 +163,9 @@ def test_parse_key_dir():
     opath.unlink()
 
 
-def test_hdr():
+def test_hdr(tmp_path):
     calib = MinimalCalibFrame()
-    odir = Path(data_output_path('')).absolute()
+    odir = tmp_path
     calib.set_paths(odir, 'A', '1', 'DET01')
 
     hdr = calib._base_header()

--- a/pypeit/tests/test_calibrations.py
+++ b/pypeit/tests/test_calibrations.py
@@ -14,8 +14,6 @@ from pypeit.images import buildimage
 from pypeit.par import pypeitpar
 from pypeit.spectrographs.util import load_spectrograph
 
-from pypeit.tests.tstutils import data_output_path
-
 det = 1
 
 @pytest.fixture
@@ -37,7 +35,7 @@ def fitstbl():
     return setupc.fitstbl
 
 @pytest.fixture
-def multi_caliBrate(fitstbl):
+def multi_caliBrate(tmp_path, fitstbl):
     # Grab a science file for configuration specific parameters
     indx = fitstbl.find_frames('science', index=True)[0]
     sci_file = fitstbl.frame_paths(indx)
@@ -52,7 +50,7 @@ def multi_caliBrate(fitstbl):
     calib_par['slitedges']['sync_predict'] = 'nearest'
 
     multi_caliBrate = calibrations.MultiSlitCalibrations(
-        fitstbl, calib_par, spectrograph, data_output_path('Calibrations'),
+        fitstbl, calib_par, spectrograph, str(tmp_path / 'Calibrations'),
         calib_ID, indx, det)
     multi_caliBrate.success = True
     return multi_caliBrate
@@ -60,11 +58,11 @@ def multi_caliBrate(fitstbl):
 ###################################################
 # TESTS BEGIN HERE
 
-def test_abstract_init(fitstbl):
+def test_abstract_init(tmp_path, fitstbl):
     frame = fitstbl.find_frames('science', index=True)[0]
     par = pypeitpar.CalibrationsPar()
     spectrograph = load_spectrograph('shane_kast_blue')
-    caldir = data_output_path('Calibrations')
+    caldir = str(tmp_path / 'Calibrations')
     calib_ID = fitstbl.calib_groups[0]
     calib = calibrations.Calibrations.get_instance(
         fitstbl, par, spectrograph, caldir,calib_ID,frame,det)
@@ -79,11 +77,11 @@ def test_abstract_init(fitstbl):
     assert isinstance(calib, calibrations.IFUCalibrations), 'Wrong calibration object type'
 
 
-def test_instantiate(fitstbl):
+def test_instantiate(tmp_path, fitstbl):
     frame = fitstbl.find_frames('science', index=True)[0]
     par = pypeitpar.CalibrationsPar()
     spectrograph = load_spectrograph('shane_kast_blue')
-    caldir = data_output_path('Calibrations')
+    caldir = str(tmp_path / 'Calibrations')
     calib_ID = fitstbl.calib_groups[0]
     caliBrate = calibrations.MultiSlitCalibrations(
         fitstbl, par, spectrograph, caldir, calib_ID, frame, det)

--- a/pypeit/tests/test_detector.py
+++ b/pypeit/tests/test_detector.py
@@ -5,6 +5,8 @@ import os
 
 from IPython import embed
 
+import pytest
+
 import numpy as np
 
 from pypeit.tests import tstutils
@@ -28,11 +30,11 @@ def test_bundle():
     assert len(data) == 1
 
 
-def test_io():
+def test_io(tmp_path):
     detector = detector_container.DetectorContainer(**tstutils.default_detector())
-    detector.to_file(tstutils.data_output_path('tmp_detector.fits'), overwrite=True)
+    detector.to_file(str(tmp_path / 'tmp_detector.fits'), overwrite=True)
 
-    _new_detector = detector.from_file(tstutils.data_output_path('tmp_detector.fits'))
+    _new_detector = detector.from_file(str(tmp_path / 'tmp_detector.fits'))
 
     # Check a few attributes are equal
     assert detector['dataext'] == _new_detector['dataext'], 'Bad read dataext'
@@ -40,7 +42,7 @@ def test_io():
     assert detector['binning'] == _new_detector['binning'], 'Bad read binning'
     assert np.array_equal(detector['datasec'], _new_detector['datasec']), 'Bad read datasec'
 
-    os.remove(tstutils.data_output_path('tmp_detector.fits'))
+    os.remove(str(tmp_path / 'tmp_detector.fits'))
 
 
 def test_copy():

--- a/pypeit/tests/test_fiberflatfield.py
+++ b/pypeit/tests/test_fiberflatfield.py
@@ -2,11 +2,12 @@
 import numpy as np
 from pathlib import Path
 
+import pytest
+
 from pypeit.flatfield import FiberFlatImages
-from pypeit.tests.tstutils import data_output_path
 
 
-def test_fiberflatimages_io():
+def test_fiberflatimages_io(tmp_path):
     """Test FiberFlatImages DataContainer I/O round-trip."""
     nfibers = 40
     nwave = 100
@@ -29,7 +30,7 @@ def test_fiberflatimages_io():
     )
 
     # Write and read back
-    ofile = Path(data_output_path('test_fiberflatimages.fits')).absolute()
+    ofile = tmp_path / 'test_fiberflatimages.fits'
     ffi.to_file(str(ofile), overwrite=True)
     _ffi = FiberFlatImages.from_file(str(ofile))
 

--- a/pypeit/tests/test_fitting.py
+++ b/pypeit/tests/test_fitting.py
@@ -11,11 +11,10 @@ import numpy as np
 
 from pypeit import dataPaths
 from pypeit.core import fitting
-from pypeit.tests.tstutils import data_output_path
 
 
-def test_pypeitfit():
-    out_file = data_output_path('test_fit.fits')
+def test_pypeitfit(tmp_path):
+    out_file = str(tmp_path / 'test_fit.fits')
     if os.path.isfile(out_file):
         os.remove(out_file)
     pypeitFit = fitting.PypeItFit(fitc=np.arange(100).astype(float))

--- a/pypeit/tests/test_flatfield.py
+++ b/pypeit/tests/test_flatfield.py
@@ -5,6 +5,8 @@ from pathlib import Path
 
 from IPython import embed
 
+import pytest
+
 import numpy as np
 
 from astropy.io import fits
@@ -13,10 +15,9 @@ from pypeit import flatfield
 from pypeit.core.bspline import Knots
 from pypeit.containers.bspline import BSplineContainer
 from pypeit.spectrographs.util import load_spectrograph
-from pypeit.tests.tstutils import data_output_path
 
 
-def test_flatimages():
+def test_flatimages(tmp_path):
     tmp = np.ones((1000, 100)) * 10.
     x = np.random.rand(500)
     # Create bspline
@@ -37,7 +38,7 @@ def test_flatimages():
     assert flatImages.pixelflat_model is None
     assert flatImages.pixelflat_spec_illum is None
     assert flatImages.pixelflat_spat_bsplines is not None
-    flatImages.set_paths(data_output_path(''), 'A', '1', 'DET01')
+    flatImages.set_paths(str(tmp_path), 'A', '1', 'DET01')
 
     # I/O
     ofile = Path(flatImages.get_path()).absolute()

--- a/pypeit/tests/test_fluxspec.py
+++ b/pypeit/tests/test_fluxspec.py
@@ -13,7 +13,6 @@ from pypeit import dataPaths
 from pypeit import fluxcalibrate
 from pypeit import sensfunc
 from pypeit.par import pypeitpar
-from pypeit.tests.tstutils import data_output_path
 from pypeit import specobjs, specobj
 
 from pypeit import fluxcalibrate
@@ -76,7 +75,7 @@ def test_flux_calib(tmp_path, monkeypatch):
         config_file_no_sens = str(tmp_path / "test_flux_calib_no_sens.flux")
         with open(config_file_no_sens, "w") as f:
             print("flux read", file=f)
-            print(f"path {data_output_path('')}", file=f)
+            print(f"path {str(tmp_path)}", file=f)
             print("filename", file=f)
             # TODO: Are these meant to be the same file?
             print("spec1d_cN20170331S0216-pisco_GNIRS_20170331T085412.181.fits", file=f)
@@ -91,15 +90,15 @@ def test_flux_calib(tmp_path, monkeypatch):
 # TODO: Include tests for coadd2d, sensfunc
 
 
-def test_extinction_correction_uvis():
-    extinction_correction_tester('UVIS')
+def test_extinction_correction_uvis(tmp_path):
+    extinction_correction_tester(tmp_path, 'UVIS')
 
-def test_extinction_correction_ir():
-    extinction_correction_tester('IR')
+def test_extinction_correction_ir(tmp_path):
+    extinction_correction_tester(tmp_path, 'IR')
 
-def extinction_correction_tester(algorithm):
-    spec1d_file = data_output_path('spec1d_test.fits')
-    sens_file = data_output_path('sens_test.fits')
+def extinction_correction_tester(tmp_path, algorithm):
+    spec1d_file = str(tmp_path / 'spec1d_test.fits')
+    sens_file = str(tmp_path / 'sens_test.fits')
 
     if os.path.isfile(spec1d_file):
         os.remove(spec1d_file)

--- a/pypeit/tests/test_inputfiles.py
+++ b/pypeit/tests/test_inputfiles.py
@@ -18,7 +18,7 @@ from pypeit import inputfiles
 from pypeit.tests import tstutils
 
 
-def _pypeitfile_components():
+def _pypeitfile_components(tmp_path):
     """
     Bits needed to generate a PypeIt file
     """
@@ -29,7 +29,7 @@ def _pypeitfile_components():
     data['frametype'] = ['arc', 'science']
     data['exptime'] = [1., 10.]
 
-    file_paths = [tstutils.data_output_path('')]
+    file_paths = [tmp_path]
 
     setup_dict = {'Setup A': ' '}
 
@@ -37,9 +37,9 @@ def _pypeitfile_components():
     return confdict, data, file_paths, setup_dict
 
 
-def test_grab_rawfiles():
+def test_grab_rawfiles(tmp_path):
 
-    tst_file = Path(tstutils.data_output_path('test.rawfiles')).absolute()
+    tst_file = tmp_path / 'test.rawfiles'
     if tst_file.exists():
         tst_file.unlink()
 
@@ -47,7 +47,7 @@ def test_grab_rawfiles():
     # installation
     tstutils.install_shane_kast_blue_raw_data()
 
-    root = Path(tstutils.data_output_path('')).absolute()
+    root = tmp_path
     raw_files = [root / 'b11.fits.gz', root / 'b12.fits.gz']
     assert all([f.exists() for f in raw_files]), 'Files missing'
 
@@ -103,9 +103,9 @@ def test_read_backwards_pypeitfile():
     assert isinstance(pypeItFile.config, dict), 'Backwards-format PypeIt file should parse to a dict'
 
 
-def test_write_pypeitfile():
+def test_write_pypeitfile(tmp_path):
     # Test writing a PypeIt file
-    outfile = Path(tstutils.data_output_path('tmp_file.pypeit')).absolute()
+    outfile = tmp_path / 'tmp_file.pypeit'
     if outfile.is_file():
         outfile.unlink()
 
@@ -131,9 +131,9 @@ def test_write_pypeitfile():
     outfile.unlink()
 
 
-def test_path_and_files_commented_and_skip_blank():
+def test_path_and_files_commented_and_skip_blank(tmp_path):
     # Prepare a small test directory and files
-    root = Path(tstutils.data_output_path('')).absolute()
+    root = tmp_path
 
     f1 = root / 'good.fits'
     f2 = root / 'masked.fits'
@@ -174,8 +174,8 @@ def test_path_and_files_commented_and_skip_blank():
     f2.unlink()
 
 
-def test_path_and_files_check_exists_flag():
-    root = Path(tstutils.data_output_path('')).absolute()
+def test_path_and_files_check_exists_flag(tmp_path):
+    root = tmp_path
 
     f_exists = root / 'exists1.fits'
     if f_exists.exists():
@@ -206,9 +206,9 @@ def test_path_and_files_check_exists_flag():
     f_exists.unlink()
 
 
-def test_vet_raises_when_missing_datablock():
+def test_vet_raises_when_missing_datablock(tmp_path):
     # datablock_required for PypeItFile is True; vet should raise when data is None
-    root = Path(tstutils.data_output_path('')).absolute()
+    root = tmp_path
     pfile = inputfiles.PypeItFile(
         config={'rdx': {}}, file_paths=[str(root)], data_table=None, setup={'Setup A': ' '},
         vet=False,
@@ -217,9 +217,9 @@ def test_vet_raises_when_missing_datablock():
         pfile.vet()
 
 
-def test_vet_raises_when_required_columns_missing():
+def test_vet_raises_when_required_columns_missing(tmp_path):
     # Missing required column 'frametype' should trigger vet() to raise
-    root = Path(tstutils.data_output_path('')).absolute()
+    root = tmp_path
     tbl = Table()
     tbl['filename'] = ['a.fits']
     pfile = inputfiles.PypeItFile(
@@ -286,9 +286,9 @@ def test_find_block():
 # that function.  We should fix that, and then we can uncomment this test.  We
 # could also move this test to the dev-suite unit tests so that it has a real
 # raw file to go from.
-#def test_get_pypeitpar_selects_science_file():
+#def test_get_pypeitpar_selects_science_file(tmp_path):
 #    # Create example files and a PypeIt table with an arc and a science frame
-#    root = Path(tstutils.data_output_path('')).absolute()
+#    root = tmp_path
 #    sci = root / 'sci1.fits'
 #    arc = root / 'arc1.fits'
 #    if sci.exists():
@@ -320,8 +320,8 @@ def test_find_block():
 #    sci.unlink()
 #    arc.unlink()
 
-def test_preserve_comments_in_filenames_property():
-    root = Path(tstutils.data_output_path('')).absolute()
+def test_preserve_comments_in_filenames_property(tmp_path):
+    root = tmp_path
     f1 = root / 'good.fits'
     f2 = root / 'masked.fits'
     if f1.exists():
@@ -507,20 +507,20 @@ def test_write_preserve_comments_true_and_cfg_lines():
         assert pfile2.setup_name == 'B', 'setup_name should return the setup letter'
 
 
-def test_sensfile_basic():
-    root = Path(tstutils.data_output_path('')).absolute()
+def test_sensfile_basic(tmp_path):
+    root = tmp_path
     sfile = inputfiles.SensFile(config={'rdx': {}}, file_paths=[str(root)], data_table=None, setup=None, vet=False)
     sfile.vet()
 
 
-def test_extractfile_basic():
-    root = Path(tstutils.data_output_path('')).absolute()
+def test_extractfile_basic(tmp_path):
+    root = tmp_path
     efile = inputfiles.ExtractFile(config={'rdx': {}}, file_paths=[str(root)], data_table=None, setup=None, vet=False)
     efile.vet()
 
 
-def test_fluxfile_basic():
-    root = Path(tstutils.data_output_path('')).absolute()
+def test_fluxfile_basic(tmp_path):
+    root = tmp_path
     tbl = Table()
     tbl['filename'] = ['f1.fits']
     tbl['frametype'] = ['science']
@@ -530,11 +530,11 @@ def test_fluxfile_basic():
         'FluxFile.vet should add an empty sensfile column when not provided'
 
 
-def test_input_flux_file():
+def test_input_flux_file(tmp_path):
     """Tests for generating and reading fluxing input files
     """
     # Generate an input file
-    flux_input_file = Path(tstutils.data_output_path('test.flux')).absolute()
+    flux_input_file = tmp_path /'test.flux'
     if flux_input_file.is_file():
         flux_input_file.unlink()
 
@@ -548,7 +548,7 @@ def test_input_flux_file():
                         'spec1d_cN20170331S0217-pisco_GNIRS_20170331T085933.097.fits']
     data['sensfile'] = 'sens_cN20170331S0206-HIP62745_GNIRS_20170331T083351.681.fits'
     # 
-    paths = [Path(tstutils.data_output_path('')).absolute()]
+    paths = [tmp_path]
     # If pulling from the cache, make sure there are symlinks at the expected path
     for f in data['filename']:
         dataPaths.tests.get_file_path(f, to_pkg='symlink')
@@ -595,8 +595,8 @@ def test_input_flux_file():
     flux_input_file.unlink()
 
 
-def test_coadd1dfile_basic():
-    root = Path(tstutils.data_output_path('')).absolute()
+def test_coadd1dfile_basic(tmp_path):
+    root = tmp_path
     tbl2 = Table()
     tbl2['filename'] = ['a.fits']
     with pytest.raises(PypeItError):
@@ -606,8 +606,8 @@ def test_coadd1dfile_basic():
     c1.vet()
 
 
-def test_coadd2d_basic():
-    root = Path(tstutils.data_output_path('')).absolute()
+def test_coadd2d_basic(tmp_path):
+    root = tmp_path
     tbl3 = Table()
     tbl3['filename'] = ['b.fits']
     with pytest.raises(PypeItError):
@@ -616,8 +616,8 @@ def test_coadd2d_basic():
     c2.vet()
 
 
-def test_coadd3d_basic():
-    root = Path(tstutils.data_output_path('')).absolute()
+def test_coadd3d_basic(tmp_path):
+    root = tmp_path
     tbl3 = Table()
     tbl3['filename'] = ['b.fits']
     with pytest.raises(PypeItError):
@@ -626,14 +626,14 @@ def test_coadd3d_basic():
     c3.vet()
 
 
-def test_telluric_basic():
-    root = Path(tstutils.data_output_path('')).absolute()
+def test_telluric_basic(tmp_path):
+    root = tmp_path
     tfile = inputfiles.TelluricFile(config={'rdx': {}}, file_paths=[str(root)], data_table=None, setup=None, vet=False)
     tfile.vet()
 
 
-def test_flexure_basic():
-    root = Path(tstutils.data_output_path('')).absolute()
+def test_flexure_basic(tmp_path):
+    root = tmp_path
     tbl3 = Table()
     tbl3['filename'] = ['b.fits']
     with pytest.raises(PypeItError):
@@ -642,8 +642,8 @@ def test_flexure_basic():
     flex.vet()
 
 
-def test_collate1d_basic():
-    root = Path(tstutils.data_output_path('')).absolute()
+def test_collate1d_basic(tmp_path):
+    root = tmp_path
     with pytest.raises(PypeItError):
         inputfiles.Collate1DFile(config={'rdx': {}}, file_paths=[str(root)], data_table=Table(), setup=None, vet=True)
     rtbl = Table()
@@ -652,8 +652,8 @@ def test_collate1d_basic():
     coll.vet()
 
 
-def test_rawfiles_basic():
-    root = Path(tstutils.data_output_path('')).absolute()
+def test_rawfiles_basic(tmp_path):
+    root = tmp_path
     with pytest.raises(PypeItError):
         inputfiles.RawFiles(config={'rdx': {}}, file_paths=[str(root)], data_table=Table(), setup=None, vet=True)
     rtbl = Table()

--- a/pypeit/tests/test_metadata.py
+++ b/pypeit/tests/test_metadata.py
@@ -17,11 +17,11 @@ from astropy.table import Table
 from pypeit import PypeItError
 
 
-def test_read_combid():
+def test_read_combid(tmp_path):
 
     # ------------------------------------------------------------------
     # In case of failed tests
-    config_dir = Path(tstutils.data_output_path('shane_kast_blue_A')).absolute()
+    config_dir = tmp_path / 'shane_kast_blue_A'
     if config_dir.exists():
         shutil.rmtree(config_dir)
     # ------------------------------------------------------------------
@@ -29,7 +29,7 @@ def test_read_combid():
     tstutils.install_shane_kast_blue_raw_data()
 
     # Generate the pypeit file with the comb_id
-    droot = tstutils.data_output_path('b')
+    droot = str(tmp_path / 'b')
     pargs = Setup.parse_args(['-r', droot, '-s', 'shane_kast_blue', '-c', 'all', '-b',
                               '--output_path', f'{config_dir.parent}'])
     Setup.main(pargs)
@@ -180,13 +180,13 @@ def test_multiple_setups():
         os.remove(fil)
 
 
-def test_get_row_for_filename():
+def test_get_row_for_filename(tmp_path):
     ## Clone of above test, just trying to get a metadata object
-    config_dir = Path(tstutils.data_output_path('shane_kast_blue_A')).absolute()
+    config_dir = tmp_path / 'shane_kast_blue_A'
     if config_dir.exists():
         shutil.rmtree(config_dir)
     tstutils.install_shane_kast_blue_raw_data()
-    droot = tstutils.data_output_path('b')
+    droot = str(tmp_path / 'b')
     pargs = Setup.parse_args(['-r', droot, '-s', 'shane_kast_blue', '-c', 'all', '-b',
                               '--output_path', f'{config_dir.parent}'])
     Setup.main(pargs)

--- a/pypeit/tests/test_mosaic.py
+++ b/pypeit/tests/test_mosaic.py
@@ -6,25 +6,24 @@ import pytest
 from astropy.io import fits
 
 from pypeit import PypeItDataModelError
-from pypeit.tests.tstutils import data_output_path
 from pypeit.images.mosaic import Mosaic
 from pypeit.spectrographs.util import load_spectrograph
 
 
-def test_io():
+def test_io(tmp_path):
     # Create the mosaic
     spec = load_spectrograph('keck_deimos')
     mpar = spec.get_mosaic_par((1,5))
 
     # Write it
-    ofile = data_output_path('tmp_mosaic.fits')
+    ofile = str(tmp_path / 'tmp_mosaic.fits')
     mpar.to_file(ofile, overwrite=True)
 
     # Try to read it
     _mpar = Mosaic.from_file(ofile)
 
     # Change the version
-    _ofile = data_output_path('tmp_mosaic_wrongver.fits')
+    _ofile = str(tmp_path / 'tmp_mosaic_wrongver.fits')
     with fits.open(ofile) as hdu:
         hdu['MOSAIC'].header['DMODVER'] = '1.0.0'
         hdu.writeto(_ofile, overwrite=True)

--- a/pypeit/tests/test_onespec.py
+++ b/pypeit/tests/test_onespec.py
@@ -5,10 +5,11 @@ from pathlib import Path
 
 from IPython import embed
 
+import pytest
+
 import numpy as np
 
 from pypeit import onespec
-from pypeit.tests.tstutils import data_output_path
 
 
 def test_init():
@@ -24,12 +25,12 @@ def test_init():
     #assert np.allclose(spec.sigma, 1/np.sqrt(2)), 'Conversion to sigma is wrong'
 
 
-def test_io():
+def test_io(tmp_path):
     wave = np.linspace(3500,10000,1000)
     flux = np.ones(1000, dtype=float)
     # TODO: PYP_SPEC is required if we want to be able to read the file!
     spec = onespec.OneSpec(wave, wave, flux, PYP_SPEC='shane_kast_blue')
-    ofile = Path(data_output_path('tmp.fits')).absolute()
+    ofile = tmp_path / 'tmp.fits'
     spec.to_file(str(ofile), overwrite=True)
     _spec = onespec.OneSpec.from_file(ofile)
     assert np.array_equal(spec.flux, _spec.flux), 'Flux munged'

--- a/pypeit/tests/test_pypeitimage.py
+++ b/pypeit/tests/test_pypeitimage.py
@@ -14,17 +14,16 @@ from astropy.io import fits
 from pypeit import PypeItError
 from pypeit.images import pypeitimage
 from pypeit.images import imagebitmask
-from pypeit.tests.tstutils import data_output_path
 
 
-def test_full():
+def test_full(tmp_path):
     shape = (100,100)
     pypeitImage = pypeitimage.PypeItImage(np.ones(shape), ivar=np.ones(shape))
     # Full datamodel
     assert 'detector' in pypeitImage.keys(), 'Detector somehow missing!'
 
     # I/O
-    outfile = Path(data_output_path('tst_pypeitimage.fits')).absolute()
+    outfile = tmp_path / 'tst_pypeitimage.fits'
     pypeitImage.to_file(str(outfile), overwrite=True)
     _pypeitImage = pypeitimage.PypeItImage.from_file(str(outfile))
 
@@ -134,8 +133,8 @@ def test_bitmaskarray():
     assert np.all(mask.saturation), 'All should have been flagged as saturated.'
 
 
-def test_bitmaskarray_io():
-    path = Path(data_output_path('test.fits')).absolute()
+def test_bitmaskarray_io(tmp_path):
+    path = tmp_path / 'test.fits'
     if path.exists():
         path.unlink()
 
@@ -205,14 +204,14 @@ def test_calib_instantiation():
     assert hasattr(img, 'newdmcomponent'), 'Missing added datamodel component'
 
 
-def test_calib_io():
+def test_calib_io(tmp_path):
 
     rng = np.random.default_rng(99)
     ran_image = rng.normal(size=(100,100))
 
     img = MinimalPypeItCalibrationImage(ran_image)
     img.PYP_SPEC = 'test'
-    odir = Path(data_output_path('')).absolute()
+    odir = tmp_path
     img.set_paths(odir, 'A', '1', 'DET01')
     assert img.calib_dir == str(odir), 'Bad output directory'
     opath = Path(img.get_path()).absolute()

--- a/pypeit/tests/test_setups.py
+++ b/pypeit/tests/test_setups.py
@@ -21,11 +21,11 @@ def expected_file_extensions():
     return ['sorted']
 
 
-def test_read_list_rawfiles():
+def test_read_list_rawfiles(tmp_path):
     """ Read in a file which is a 
     list of raw data files for setting up
     """
-    tst_file = tstutils.data_output_path('test.rawfiles')
+    tst_file = str(tmp_path / 'test.rawfiles')
     if os.path.isfile(tst_file):
         os.remove(tst_file)
 
@@ -36,7 +36,7 @@ def test_read_list_rawfiles():
     # Bulid
     tbl = Table()
     tbl['filename'] = ['b11.fits.gz', 'b12.fits.gz']
-    iRaw = RawFiles(file_paths=[tstutils.data_output_path('')],
+    iRaw = RawFiles(file_paths=[str(tmp_path)],
                     data_table=tbl)
 
     # Write
@@ -53,15 +53,15 @@ def test_read_list_rawfiles():
         os.remove(tst_file)
 
 
-def test_run_setup():
+def test_run_setup(tmp_path):
     """ Test the setup script
     """
     # Download and move all the required b*fits.gz files into the local package
     # installation
     tstutils.install_shane_kast_blue_raw_data()
 
-    droot = tstutils.data_output_path('b')
-    odir = Path(tstutils.data_output_path('')).absolute() / 'shane_kast_blue_A'
+    droot = str(tmp_path / 'b')
+    odir = tmp_path / 'shane_kast_blue_A'
     pargs = Setup.parse_args(['-r', droot, '-s', 'shane_kast_blue', '-c', 'all',
                               '--output_path', f'{odir.parent}'])
     Setup.main(pargs)
@@ -72,7 +72,7 @@ def test_run_setup():
     with pytest.raises(ValueError):
         Setup.main(pargs2)
     
-    pypeit_file = tstutils.data_output_path('shane_kast_blue_A/shane_kast_blue_A.pypeit')
+    pypeit_file = str(tmp_path / 'shane_kast_blue_A/shane_kast_blue_A.pypeit')
     pypeItFile = PypeItFile.from_file(pypeit_file)
 
     # Test
@@ -81,6 +81,6 @@ def test_run_setup():
     assert pypeItFile.setup_name == 'A'
 
     # Cleanup
-    shutil.rmtree(tstutils.data_output_path('shane_kast_blue_A'))
+    shutil.rmtree(str(tmp_path / 'shane_kast_blue_A'))
 
 

--- a/pypeit/tests/test_skysub.py
+++ b/pypeit/tests/test_skysub.py
@@ -4,12 +4,13 @@ Module to run tests on skysub routines (mainly for IFU)
 from pathlib import Path
 from IPython import embed
 
+import pytest
+
 import numpy as np
 
 from pypeit.core import skysub
 from pypeit.images.buildimage import SkyRegions
 from pypeit.slittrace import SlitTraceSet
-from pypeit.tests.tstutils import data_output_path
 
 
 def test_userregions():
@@ -57,10 +58,10 @@ def test_generatemask():
     assert np.array_equal(skymask, tstmsk), 'Sky mask mismatch'
 
 
-def test_skyregions_io():
+def test_skyregions_io(tmp_path):
     tstmsk = np.zeros((1000, 1000), dtype=bool)
     tstmsk[:, 744:901] = True
-    ofile = Path(data_output_path('test_skyregions.fits')).absolute()
+    ofile = tmp_path / 'test_skyregions.fits'
     if ofile.exists():
         ofile.unlink()
     SkyRegions(image=tstmsk.astype(float), PYP_SPEC='dummy').to_file(file_path=ofile)

--- a/pypeit/tests/test_slittrace.py
+++ b/pypeit/tests/test_slittrace.py
@@ -5,10 +5,11 @@ from pathlib import Path
 
 from IPython import embed
 
+import pytest
+
 import numpy as np
 
 from pypeit.slittrace import SlitTraceSet, SlitTraceBitMask
-from pypeit.tests.tstutils import data_output_path
 
 
 def test_bits():
@@ -38,11 +39,11 @@ def test_init():
     assert np.all(center == 5), 'Bad center'
 
 
-def test_io():
+def test_io(tmp_path):
 
     slits = SlitTraceSet(np.full((1000,3), 2, dtype=float), np.full((1000,3), 8, dtype=float),
                          'MultiSlit', nspat=10, PYP_SPEC='dummy')
-    slits.set_paths(data_output_path(''), 'A', '1', 'DET01')
+    slits.set_paths(str(tmp_path), 'A', '1', 'DET01')
     ofile = Path(slits.get_path()).absolute()
 
     # Try to save it
@@ -59,14 +60,14 @@ def test_io():
     ofile.unlink()
 
 
-def test_io_single():
+def test_io_single(tmp_path):
     # NOTE this is just a test string. The file itself is not actually read, so it is not required to run the test.
     file = '/home/xavier/Projects/PypeIt-development-suite/RAW_DATA/keck_deimos/830G_M_8500/DE.20100913.57006.fits.gz'
     slits = SlitTraceSet(np.full((1000, 1), 2, dtype=float), np.full((1000, 1), 8, dtype=float),
                          'MultiSlit',
                          nspat=10, PYP_SPEC='dummy',
                          maskfile=file)
-    slits.set_paths(data_output_path(''), 'A', '1', 'DET01')
+    slits.set_paths(str(tmp_path), 'A', '1', 'DET01')
     ofile = Path(slits.get_path()).absolute()
 
     # Try to save it

--- a/pypeit/tests/test_spec2dobj.py
+++ b/pypeit/tests/test_spec2dobj.py
@@ -79,11 +79,11 @@ def test_init(init_dict):
     assert spec2DObj.hdu_prefix == 'DET01-'
 
 
-def test_spec2dobj_io(init_dict):
+def test_spec2dobj_io(tmp_path, init_dict):
     init_dict['detector'] = tstutils.get_kastb_detector()
     spec2DObj = spec2dobj.Spec2DObj(**init_dict)
     # Write
-    ofile = tstutils.data_output_path('tst_spec2d.fits')
+    ofile = str(tmp_path / 'tst_spec2d.fits')
     if os.path.isfile(ofile):
         os.remove(ofile)
     spec2DObj.to_file(ofile)
@@ -127,7 +127,7 @@ def test_spec2dobj_update_slit(init_dict):
 ####################################################3
 # Testing of AllSpec2DObj
 
-def test_all2dobj_hdr(init_dict):
+def test_all2dobj_hdr(tmp_path, init_dict):
     # Build one
     init_dict['detector'] = tstutils.get_kastb_detector()
     spec2DObj = spec2dobj.Spec2DObj(**init_dict)
@@ -141,12 +141,12 @@ def test_all2dobj_hdr(init_dict):
     spectrograph = load_spectrograph('shane_kast_blue')
     # Do it
     hdr = allspec2D.build_primary_hdr(header, spectrograph,
-                                      calib_dir=tstutils.data_output_path(''))
+                                      calib_dir=str(tmp_path))
     # Test it
     assert hdr['SKYSUB'] == 'MODEL'
 
 
-def test_all2dobj_write(init_dict):
+def test_all2dobj_write(tmp_path, init_dict):
     # Build one
     init_dict['detector'] = tstutils.get_kastb_detector()
     spec2DObj = spec2dobj.Spec2DObj(**init_dict)
@@ -156,7 +156,7 @@ def test_all2dobj_write(init_dict):
     detname = spec2DObj.detname
     allspec2D[detname] = spec2DObj
     # Write
-    ofile = tstutils.data_output_path('tst_allspec2d.fits')
+    ofile = str(tmp_path / 'tst_allspec2d.fits')
     if os.path.isfile(ofile):
         os.remove(ofile)
     allspec2D.write_to_fits(ofile)
@@ -177,7 +177,7 @@ def test_all2dobj_write(init_dict):
     os.remove(ofile)
 
 
-def test_all2dobj_update_image(init_dict):
+def test_all2dobj_update_image(tmp_path, init_dict):
 
     allspec2D = spec2dobj.AllSpec2DObj()
     allspec2D['meta']['bkg_redux'] = False
@@ -187,7 +187,7 @@ def test_all2dobj_update_image(init_dict):
         allspec2D[d.name] = spec2dobj.Spec2DObj(detector=d, **init_dict)
 
     # Write
-    ofile = tstutils.data_output_path('tst_allspec2d.fits')
+    ofile = str(tmp_path / 'tst_allspec2d.fits')
     if os.path.isfile(ofile):
         os.remove(ofile)
     allspec2D.write_to_fits(ofile)

--- a/pypeit/tests/test_specobj.py
+++ b/pypeit/tests/test_specobj.py
@@ -13,7 +13,6 @@ import numpy as np
 from astropy.io import fits
 
 from pypeit import specobj
-from pypeit.tests.tstutils import data_output_path
 from pypeit import log
 
 
@@ -54,11 +53,11 @@ def test_hdu():
     assert 'TRACE_SPAT' in hdul[0].data.dtype.names
     assert 'SLITID' in hdul[0].header.keys()
 
-def test_io():
+def test_io(tmp_path):
     sobj = specobj.SpecObj('MultiSlit', 'DET01', SLITID=0)
     # Can we handle 1 array?
     sobj['BOX_WAVE'] = np.arange(100).astype(float)
-    ofile = data_output_path('tmp.fits')
+    ofile = str(smp_path / 'tmp.fits')
     sobj.to_file(ofile, overwrite=True)
     _sobj = specobj.SpecObj.from_file(ofile)
     assert np.array_equal(sobj.BOX_WAVE, _sobj.BOX_WAVE)
@@ -66,7 +65,7 @@ def test_io():
     # Cleanup
     os.remove(ofile)
 
-def test_iotwo():
+def test_iotwo(tmp_path):
     sobj = specobj.SpecObj('MultiSlit', 'DET01', SLITID=0)
     #
     sobj['BOX_WAVE'] = np.arange(100).astype(float)
@@ -75,7 +74,7 @@ def test_iotwo():
     sobj['BOX_MASK'] = np.arange(100).astype(bool)
 
     # Write table
-    ofile = data_output_path('tmp.fits')
+    ofile = str(tmp_path / 'tmp.fits')
     sobj.to_file(ofile, overwrite=True)
     sobj2 = specobj.SpecObj.from_file(ofile)
     #

--- a/pypeit/tests/test_specobjs.py
+++ b/pypeit/tests/test_specobjs.py
@@ -79,7 +79,7 @@ def test_set(sobj1, sobj2, sobj3):
     assert sobjs.PYPELINE[0] == 'MultiSlit'
 
 
-def test_io(sobj1, sobj2, sobj3, sobj4):
+def test_io(tmp_path, sobj1, sobj2, sobj3, sobj4):
     sobjs = specobjs.SpecObjs([sobj1,sobj2,sobj3,sobj4])
     sobjs[0]['BOX_WAVE'] = np.arange(1000).astype(float)
     sobjs[1]['BOX_WAVE'] = np.arange(1000).astype(float)
@@ -96,7 +96,7 @@ def test_io(sobj1, sobj2, sobj3, sobj4):
     # Write
     header = fits.PrimaryHDU().header
     header['TST'] = 'TEST'
-    ofile = tstutils.data_output_path('tst_specobjs.fits')
+    ofile = str(tmp_path / 'tst_specobjs.fits')
     if os.path.isfile(ofile):
         os.remove(ofile)
     sobjs.write_to_fits(header, ofile, overwrite=False)

--- a/pypeit/tests/test_spectrographs.py
+++ b/pypeit/tests/test_spectrographs.py
@@ -14,7 +14,6 @@ from pypeit import spectrographs
 from pypeit.spectrographs.util import load_spectrograph
 from pypeit import pypeitsetup
 from pypeit.tests import tstutils
-from pypeit.tests.tstutils import data_output_path
 
 from IPython import embed
 
@@ -30,11 +29,11 @@ def test_shanekastblue():
     assert bpm.shape == (2048,350)
 
 
-def test_select_detectors_pypeit_file():
+def test_select_detectors_pypeit_file(tmp_path):
     # Generate a PypeIt file
     tstutils.install_shane_kast_blue_raw_data()
-    pypeItFile = tstutils.make_shane_kast_blue_pypeitfile()
-    pypeit_file = data_output_path('test.pypeit')
+    pypeItFile = tstutils.make_shane_kast_blue_pypeitfile(tmp_path)
+    pypeit_file = str(tmp_path / 'test.pypeit')
     pypeItFile.write(pypeit_file)
 
     # Perform the setup

--- a/pypeit/tests/test_specutils.py
+++ b/pypeit/tests/test_specutils.py
@@ -22,14 +22,14 @@ specutils_required = pytest.mark.skipif(Spectrum is None or SpectrumList is None
 
 
 @specutils_required
-def test_onespec_io():
+def test_onespec_io(tmp_path):
     rng = np.random.default_rng()
     grid_wave = np.linspace(3500,10000,1000)
     wave = grid_wave + (2*rng.uniform(size=grid_wave.size) - 1)
     flux = np.ones(1000, dtype=float)
     # TODO: PYP_SPEC is required if we want to be able to read the file!
     spec = onespec.OneSpec(wave, grid_wave, flux, PYP_SPEC='shane_kast_blue')
-    ofile = Path(tstutils.data_output_path('tmp.fits')).absolute()
+    ofile = tmp_path / 'tmp.fits'
     spec.to_file(str(ofile), overwrite=True)
 
     _spec = Spectrum.read(ofile)
@@ -43,9 +43,9 @@ def test_onespec_io():
 
 
 @specutils_required
-def test_spec1d_io():
+def test_spec1d_io(tmp_path):
 
-    ofile = Path(tstutils.data_output_path('tmp.fits')).absolute()
+    ofile = tmp_path / 'tmp.fits'
 
     spec1 = specobj.SpecObj('MultiSlit', 'DET01', SLITID=0)
     npix_spec = 100
@@ -138,14 +138,14 @@ def test_spec1d_io():
 
 
 @specutils_required
-def test_onespec_monotonic():
+def test_onespec_monotonic(tmp_path):
     rng = np.random.default_rng(999)
     grid_wave = np.linspace(3500,10000,1000)
     wave = grid_wave + (10*rng.uniform(size=grid_wave.size) - 1)
     flux = np.ones(1000, dtype=float)
     # TODO: PYP_SPEC is required if we want to be able to read the file!
     spec = onespec.OneSpec(wave, grid_wave, flux, PYP_SPEC='shane_kast_blue')
-    ofile = Path(tstutils.data_output_path('tmp.fits')).absolute()
+    ofile = tmp_path / 'tmp.fits'
     spec.to_file(str(ofile), overwrite=True)
 
     with pytest.raises(PypeItError):

--- a/pypeit/tests/test_utils.py
+++ b/pypeit/tests/test_utils.py
@@ -13,7 +13,6 @@ import numpy as np
 
 from pypeit import utils
 from pypeit import log
-from pypeit.tests.tstutils import data_output_path
 from pypeit import io
 
 
@@ -99,7 +98,7 @@ def test_boxcar_smooth_rows():
 
 
 
-def test_yamlify():
+def test_yamlify(tmp_path):
     """ This tests the yamlify method and also the approach to 
     writing and reading the Setup block of PypeIt"""
 
@@ -108,7 +107,7 @@ def test_yamlify():
     new_obj = utils.yamlify(obj)
 
     # Write
-    tst_file = data_output_path('tst.yaml')
+    tst_file = str(tmp_path / 'tst.yaml')
     with open(tst_file, 'w') as f:
         setup_lines = io.dict_to_lines(new_obj, level=1)
         f.write('\n'.join(setup_lines)+'\n')

--- a/pypeit/tests/test_wavetilts.py
+++ b/pypeit/tests/test_wavetilts.py
@@ -6,12 +6,13 @@ from pathlib import Path
 
 import numpy as np
 
-from pypeit.tests.tstutils import data_output_path
+import pytest
+
 from pypeit import wavetilts
 
 
 # Test WaveTilts
-def test_wavetilts():
+def test_wavetilts(tmp_path):
 
     instant_dict = dict(coeffs=np.ones((6,4,1)),
                         nslit=1,
@@ -21,7 +22,7 @@ def test_wavetilts():
                         func2d='legendre2d')
 
     wvtilts = wavetilts.WaveTilts(**instant_dict)
-    wvtilts.set_paths(data_output_path(''), 'A', '1', 'DET01')
+    wvtilts.set_paths(str(tmp_path), 'A', '1', 'DET01')
     # I/O
     ofile = Path(wvtilts.get_path()).absolute()
     wvtilts.to_file(overwrite=True)

--- a/pypeit/tests/test_wvcalib.py
+++ b/pypeit/tests/test_wvcalib.py
@@ -12,7 +12,6 @@ from pypeit.core.wavecal import wv_fitting
 from pypeit.core import fitting
 from pypeit import wavecalib
 from pypeit import slittrace
-from pypeit.tests.tstutils import data_output_path
 from pypeit.core.wavecal import waveio
 
 
@@ -34,9 +33,9 @@ def test_wavefit_hduprefix():
     assert spat_id == _spat_id, 'Bad parse'
 
 
-def test_wavefit():
+def test_wavefit(tmp_path):
     "Fuss with the WaveFit DataContainer"
-    out_file = Path(data_output_path('test_wavefit.fits')).absolute()
+    out_file = tmp_path / 'test_wavefit.fits'
     if out_file.exists():
         out_file.unlink()
     pypeitFit = fitting.PypeItFit(fitc=np.arange(5).astype(float))
@@ -75,7 +74,7 @@ def test_wavefit():
     out_file.unlink()
 
 
-def test_wavecalib():
+def test_wavecalib(tmp_path):
     "Fuss with the WaveCalib DataContainer"
     # Pieces
     pypeitFit = fitting.PypeItFit(fitc=np.arange(5).astype(float), xval=np.linspace(1,100., 100))
@@ -90,7 +89,7 @@ def test_wavecalib():
                                     nslits=1, spat_ids=np.asarray([232]),
                                     wv_fit2d=np.array([pypeitFit2]),
                                     fwhm_map=np.array([pypeitFit2]))
-    waveCalib.set_paths(data_output_path(''), 'A', '1', 'DET01')
+    waveCalib.set_paths(str(tmp_path), 'A', '1', 'DET01')
 
     ofile = Path(waveCalib.get_path()).absolute()
 
@@ -119,7 +118,7 @@ def test_wavecalib():
     waveCalib3 = wavecalib.WaveCalib(wv_fits=np.asarray([waveFit, wv_fitting.WaveFit(949)]),
                                      nslits=2, spat_ids=spat_ids,
                                      wv_fit2d=np.array([pypeitFit2, pypeitFit2]))
-    waveCalib3.set_paths(data_output_path(''), 'A', '1', 'DET01')
+    waveCalib3.set_paths(str(tmp_path), 'A', '1', 'DET01')
     waveCalib3.to_file(overwrite=True)
     waveCalib4 = wavecalib.WaveCalib.from_file(ofile)
 
@@ -135,7 +134,7 @@ def test_wavecalib():
     ofile.unlink()
 
 
-def test_wvcalib_no2d():
+def test_wvcalib_no2d(tmp_path):
     """ Test WaveCalib without a 2D fit (not echelle) """
     # Pieces
     pypeitFit = fitting.PypeItFit(fitc=np.arange(5).astype(float), xval=np.linspace(1,100., 100))
@@ -146,7 +145,7 @@ def test_wvcalib_no2d():
     spat_ids = np.asarray([232, 949])
     waveCalib = wavecalib.WaveCalib(wv_fits=np.asarray([waveFit, wv_fitting.WaveFit(949)]),
                                     nslits=2, spat_ids=spat_ids)
-    waveCalib.set_paths(data_output_path(''), 'A', '1', 'DET01')
+    waveCalib.set_paths(str(tmp_path), 'A', '1', 'DET01')
     ofile = Path(waveCalib.get_path()).absolute()
 
     waveCalib.to_file(overwrite=True)

--- a/pypeit/tests/tstutils.py
+++ b/pypeit/tests/tstutils.py
@@ -17,21 +17,6 @@ from pypeit.metadata import PypeItMetaData
 from pypeit.inputfiles import PypeItFile 
 
 
-# NOTE: Now that the test data files are kept remotely, we have to distinguish
-# between paths to files that are *written* (data_output_path) as part of the
-# tests and those that are *read* (data_input_path) as part of the tests.  I.e.,
-# files to be written should not exist on GitHub, so we should not attempt to
-# download them.
-# def data_input_path(filename, to_pkg=None):
-#    return str(dataPaths.tests.get_file_path(filename, to_pkg=to_pkg))
-
-
-def data_output_path(filename):
-    if len(filename) == 0:
-        return str(dataPaths.tests.path)
-    return str(dataPaths.tests.path / filename)
-
-
 # Example (shane_kast_blue)
 def default_detector():
     return dict(
@@ -159,7 +144,7 @@ def dummy_fitstbl(nfile=10, spectro_name='shane_kast_blue', directory='', notype
     return fitstbl
 
 
-def make_shane_kast_blue_pypeitfile():
+def make_shane_kast_blue_pypeitfile(tmp_path):
     """ Generate a PypeItFile class """
     # Bits needed to generate a PypeIt file
     confdict = {'rdx': {'spectrograph': 'shane_kast_blue'}}
@@ -176,7 +161,7 @@ def make_shane_kast_blue_pypeitfile():
     data['filename'] = [os.path.basename(dataPaths.tests.get_file_path(f, to_pkg='symlink'))
                             for f in raw_files]
     data['frametype'] = ['science']*len(data)
-    file_paths = [data_output_path('')]
+    file_paths = [str(tmp_path)]
     setup_dict = {'Setup A': ' '}
 
     # Return


### PR DESCRIPTION
Use the pytest **tmp_path** fixture instead of writing generated files into `pypeit/data/tests`. This avoids writes to the installed package tree and follows pytest best practices for temporary test output.

This allows to test the installed package with the command `python3 -m pytest --pyargs pypeit`, without write access to the package directory tree. Also it ensures that no remnants of the tests remain in the installed package.

Alternatives could be

* Directly use **tmp_path instead of a **data_output_path** fixture. This would make the code simpler, but would require more changes.
* Instead of using the **tmp_path** fixture, use the **tempfile** package. This would result in a minimal change (only in `tstutils.py`, no changes in the test modules at all) but would have the disadvantage that it is more difficult to investigate the result in case of a failure (the **tmp_path** fixture uses a well-defined directory to store the temporary files).

Fixes #2177 