### PR TITLE
Provide explicit default for pytest option

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -202,7 +202,7 @@ testpaths = [
     "pypeit",
 ]
 addopts = [
-    "--remote-data",
+    "--remote-data=any",
 ]
 
 [tool.coverage]


### PR DESCRIPTION
As titled.

Executing:

```
cd pypeit/tests
pytest . -W ignore
```

was failing because pytest was interpreting `.` as the optional value for `--remote-data`.  This explicitly sets the value for `--remote-data` to be `any`.
