### PR TITLE
HOTFIX: broadcast weights needs a new option for mosaics

### DIFF
--- a/pypeit/core/combine.py
+++ b/pypeit/core/combine.py
@@ -248,6 +248,8 @@ def broadcast_weights(weights, shape):
             weights_stack = np.einsum('i,ij->ij', weights, np.ones(shape))
         elif len(shape) == 3:
             weights_stack = np.einsum('i,ijk->ijk', weights, np.ones(shape))
+        elif len(shape) == 4:
+            weights_stack = np.einsum('i,ijkl->ijkl', weights, np.ones(shape))
         else:
             raise PypeItError('Image shape is not supported')
     elif weights.ndim == 2:


### PR DESCRIPTION
Keck/HIRES mosaic needs an additional option for broadcast weights when mean combining calibration frames.